### PR TITLE
Fixes #12243. Merged style definitions.

### DIFF
--- a/plugins/pastefromword/filter/default.js
+++ b/plugins/pastefromword/filter/default.js
@@ -868,6 +868,9 @@
 						// Convert the merged into a span with all attributes preserved.
 						else {
 							styleText = styleText || '';
+							// ensure a trailing ';' if we're going to add more to the style value //
+							styleText += (styleText.length && styleText[ styleText.length - 1 ] !== ';') ? ';' : '';
+							
 							// IE's having those deprecated attributes, normalize them.
 							if ( attrs.color ) {
 								attrs.color != '#000000' && ( styleText += 'color:' + attrs.color + ';' );


### PR DESCRIPTION
The _styleText_ variable does not always have a trailing ';' as it may come like this directly when pasting. Added a sanity check/fix to ensure it ends in ';' so that adding new definitions keeps a valid syntax.

Bug report: http://dev.ckeditor.com/ticket/12243
