### PR TITLE
Compute selected cells more correctly.

### DIFF
--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -46,11 +46,14 @@
 					// So we have to take care to include a td we've entered only when we've
 					// walked into its children.
 
-					var parent = node.getAscendant( 'td' ) || node.getAscendant( 'th' );
-					if ( parent && !parent.getCustomData( 'selected_cell' ) ) {
-						CKEDITOR.dom.element.setMarker( database, parent, 'selected_cell', true );
-						retval.push( parent );
-					}
+          if( !( node instanceof CKEDITOR.dom.element && node.is( 'tr', 'thead', 'tfoot', 'tbody', 'table' ))) {
+            var parent = node.getAscendant( 'td', true ) || node.getAscendant( 'th', true );
+            if ( parent && !parent.getCustomData( 'selected_cell' ) )
+            {
+              CKEDITOR.dom.element.setMarker( database, parent, 'selected_cell', true );
+              retval.push( parent );
+            }
+          }
 				}
 			}
 		}


### PR DESCRIPTION
Now selecting cells in an inner table does not delete the parent cell (and 
consequently the entire inner table).

Fixes [Tracker ticket 8675](http://dev.ckeditor.com/ticket/8675).
