### PR TITLE
Content config fix

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -606,7 +606,7 @@ CKEDITOR.config.disableNativeSpellChecker = true;
  *		config.contentsCss = '/css/mysitestyles.css';
  *		config.contentsCss = ['/css/mysitestyles.css', '/css/anotherfile.css'];
  *
- * @cfg {String/Array} [contentsCss=CKEDITOR.basePath + 'contents.css']
+ * @cfg {String/Array} [contentsCss=CKEDITOR.getUrl('contents.css')]
  * @member CKEDITOR.config
  */
 CKEDITOR.config.contentsCss = CKEDITOR.getUrl('contents.css');


### PR DESCRIPTION
This change simply modifies the default configuration for the WYSIWYG editor to use the getUrl method. This will ensure that the default configuration will use the correct path, even when the getUrl method is overriden using window.CKEDITOR_GETURL.
