### PR TITLE
Detect first list item with block elements

### DIFF
--- a/plugins/indentlist/plugin.js
+++ b/plugins/indentlist/plugin.js
@@ -284,7 +284,7 @@
 		if ( !list )
 			list = path.contains( this.context );
 
-		return list && path.block && path.block.equals( list.getFirst( listItem ) );
+		return list && path.contains( listItem ).equals( list.getFirst( listItem ) );
 	}
 
 	// Determines whether a node is a list <li> element.


### PR DESCRIPTION
With an HTML structure like below, the Indent button is enabled when we put caret on the first item. When we click on it, the rest of the list items is removed. Function old firstItemInPath tried to compare <p> to <li> and failed to detect the match. The fix gets the <li> element of path.

{{{
<ul>
  <li><p>First</p></li>
  <li><p>Second</p></li>
</ul>
}}}
