### PR TITLE
Allow attributes when getting ascendants with getAscendant

### DIFF
--- a/core/dom/node.js
+++ b/core/dom/node.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2013, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
@@ -535,12 +535,13 @@ CKEDITOR.tools.extend( CKEDITOR.dom.node.prototype, {
 	 * Gets the closest ancestor node of this node, specified by its name.
 	 *
 	 *		// Suppose we have the following HTML structure:
-	 *		// <div id="outer"><div id="inner"><p><b>Some text</b></p></div></div>
+	 *		// <div id="outer" data-myattr="foo"><div id="inner"><p><b>Some text</b></p></div></div>
 	 *		// If node == <b>
 	 *		ascendant = node.getAscendant( 'div' );				// ascendant == <div id="inner">
 	 *		ascendant = node.getAscendant( 'b' );				// ascendant == null
 	 *		ascendant = node.getAscendant( 'b', true );			// ascendant == <b>
 	 *		ascendant = node.getAscendant( { div:1,p:1 } );		// Searches for the first 'div' or 'p': ascendant == <div id="inner">
+	 * 		ascendant = node.getAscendant( 'div[data-myattr]' ) // ascendant == <div id="outer" data-myattr="foo">
 	 *
 	 * @since 3.6.1
 	 * @param {String} reference The name of the ancestor node to search or
@@ -551,13 +552,25 @@ CKEDITOR.tools.extend( CKEDITOR.dom.node.prototype, {
 	 */
 	getAscendant: function( reference, includeSelf ) {
 		var $ = this.$,
-			name;
+			name,
+			hasAttributes = false,
+			attributeName = null,
+			reAttr = /^(.*)\[(.+)\]$/;
 
 		if ( !includeSelf )
 			$ = $.parentNode;
+			
+		if ( typeof reference  == 'string' && reAttr.test( reference ) )
+		{
+			var res = reAttr.exec(reference);
+			reference = res[1];
+			attributeName = res[2];
+			hasAttributes = true;
+		}
 
 		while ( $ ) {
-			if ( $.nodeName && ( name = $.nodeName.toLowerCase(), ( typeof reference == 'string' ? name == reference : name in reference ) ) )
+			
+			if ( $.nodeName && ( name = $.nodeName.toLowerCase(), ( typeof reference == 'string' ? name == reference && ( !hasAttributes || ( $.getAttribute && $.getAttribute(attributeName) !== null ) ) : name in reference ) ) )
 				return new CKEDITOR.dom.node( $ );
 
 			try {


### PR DESCRIPTION
Allowing attribute check for elements gives a possibility to match elements with specific attribute. This is handy for creating complex custom templates and accessing them later on.

I'm creating templatesExtended plugin which relies on this behavior.

This only supports check for one attribute.
