### PR TITLE
Extended Mathjax plugin with display/block type mathjax equations.

### DIFF
--- a/plugins/mathjax/dialogs/mathjax.js
+++ b/plugins/mathjax/dialogs/mathjax.js
@@ -35,15 +35,42 @@ CKEDITOR.dialog.add( 'mathjax', function( editor ) {
 						},
 
 						setup: function( widget ) {
-							// Remove \( and \).
+							// Remove MathJax prefix and suffix (e.g. \( \) or \[ \])
 							this.setValue( CKEDITOR.plugins.mathjax.trim( widget.data.math ) );
+                            // Set equation_type based on equation
+                            var equation_type = CKEDITOR.plugins.mathjax.get_equation_type(widget.data.math);
+                            widget.setData('equation_type', equation_type);
 						},
 
 						commit: function( widget ) {
-							// Add \( and \) to make TeX be parsed by MathJax by default.
-							widget.setData( 'math', '\\(' + this.getValue() + '\\)' );
+                            // Get value from equation_type box
+                            var equation_type = this.getDialog().getContentElement('info', 'equation_type').getValue();
+
+							// Add prefix and suffix to make TeX be parsed by MathJax by default.
+                            if (equation_type == 'display') {
+                                widget.setData('math', '\\[' + this.getValue() + '\\]');
+                            } else {
+                                // Default to inline
+                                widget.setData( 'math', '\\(' + this.getValue() + '\\)' );
+                            }
+
 						}
 					},
+                    {
+                        id: 'equation_type',
+                        type: 'select',
+                        label: 'Type of equation',
+                        items: [
+                            ['Inline equation', 'inline'],
+                            ['Display equation', 'display']
+                        ],
+                        setup: function(widget) {
+                            this.setValue(widget.data.equation_type);
+                        },
+                        commit: function(widget) {
+                            widget.setData('equation_type', this.getValue());
+                        }
+                    },
 					{
 						id: 'documentation',
 						type: 'html',

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -187,18 +187,40 @@
 	};
 
 	/**
-	 * Trims MathJax value from '\(1+1=2\)' to '1+1=2'.
+	 * Trims MathJax value from '\(1+1=2\)' or '\[1+1=2\]' to '1+1=2'.
 	 *
 	 * @private
 	 * @param {String} value String to trim.
 	 * @returns {String} Trimed string.
 	 */
 	CKEDITOR.plugins.mathjax.trim = function( value ) {
-		var begin = value.indexOf( '\\(' ) + 2,
-			end = value.lastIndexOf( '\\)' );
+        var length_of_mathjax_prefix = 2; // i.e. length of '\\('
 
-		return value.substring( begin, end );
+        // Inline equation
+		var begin = value.indexOf( '\\(' );
+        if (begin >= 0) {
+            var end = value.lastIndexOf( '\\)' );
+        } else {
+            // Display equation
+            begin = value.indexOf('\\[');
+            var end = value.indexOf(('\\]'));
+        }
+
+		return value.substring(begin + length_of_mathjax_prefix, end);
 	};
+
+    /**
+     * Returns the type of equation based on the value,
+     * e.g. '\(x=2\)' gives inline, while '\[x=3\]' gives display
+     * @param {String} value Mathjax equation expression
+     * @returns {string} Type of equation
+     */
+    CKEDITOR.plugins.mathjax.get_equation_type = function(value) {
+        if (value.indexOf('\\(') >= 0) {
+            return 'inline';
+        }
+        return 'display';
+    }
 
 	/**
 	 * FrameWrapper is responsible for communication between the MathJax library
@@ -402,6 +424,8 @@
 						tex = doc.getById( 'tex' );
 
 					tex.setHtml( CKEDITOR.plugins.mathjax.trim( value ) );
+                    var equation_type = CKEDITOR.plugins.mathjax.get_equation_type(value);
+                    this.setData('equation_type', equation_type);
 
 					CKEDITOR.plugins.mathjax.copyStyles( iFrame, tex );
 


### PR DESCRIPTION
Extended Mathjax plugin with display/block type mathjax equations. Added option for inline or display/block equation, defaults to inline as before.

Mentioned in ticket:
http://dev.ckeditor.com/ticket/11595
