### PR TITLE
add hidpi option for indent plugin

### DIFF
--- a/plugins/indent/plugin.js
+++ b/plugins/indent/plugin.js
@@ -16,6 +16,7 @@
 	CKEDITOR.plugins.add( 'indent', {
 		lang: 'af,ar,bg,bn,bs,ca,cs,cy,da,de,el,en,en-au,en-ca,en-gb,eo,es,et,eu,fa,fi,fo,fr,fr-ca,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,km,ko,ku,lt,lv,mk,mn,ms,nb,nl,no,pl,pt,pt-br,ro,ru,si,sk,sl,sq,sr,sr-latn,sv,th,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
 		icons: 'indent,indent-rtl,outdent,outdent-rtl', // %REMOVE_LINE_CORE%
+		hidpi: true, // %REMOVE_LINE_CORE%
 
 		init: function( editor ) {
 			var genericDefinition = CKEDITOR.plugins.indent.genericDefinition;


### PR DESCRIPTION
Hey,

I was playing with icons and when I tried to regenerate them, I've noticed that `hidpi` option is missing for `indent` plugin.
