### PR TITLE
#10714 iOS: On iPad touch listeners prevents CKEditor selection

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -264,6 +264,14 @@
 			} );
 		}
 
+		if ( CKEDITOR.env.iOS ) {
+			// [iOS] If touch is bound to any parent of the iframe blur happens on any touch
+			// event and body becomes the focused element
+			this.attachListener( doc, 'touchend', function() {
+				win.focus();
+			} );
+		}
+
 		// ## END
 
 


### PR DESCRIPTION
fix for selection troubles and undesired floating panel hides, tested with iOS 6 and 7
