### PR TITLE
#9929: [Chrome 23] &nbsp; is created when deleting character and typing ...

### DIFF
--- a/core/editable.js
+++ b/core/editable.js
@@ -565,9 +565,9 @@
 							// 1. Del/Backspace key before/after table;
 							// 2. Backspace Key after start of table.
 							if ( ( block = path.block ) &&
-								 range[ rtl ? 'checkStartOfBlock' : 'checkEndOfBlock' ]() &&
 								 ( next = block[ rtl ? 'getPrevious' : 'getNext' ]( isNotWhitespace ) ) &&
-								 next.is( 'table' ) )
+								 next.is( 'table' ) &&
+								 range[ rtl ? 'checkStartOfBlock' : 'checkEndOfBlock' ]() )
 							{
 								editor.fire( 'saveSnapshot' );
 


### PR DESCRIPTION
...common space

It seems as &nbsp; is a result of altering source for checkStartOfBlock()/checkEndOfBlock(). Changing order of checks in if checkStartOfBlock()/checkEndOfBlock() are run only when necessary, not every time del/backspace is pressed.
