### PR TITLE
Fixed a typo

### DIFF
--- a/plugins/mathjax/lang/en.js
+++ b/plugins/mathjax/lang/en.js
@@ -5,7 +5,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 CKEDITOR.plugins.setLang( 'mathjax', 'en', {
 	title: 'Mathematics in TeX',
 	button: 'Math',
-	dialogInput: 'Write you TeX here',
+	dialogInput: 'Write your TeX here',
 	docUrl: 'http://en.wikibooks.org/wiki/LaTeX/Mathematics',
 	docLabel: 'TeX documentation',
 	loading: 'loading...',


### PR DESCRIPTION
English Mathjax dialog said "Write you TeX here", it should be "your".
