### PR TITLE
Change to core/skin.js to enable setting both background pos_horz and pos_vert values for icon images

### DIFF
--- a/core/skin.js
+++ b/core/skin.js
@@ -78,10 +78,12 @@
 		 * available inside a sprites image.
 		 * @param {Number} [offset_horz] The horizontal offset position of the icon, if
 		 * available inside a sprites image.
+		 * @param {Boolean} choose to override any existing icon object stored in the 
+		 * icons[] array.
 		 */
-		addIcon: function( name, path, offset_vert, offset_horz ) {
+		addIcon: function( name, path, offset_vert, offset_horz, override ) {
 			name = name.toLowerCase();
-			if ( !this.icons[ name ] ) {
+			if (override || !this.icons[ name ] ) {
 				this.icons[ name ] = {
 					path: path,
 					offset: offset_vert || 0, //offset can't be renamed here because it seems that ckbuilder.jar sets this prop name directly during a build


### PR DESCRIPTION
As discussed at:

http://ckeditor.com/forums/CKEditor/Considering-making-a-change-via-GitHub-wanted-sanity-check...

Made a few changes to:
CKEDITOR.skins.addIcon() added a fourth parameter, and renamed the
third.  These parameters:
offset_vert[3:Number]
offset_horz[4:Number]
...allow defining a specific icon image file, and allows specifying the
background-position offset for both x and y positions.  I also removed
the "check" not to override any existing value, as a call to addIcon
should always allow overriding a previous value.

I also modified the call to: CKEDITOR.skin.getIconStyle() such that the
background-position is now populated with any pos_horz pos_vert values
defined with a call to addIcon.

Specifying the offset_horz after the offset_vert breaks the normal x,y
nomenclature but it maintains backwards compatiblity of all plugins that
currently only specity an offset_vert value.

My first commit, but reach out at zac@zacwolf.com if you have any
questions/concerns.
