### PR TITLE
Add in a prevent drag drop in the floating panel menu.  #10373

### DIFF
--- a/plugins/floatpanel/plugin.js
+++ b/plugins/floatpanel/plugin.js
@@ -157,6 +157,7 @@ CKEDITOR.plugins.add( 'floatpanel', {
 					left = position.x + ( offsetX || 0 ) - positionedAncestorPosition.x,
 					top = position.y + ( offsetY || 0 ) - positionedAncestorPosition.y;
 
+        
 				// Floating panels are off by (-1px, 0px) in RTL mode. (#3438)
 				if ( rtl && ( corner == 1 || corner == 4 ) )
 					left += offsetParent.$.offsetWidth;
@@ -365,20 +366,47 @@ CKEDITOR.plugins.add( 'floatpanel', {
 
 					// Set the panel frame focus, so the blur event gets fired.
 					CKEDITOR.tools.setTimeout( function() {
-
 						this.focus();
 
 						// We need this get fired manually because of unfired focus() function.
 						this.allowBlur( true );
 						this._.editor.fire( 'panelShow', this );
-					}, 0, this );
-				}, CKEDITOR.env.air ? 200 : 0, this );
-				this.visible = 1;
 
+            if(CKEDITOR.config.disableMenuDrag){
+              this.setDragOff();
+            }else{
+              this.setDragOn();
+            }
+					}, 0, this );
+
+
+				}, CKEDITOR.env.air ? 200 : 0, this );
+
+				this.visible = 1;
 				if ( this.onShow )
 					this.onShow.call( this );
 
 			},
+      getFrameBody: function(cfg){
+        var t = cfg || this._; 
+        if(t && t.iframe && t.iframe.$){
+          var el   = t.iframe.$;
+          return el.contentDocument || el.contentWindow;
+        }
+      },
+      setDragOn: function(){
+        var body = this.getFrameBody();
+        if(body && body.ondragstart){
+          body.ondragstart = null;
+        }
+      },
+      setDragOff: function(){
+        var body = this.getFrameBody();
+        if(body && !body.ondragstart){
+          body.ondragstart = function(){return false;}
+        }
+    
+      },
 
 			/**
 			 * Restores last focused element or simply focus panel window.


### PR DESCRIPTION
A patch for http://dev.ckeditor.com/ticket/10373

I left the configuration CKEDITOR.config.disableMenuDrag as false by default since I was not certain somebody did write a plugin that _did_ allow you to drag images or something into the editor.

This will prevent drags from the menu in most recent browsers (they do need an on dragstart event).   In addition another option is to to add in this css to the iFrame body, but that probably only works in FF and Chrome.

//Css for the body of the iFrame if that route is preferred.
-moz-user-select: none;
-webkit-user-select: none;
