### PR TITLE
Update element.js

### DIFF
--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -571,7 +571,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.element.prototype, {
 	 * @param {String} propertyName The style property name.
 	 * @returns {String} The property value.
 	 */
-	getComputedStyle: CKEDITOR.env.ie ?
+	getComputedStyle: CKEDITOR.env.ie && !window.getComputedStyle ?
 		function( propertyName ) {
 			return this.$.currentStyle[ CKEDITOR.tools.cssStyleToDomStyle( propertyName ) ];
 		} : function( propertyName ) {


### PR DESCRIPTION
IE 10/11 (maybe older too) has issue with getComputedStyle because this.$.currentStyle is magically to be undefined, even in the previous callStack it was defined.
Andalso add checking if window.getComputedStyle feature is available (IE9-11) to use it like moz/chrome.
Its not really a bug from ckeditor, its a bug from IE.
