### PR TITLE
Update filter.js

### DIFF
--- a/core/filter.js
+++ b/core/filter.js
@@ -1839,7 +1839,7 @@
 				// after removing all elements.
 				if ( parent.type != CKEDITOR.NODE_DOCUMENT_FRAGMENT &&
 					child.type == CKEDITOR.NODE_ELEMENT &&
-					!DTD[ parent.name ][ child.name ]
+					!(DTD[ parent.name ] && DTD[ parent.name ][ child.name ])
 				)
 					toBeChecked.push( { check: 'el-up', el: child } );
 			}


### PR DESCRIPTION
Added a check whether "DTD[ parent.name ]" exists, before accessing "DTD[ parent.name ] && DTD[ parent.name ][ child.name ]".
Otherwise, if you have some exotic tag in your HTML, the scripts would throw an exception because no DTD definition would exist for that tag. Ofcourse you should only use valid HTML, but when you don't, you don't want the whole editor to breakdown.

Gr. Tim Selier, 
