### PR TITLE
Setting of the "dir" attribute in the preloaded lang JS case

### DIFF
--- a/core/lang.js
+++ b/core/lang.js
@@ -55,9 +55,9 @@
 					callback( languageCode, this[ languageCode ] );
 				}, this );
 			} else {
-                this[ languageCode ].dir = this.rtl[ languageCode ] ? 'rtl' : 'ltr';
+				this[ languageCode ].dir = this.rtl[ languageCode ] ? 'rtl' : 'ltr';
 				callback( languageCode, this[ languageCode ] );
-            }
+			}
 		},
 
 		/**


### PR DESCRIPTION
Sometime earlier, probably during 4.3.x, the "dir" attribute was moved out of the individual language JS into the core. This required attribute was then being set on load(through the scriptloader) of the specific language JS but corresponding code for the pre-loaded case is missing. This fix should rectify the issue.
