### PR TITLE
Fix protectedAttributeRegex by matching entire attribute name

### DIFF
--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -658,7 +658,7 @@
 	}
 
 	var protectElementRegex = /<(a|area|img|input|source)\b([^>]*)>/gi,
-		protectAttributeRegex = /\b(on\w+|href|src|name)\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|(?:[^ "'>]+))/gi;
+		protectAttributeRegex = /\s(on\w+|href|src|name)\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|(?:[^ "'>]+))/gi;
 
 		// Note: we use lazy star '*?' to prevent eating everything up to the last occurrence of </style> or </textarea>.
 	var protectElementsRegex = /(?:<style(?=[ >])[^>]*>[\s\S]*?<\/style>)|(?:<(:?link|meta|base)[^>]*>)/gi,


### PR DESCRIPTION
A fix for ticket https://dev.ckeditor.com/ticket/10298

The protectedAttributeRegex matches `href` within `data-href` consequently breaking the attribute. The issue is that `-`-char is not a word-character.
