### PR TITLE
changes for bug number 10986 - Setting text direction to content within CKEditor dialogs

### DIFF
--- a/plugins/forms/dialogs/button.js
+++ b/plugins/forms/dialogs/button.js
@@ -58,6 +58,7 @@ CKEDITOR.dialog.add( 'button', function( editor ) {
 			elements: [
 				{
 				id: 'name',
+				bidi: true,
 				type: 'text',
 				label: editor.lang.common.name,
 				'default': '',

--- a/plugins/forms/dialogs/form.js
+++ b/plugins/forms/dialogs/form.js
@@ -62,6 +62,7 @@ CKEDITOR.dialog.add( 'form', function( editor ) {
 			elements: [
 				{
 				id: 'txtName',
+				bidi: true,
 				type: 'text',
 				label: editor.lang.common.name,
 				'default': '',

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -525,6 +525,7 @@
 						{
 						type: 'text',
 						id: 'txtSummary',
+						bidi: true,
 						requiredContent: 'table[summary]',
 						label: editor.lang.table.summary,
 						setup: function( selectedTable ) {


### PR DESCRIPTION
Bidi support code have been relocated (from dialog/plugin  to dialogui/plugin)

Direction is saved by attaching an lre/rle character to the value.
This character is added in the getValue method in textInput class 
This character is removed in the setValue method in textInput class
These two methods apply also for textArea elements
