### PR TITLE
Make iFrame body have a minHeight equal to the config.height of t...

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -178,6 +178,14 @@
 			body.removeAttribute( 'disabled' );
 		}
 
+		// Fix problem with cursor not appearing in iOS (iPad) when clicking below the body (#10770).
+		if( typeof(this.editor.config.height) == number ) {
+			var configHeight = (this.editor.config.height).toString() + "px";
+			body.style.minHeight = configHeight;
+		} else {
+			body.style.minHeight = this.editor.config;
+		}
+
 		delete this._.isLoadingData;
 
 		// Play the magic to alter element reference to the reloaded one.


### PR DESCRIPTION
...he editor (#10770)

I ran into an issue while using an iPad.  I found that making the height of the iFrame's body larger make the area focus-able.

This also may make other event focused solutions (see line 213 or 221) to the same problem unnecessary.
