### PR TITLE
Fix for #10571 filler char should be removed 

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -416,6 +416,11 @@
 				editable.attachListener( CKEDITOR.env.ie ? editable : doc.getDocumentElement(), 'mouseup', checkSelectionChangeTimeout, editor );
 
 			if ( CKEDITOR.env.webkit ) {
+				// remove filler chars before undos #10571
+				editor.on('beforeUndoImage', function ( evt ) { 
+			    	removeFillingChar(editable); 
+				});
+
 				// Before keystroke is handled by editor, check to remove the filling char.
 				editable.attachListener( doc, 'keydown', function( evt ) {
 					var key = evt.data.getKey();


### PR DESCRIPTION
Removing filler char prior to creating and undo image, as it cannot be removed once the image has been restored.
see https://dev.ckeditor.com/ticket/10571
