### PR TITLE
Fixed editor crash after deleting a table

### DIFF
--- a/plugins/table/plugin.js
+++ b/plugins/table/plugin.js
@@ -45,9 +45,9 @@ CKEDITOR.plugins.add( 'table', {
 				if ( !table )
 					return;
 
-				// If the table's parent has only one child remove it as well (unless it's the body or a table cell) (#5416, #6289)
+				// If the table's parent has only one child remove it as well (unless it's the body, or a table cell, or the container element) (#5416, #6289)
 				var parent = table.getParent();
-				if ( parent.getChildCount() == 1 && !parent.is( 'body', 'td', 'th' ) )
+				if ( parent.getChildCount() == 1 && !parent.is( 'body', 'td', 'th' ) && !editor.container.equals(parent) )
 					table = parent;
 
 				var range = editor.createRange();


### PR DESCRIPTION
This is a fix for a bug.

**Scenario:**
1. Have an inline initialized editor
2. In that editor add a table and ensure that it is the sole element in the editable container (nothing before and nothing after)
3. Use the contextual menu to delete the table
4. The editor is no longer working :(

_Note: This can be reproduced also on the demo site: http://ckeditor.com/demo#inline_

**The fix:**
Just added a check to not remove the parent element of the table if that parent is the container.
