### PR TITLE
Fix tableresize to only attach to tables within containing editor

### DIFF
--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -354,7 +354,7 @@
 			editor.on( 'contentDom', function() {
 				var resizer;
 
-				editor.document.getBody().on( 'mousemove', function( evt ) {
+				editor.container.on( 'mousemove', function( evt ) {
 					evt = evt.data;
 
 					var pageX = evt.getPageOffset().x;
@@ -370,11 +370,14 @@
 					var target = evt.getTarget(),
 						table, pillars;
 
-					if ( !target.is( 'table' ) && !target.getAscendant( 'tbody', 1 ) )
+					if ( (!target.is( 'table' ) && !target.getAscendant( 'tbody', 1 )) )
 						return;
 
 					table = target.getAscendant( 'table', 1 );
 
+					if ( !editor.container.contains(table) )
+						return;
+					
 					if ( !( pillars = table.getCustomData( '_cke_table_pillars' ) ) ) {
 						// Cache table pillars calculation result.
 						table.setCustomData( '_cke_table_pillars', ( pillars = buildTableColumnPillars( table ) ) );


### PR DESCRIPTION
tableresize plugin attached mouse move handler to document body
element.  As a result any tables on the same page as a ckeditor that
was created using either divarea or inline editing will become
resizeable.

When an iframe is used, it is acceptable to attach to body.  When
inline or divarea is used, one must filter table resize events to
only those contained within an actual ckeditor.
