### PR TITLE
Update plugins/link/dialogs/anchor.js

### DIFF
--- a/plugins/link/dialogs/anchor.js
+++ b/plugins/link/dialogs/anchor.js
@@ -24,6 +24,7 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 			var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) );
 			var attributes = {
 				name: name,
+ 				id: name,
 				'data-cke-saved-name': name
 			};
 


### PR DESCRIPTION
Anchor Tags should create the id attribute also to conform to XHTML standards.
http://dev.ckeditor.com/ticket/1961
