### PR TITLE
Add editor.config.linkShowSurroundingAnchors

### DIFF
--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -205,11 +205,12 @@ CKEDITOR.dialog.add( 'link', function( editor ) {
 
 			// Find out whether we have any anchors in the editor.
 			var anchors = retval.anchors = [],
+				anchorScope = editor.config.linkShowSurroundingAnchors ? editor.document : editor.editable(),
 				i, count, item;
 
 			// For some browsers we set contenteditable="false" on anchors, making document.anchors not to include them, so we must traverse the links manually (#7893).
-			if ( CKEDITOR.plugins.link.emptyAnchorFix ) {
-				var links = editor.document.getElementsByTag( 'a' );
+			if ( CKEDITOR.plugins.link.emptyAnchorFix || !editor.config.linkShowSurroundingAnchors ) {
+				var links = anchorScope.getElementsByTag( 'a' );
 				for ( i = 0, count = links.count(); i < count; i++ ) {
 					item = links.getItem( i );
 					if ( item.data( 'cke-saved-name' ) || item.hasAttribute( 'name' ) )
@@ -224,7 +225,7 @@ CKEDITOR.dialog.add( 'link', function( editor ) {
 			}
 
 			if ( CKEDITOR.plugins.link.fakeAnchor ) {
-				var imgs = editor.document.getElementsByTag( 'img' );
+				var imgs = anchorScope.getElementsByTag( 'img' );
 				for ( i = 0, count = imgs.count(); i < count; i++ ) {
 					if ( ( item = CKEDITOR.plugins.link.tryRestoreFakeAnchor( editor, imgs.getItem( i ) ) ) )
 						anchors.push( { name: item.getAttribute( 'name' ), id: item.getAttribute( 'id' ) } );

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -361,5 +361,12 @@ CKEDITOR.tools.extend( CKEDITOR.config, {
 	 * @member CKEDITOR.config
 	 * @todo
 	 */
-	linkShowTargetTab: true
+	linkShowTargetTab: true,
+
+	/**
+	 * @cfg {Boolean} [linkShowSurroundingAnchors=true]
+	 * @member CKEDITOR.config
+	 * @todo
+	 */
+	linkShowSurroundingAnchors: true,
 });


### PR DESCRIPTION
By default, editor.config.linkShowSurroundingAnchors is true,
and the 'Link to anchors in the text' option in the Link dialog
shows all anchors in the document in which the editor is rendered.

When editor.config.linkShowSurroundingAnchors is false, only
the anchors within the editable area are shown. This is especially
useful when the divarea plugin is used and not all anchors in the
surrounding page should show up as options in the Link dialog.
