### PR TITLE
Fixed wrong action when line start via space in webkit.

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -149,7 +149,7 @@
 			// We can't simply remove the filling node because the user
 			// will actually enlarge it when typing, so we just remove the
 			// invisible char from it.
-			fillingChar.setText( fillingChar.getText().replace( /\u200B/g, '' ) );
+			fillingChar.setText( fillingChar.getText().replace( /\u200B( )?/g, function( m ) { return m[1] ? '\xa0' : '' } ) );
 
 			// Restore the bookmark.
 			if ( bm ) {


### PR DESCRIPTION
I'm sorry my english isn't good.

Error case:

In webkit, typed shift+enter (or mode is ENTER_BR, typed enter), editor generated this code:

``` html
  <br>&#8203; (&#8203; is filling char.)
```

and typed space and some text, editor generated this code:

``` html
  <br>&#8203; some text
```

finally, pressed enter, editor delete filling char.

``` html
  <br> some text
  <br>&#8203;
```

therefore, whitespace is removed on result.

After patch:
final action changed.

``` html
  <br>&nbsp;some text
  <br>&#8203;
```
