### PR TITLE
Fix CSS so CKeditor shows in IE when using Fitvids

### DIFF
--- a/skins/moono/editor.css
+++ b/skins/moono/editor.css
@@ -46,7 +46,7 @@ other files.
 /* Important!
    To avoid showing the editor UI while its styles are still not available, the
    editor creates it with visibility:hidden. Here, we restore the UI visibility. */
-.cke_chrome
+.cke.cke_chrome
 {
 	visibility: inherit;
 }


### PR DESCRIPTION
If you use Fitvids and CKeditor, the editor doesn't show in IE.
That's because the CSS order gets changed, and the `cke_chrome` rule isn't applied.
See https://github.com/davatron5000/FitVids.js/issues/147

This change increases the specificity so it works.
