### PR TITLE
Use for loop to iterate over array, check existance

### DIFF
--- a/plugins/filebrowser/plugin.js
+++ b/plugins/filebrowser/plugin.js
@@ -219,9 +219,11 @@
 	//            elements Array of {@link CKEDITOR.dialog.definition.content}
 	//            objects.
 	function attachFileBrowser( editor, dialogName, definition, elements ) {
+		if (!elements) return;
+
 		var element, fileInput;
 
-		for ( var i in elements ) {
+		for ( var i = 0, l = elements.length; i < l; ++i) {
 			element = elements[ i ];
 
 			if ( element.type == 'hbox' || element.type == 'vbox' || element.type == 'fieldset' )


### PR DESCRIPTION
A couple things here were causing the editor to `TypeError` in Safari and IE when trying to use any of the popup initializer buttons.
1. Iterating over an `Array` like it was a plain `Object` was causing unexpected results (fixed with a standard `for` loop).
2. `elements` being passed to `attachFileBrowser` as `undefined` (fixed with a simple check and return);

I didn't dig very deep into this and definitely don't know the ins and outs of ckeditor, but this has fixed Safari and IE for us.
