### PR TITLE
Add one line to fix an edge case about pasting in Safari

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -738,6 +738,9 @@
 				margin: 0,
 				padding: 0
 			} );
+			
+			// Paste fails in Safari when the body tag has 'user-select: none'
+			pastebin.setStyles( CKEDITOR.tools.cssVendorPrefix( 'user-select', 'text' ) );
 
 			// Check if the paste bin now establishes new editing host.
 			var isEditingHost = pastebin.getParent().isReadOnly();


### PR DESCRIPTION
Situation:
When body tag has 'user-select:none', paste with Ctrl+V doesn't work in Safari

See [this CodePen for demo](http://codepen.io/getshao/pen/HcAqe)

Notice how copy and paste with Ctrl + C / Ctrl + V works in all browsers except Safari
