### PR TITLE
richcombo plugin: Removes extra quote from template string.

### DIFF
--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -16,8 +16,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 		' class="cke_combo cke_combo__{name} {cls}"' +
 		' role="presentation">' +
 			'<span id="{id}_label" class="cke_combo_label">{label}</span>' +
-			'<a class="cke_combo_button" hidefocus=true title="{title}" tabindex="-1"' +
-			( CKEDITOR.env.gecko && !CKEDITOR.env.hc ? '' : '" href="javascript:void(\'{titleJs}\')"' ) +
+			'<a class="cke_combo_button" title="{title}" tabindex="-1"' +
+			( CKEDITOR.env.gecko && !CKEDITOR.env.hc ? '' : ' href="javascript:void(\'{titleJs}\')"' ) +
 			' hidefocus="true"' +
 			' role="button"' +
 			' aria-labelledby="{id}_label"' +


### PR DESCRIPTION
This was resulting in invalid markup. (Found with help from [HTMLHint](/yaniswang/HTMLHint). :candy:)
Apparently the bug has been around in some form [since early 2010](/ckeditor/ckeditor-dev/commit/e2070a8220c13de7e7b38e35368e98a452ff958d#diff-72cbfcc1b6324132f021fda69da2b56dL116)..!

This commit also removes a duplicate `hidefocus` attribute from the same template.
