### PR TITLE
changes for bugNumber 10986 - Setting text direction to content within CKEditor dialogs

### DIFF
--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -840,6 +840,9 @@ CKEDITOR.DIALOG_RESIZE_BOTH = 3;
 
 				for ( var j in this._.contents[ content.id ] ) {
 					var elem = this._.contents[ content.id ][ j ];
+					
+					if (elem.bidi)
+						elem.getElement().on( 'keyup', keyUpHandler, elem );					
 
 					if ( elem.type == 'hbox' || elem.type == 'vbox' || !elem.getInputElement() )
 						continue;
@@ -958,6 +961,12 @@ CKEDITOR.DIALOG_RESIZE_BOTH = 3;
 			this.foreach( function( widget ) {
 				if ( widget.setup )
 					widget.setup.apply( widget, args );
+				if (widget.bidi)
+				{
+					var bidiAttr = editor.document.getDocumentElement().getAttribute('bidi'+ widget.id);
+					if (bidiAttr)
+						widget.getInputElement().setAttribute('dir', bidiAttr);
+				}				
 			} );
 		},
 
@@ -978,6 +987,14 @@ CKEDITOR.DIALOG_RESIZE_BOTH = 3;
 				if ( CKEDITOR.env.ie && this._.currentFocusIndex == widget.focusIndex )
 					widget.getInputElement().$.blur();
 
+				if (widget.bidi && widget.getValue() ) 
+				{
+					var dir = widget.getInputElement().getAttribute( 'dir' );
+					var attrName = 'bidi'+ widget.id;
+					if (dir)
+						editor.document.getDocumentElement().setAttribute(attrName, dir);
+				}
+				
 				if ( widget.commit )
 					widget.commit.apply( widget, args );
 			} );
@@ -2150,6 +2167,18 @@ CKEDITOR.DIALOG_RESIZE_BOTH = 3;
 			}
 		};
 
+	var keyUpHandler = function( event ) {
+			var keystroke = event.data.getKeystroke();
+			/* ALT + SHIFT + Home for LTR direction */
+			if (keystroke == CKEDITOR.SHIFT + CKEDITOR.ALT + 36) {
+				this.getInputElement().setAttribute( 'dir', 'ltr' );
+			}
+			/* ALT + SHIFT + End for RTL direction */
+			else if (keystroke == CKEDITOR.SHIFT + CKEDITOR.ALT + 35) {
+				this.getInputElement().setAttribute( 'dir', 'rtl' );
+			}			
+	};
+		
 	var registerAccessKey = function( uiElement, dialog, key, downFunc, upFunc ) {
 			var procList = accessKeyProcessors[ key ] || ( accessKeyProcessors[ key ] = [] );
 			procList.push( {

--- a/plugins/forms/dialogs/button.js
+++ b/plugins/forms/dialogs/button.js
@@ -58,6 +58,7 @@ CKEDITOR.dialog.add( 'button', function( editor ) {
 			elements: [
 				{
 				id: 'name',
+				bidi: true,
 				type: 'text',
 				label: editor.lang.common.name,
 				'default': '',

--- a/plugins/forms/dialogs/form.js
+++ b/plugins/forms/dialogs/form.js
@@ -62,6 +62,7 @@ CKEDITOR.dialog.add( 'form', function( editor ) {
 			elements: [
 				{
 				id: 'txtName',
+				bidi: true,
 				type: 'text',
 				label: editor.lang.common.name,
 				'default': '',

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -525,6 +525,7 @@
 						{
 						type: 'text',
 						id: 'txtSummary',
+						bidi: true,
 						requiredContent: 'table[summary]',
 						label: editor.lang.table.summary,
 						setup: function( selectedTable ) {


### PR DESCRIPTION
Following your recommendation, the code was moved to dialog plugin.
The solution serves dialogs which activate the dialog plugin's commit and setup events (meaning, the solution will not work for Image, ImageButton and Anchor dialogs).
Files table.js, button.js and form.js demonstrate the use of this functionality simply by adding the bidi attribute.
