### PR TITLE
Added "dontUpdate" parameter to undoManager.unlock

### DIFF
--- a/plugins/undo/plugin.js
+++ b/plugins/undo/plugin.js
@@ -184,7 +184,9 @@
 			 * @member CKEDITOR.editor
  			 * @param {CKEDITOR.editor} editor This editor instance.
 			 */
-			editor.on( 'unlockSnapshot', undoManager.unlock, undoManager );
+			editor.on( 'unlockSnapshot', function( evt ) {
+				undoManager.unlock( evt.data && evt.data.dontUpdate );
+			} );
 		}
 	} );
 
@@ -671,11 +673,11 @@
 		 *
 		 * @since 4.0
 		 */
-		unlock: function() {
+		unlock: function( dontUpdate ) {
 			if ( this.locked ) {
 				// Decrease level of lock and check if equals 0, what means that undoM is completely unlocked.
 				if ( !--this.locked.level ) {
-					var updateImage = this.locked.update,
+					var updateImage = (dontUpdate) ? null : this.locked.update,
 						newImage = updateImage && new Image( this.editor, true );
 
 					this.locked = null;


### PR DESCRIPTION
Very small change I've used in my implementation of CKEDITOR, thought it might be useful in the public API.  At the current moment, you can call lockSnapshot with the with the dontUpdate option, preventing an update to the latest snapshot in the undo stack, like so:

```
editor.fire('lockSnapshot', {dontUpdate: true});
```

This option doesn't exist for undo snapShot.  In cases where you need to unlock a previously locked editor, but don't want to update the latest undo state, it would be useful to have a dontUpdate option on the unlockSnapshot event as well.  Example:

```
editor.on('paste', function(e){
    //Firing the paste event locks the undoManager by default
    /* DO SOME DOM MANIPULATION TO PREPARE FOR PASTE */
    editor.fire('unlockSnapshot', {dontUpdate: true}); //Instead of updating this current snapshot in the DOM, I want to create a brand new one; previously, this would have been impossible, as the unlockSnapshot event automatically updates the latest snapshot with the current DOM changes
    editor.fire('saveSnapshot'); //Save my new snapshot
    editor.fire('lockSnapshot', {dontUpdate: true}); //Re-lock the snapshot
    e.data.dataValue = 'Whatever I'm pasting';
});

```
