### PR TITLE
Make moono CSS valid

### DIFF
--- a/plugins/magicline/plugin.js
+++ b/plugins/magicline/plugin.js
@@ -36,7 +36,7 @@
 				holdDistance: 0 | triggerOffset * ( config.magicline_holdDistance || 0.5 ),
 				boxColor: config.magicline_color || '#ff0000',
 				rtl: config.contentsLangDirection == 'rtl',
-				triggers: config.magicline_everywhere ? DTD_BLOCK : config.magicline_triggers || { table:1,hr:1,div:1,ul:1,ol:1,dl:1,form:1,blockquote:1 }
+				triggers: config.magicline_everywhere ? DTD_BLOCK : { table:1,hr:1,div:1,ul:1,ol:1,dl:1,form:1,blockquote:1 }
 			},
 			scrollTimeout, checkMouseTimeoutPending, checkMouseTimeout, checkMouseTimer;
 


### PR DESCRIPTION
The current CSS in the `dialog_iequirks.css` is not valid CSS. For anyone with an asset pipeline that actually checks for validity, the build will fail. This pull request adds an empty string to the filter, in order to produce valid CSS.
