### PR TITLE
Update editor_iequirks.css

### DIFF
--- a/skins/kama/editor_iequirks.css
+++ b/skins/kama/editor_iequirks.css
@@ -234,7 +234,7 @@ a.cke_dialog_ui_button_cancel span
 .cke_menuitem .cke_disabled .cke_icon,
 .cke_button_disabled .cke_button_icon
 {
-	filter: ;
+	filter: "";
 }
 
 .cke_menuseparator


### PR DESCRIPTION
Hi, how about to replace this line to valid css? As it were made here https://github.com/ckeditor/ckeditor-dev/commit/e5555ee210a9761e8f2fc8bd7993241ccf555056

I always need to support my branch, because of Rails precompiler fails with error

```
+Invalid CSS after "    filter: ": expected expression (e.g. 1px, bold), was ";"
```
