### PR TITLE
Mac Chrome 31 and Windows IE 11 also need help, but spew a different error message

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -180,7 +180,13 @@
 			if ( bm ) {
 				var rng = sel.getRangeAt( 0 );
 				rng.setStart( rng.startContainer, bm[ 0 ] );
-				rng.setEnd( rng.startContainer, bm[ 1 ] );
+				try {
+					rng.setEnd( rng.startContainer, bm[ 1 ] );
+				} catch (e) {
+					if (!e || !e.toString().indexOf("NS_ERROR_ILLEGAL_VALUE") >= 0 && !e.toString().indexOf('IndexSizeError') > -1) {
+						throw e;
+					}
+				}
 				sel.removeAllRanges();
 				sel.addRange( rng );
 			}
@@ -1943,7 +1949,7 @@
 						// There is a bug in Firefox implementation (it would be too easy
 						// otherwise). The new start can't be after the end (W3C says it can).
 						// So, let's create a new range and collapse it to the desired point.
-						if ( e.toString().indexOf( 'NS_ERROR_ILLEGAL_VALUE' ) >= 0 ) {
+						if ( e.toString().indexOf( 'NS_ERROR_ILLEGAL_VALUE' ) >= 0 || e.toString().indexOf('IndexSizeError') > -1 ) {
 							range.collapse( 1 );
 							nativeRange.setEnd( range.endContainer.$, range.endOffset );
 						} else


### PR DESCRIPTION
User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36
window.onerror message: "Uncaught IndexSizeError: Index or size was negative, or greater than the allowed value."

User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36
window.onerror message: "Uncaught IndexSizeError: Index or size was negative, or greater than the allowed value."

User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko
window.onerror message: "IndexSizeError"
