### PR TITLE
Added functionality "previewPostProcess"

### DIFF
--- a/plugins/preview/plugin.js
+++ b/plugins/preview/plugin.js
@@ -19,7 +19,9 @@
 				baseTag = config.baseHref ? '<base href="' + config.baseHref + '"/>' : '',
 				isCustomDomain = CKEDITOR.env.isCustomDomain();
 
-			if ( config.fullPage ) {
+			if ( config.previewPostProcess && typeof(config.previewPostProcess) == 'function' ) {
+				sHTML = config.previewPostProcess(editor);
+			} else if ( config.fullPage ) {
 				sHTML = editor.getData().replace( /<head>/, '$&' + baseTag ).replace( /[^>]*(?=<\/title>)/, '$& &mdash; ' + editor.lang.preview.preview );
 			} else {
 				var bodyHtml = '<body ',


### PR DESCRIPTION
Added "previewPostProcess". This function is called when generating a preview (and should return a proper formatted HTML document) and can be used to postprocess the data from the CKEditor instance (ie in a CMS environment).
