### PR TITLE
Fixed breaking code when creating and destroying the editors

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -310,7 +310,7 @@
 		 * @property {Boolean}
 		 * @see CKEDITOR.editor#setReadOnly
 		 */
-		editor.readOnly = !!( editor.config.readOnly || ( editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE ? editor.element.isReadOnly() : editor.elementMode == CKEDITOR.ELEMENT_MODE_REPLACE ? editor.element.getAttribute( 'disabled' ) : false ) );
+		editor.readOnly = !!( editor.config.readOnly || ( editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE ? editor.element && editor.element.isReadOnly() : editor.elementMode == CKEDITOR.ELEMENT_MODE_REPLACE ? editor.element.getAttribute( 'disabled' ) : false ) );
 
 		/**
 		 * Indicates that the editor is running into an environment where
@@ -319,7 +319,7 @@
 		 * @readonly
 		 * @property {Boolean}
 		 */
-		editor.blockless = editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE && !CKEDITOR.dtd[ editor.element.getName() ][ 'p' ];
+		editor.blockless = editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE && editor.element && !CKEDITOR.dtd[ editor.element.getName() ][ 'p' ];
 
 		/**
 		 * The [tabbing navigation](http://en.wikipedia.org/wiki/Tabbing_navigation) order determined for this editor instance.
@@ -392,7 +392,7 @@
 
 			if ( !editor.config.contentsLangDirection ) {
 				// Fallback to either the editable element direction or editor UI direction depending on creators.
-				editor.config.contentsLangDirection = editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE ? editor.element.getDirection( 1 ) : editor.lang.dir;
+				editor.config.contentsLangDirection = editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE ? editor.element && editor.element.getDirection( 1 ) : editor.lang.dir;
 			}
 
 			editor.fire( 'langLoaded' );


### PR DESCRIPTION
http://jsfiddle.net/Z4dBN/4/

This is the setup I've encountered the JS errors with and my patch will get rid of those errors. It's a quick patch and I haven't dug deeper into why errors happen, but I know for sure it's because I'm destroying and attaching editors very quickly. During this some events are lagging a bit behind and the editor.element reference is already gone when some of the events are triggered.

I don't know why the editor doesn't show up on the fiddle, it does on my computer, but I think this fiddle still points out the problem.

If you want me to change the patch so that the element reference is checked elsewhere, I'm more than happy to do so.
