### PR TITLE
#1511: Undo and change notification for object resizing in IE

### DIFF
--- a/core/editable.js
+++ b/core/editable.js
@@ -782,6 +782,22 @@
 							ev.data.preventDefault();
 					} );
 				}
+
+				// IE: detect object resizing to allow undo/redo and change notification. (#1511)
+				if ( CKEDITOR.env.ie ) {
+					// listen for resizestart/resizeend events and save undo snapshots accordingly.
+					// The this.attachListener syntax does not seem work in IE9.
+					if ( this.$.attachEvent )
+					{
+						this.$.attachEvent( 'onresizestart', function( evt ) {
+							editor.fire( 'saveSnapshot' );
+						} );
+
+						this.$.attachEvent( 'onresizeend', function( evt ) {
+							editor.fire( 'saveSnapshot' );
+						} );
+					}
+				}
 			}
 		},
 

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -217,52 +217,6 @@
 				} );
 			}
 		}
-		else if ( CKEDITOR.env.ie )
-		{
-			// Hook the onresizestart and onresizeend events so that we can track resizing via the native browser size grips (#1511).
-			function resizeStart( evt ) {
-				oldSelectedElement.$.detachEvent( 'onresizestart', resizeStart );
-				// Save an initial snapshot so that we can detect the first resize.
-				editor.fire( 'saveSnapshot' );
-			};
-
-			function resizeEnd( evt ) {
-				editor.fire( 'saveSnapshot' );
-			};
-
-			var oldSelectedElement = null;
-
-			function monitorResizeForCurrentSelection()
-			{
-				var selection = doc.getSelection();
-				if ( !selection )
-				{
-					return;
-				}
-
-				var selectedElement = selection.getSelectedElement();
-				if ( !selectedElement )
-				{
-					return;
-				}
-
-				selectedElement.$.attachEvent( 'onresizestart', resizeStart );
-				selectedElement.$.attachEvent( 'onresizeend', resizeEnd );
-				oldSelectedElement = selectedElement;
-			}
-
-			this.attachListener( doc, 'selectionchange', function ( evt ) {
-				if (oldSelectedElement)
-				{
-					oldSelectedElement.$.detachEvent('onresizeend', resizeEnd);
-					oldSelectedElement = null;
-				}
-
-				monitorResizeForCurrentSelection();
-			});
-
-			monitorResizeForCurrentSelection();
-		}
 
 		if ( CKEDITOR.env.gecko || CKEDITOR.env.ie && editor.document.$.compatMode == 'CSS1Compat' ) {
 			this.attachListener( this, 'keydown', function( evt ) {


### PR DESCRIPTION
Native resizestart and resizeend events are now tracked in Internet Explorer to create undo snapshots when objects (e.g., images) have been resized.
This does not address the issue in other browsers.
