### PR TITLE
Valuable events for the inline editor

### DIFF
--- a/plugins/floatingspace/plugin.js
+++ b/plugins/floatingspace/plugin.js
@@ -258,6 +258,7 @@
 			});
 
 			editor.on( 'focus', function( evt ) {
+				CKEDITOR.fire("floatDisplayed", null, this);
 				layout( evt );
 				win.on( 'scroll', layout );
 				win.on( 'resize', layout );
@@ -265,6 +266,7 @@
 
 			editor.on( 'blur', function() {
 				floatSpace.hide();
+				CKEDITOR.fire("floatHidden", null, this);
 				win.removeListener( 'scroll', layout );
 				win.removeListener( 'resize', layout );
 			});


### PR DESCRIPTION
Hi,

I've just added two lines of code that are very valuable. They fire events when the floating editor is displayed and hidden.

This is extremely valuable because, among other things, it allows you to easily perform on-the-fly AJAX saves when the user clicks off of the inline editor, using:

CKEDITOR.on( 'panelHidden', function( event ) {
      // code for saving elements
});

Thanks,
Pete
