### PR TITLE
Allow <cite> inside <blockquote>

### DIFF
--- a/plugins/blockquote/plugin.js
+++ b/plugins/blockquote/plugin.js
@@ -225,7 +225,7 @@
 
 		context: 'blockquote',
 
-		allowedContent: 'blockquote cite',
+		allowedContent: 'cite blockquote[cite]',
 		requiredContent: 'blockquote'
 	};
 


### PR DESCRIPTION
The blockqoute plugin doesn't allow nested cite-elements and cite-attribute.
Example:

<blockquote cite="http://example.org">
Lorem ipsum dolor sit amet
<cite>Somebody famous</cite>
</blockquote>
