### PR TITLE
Updated requiredContent for class attribute to match standards

### DIFF
--- a/plugins/image/dialogs/image.js
+++ b/plugins/image/dialogs/image.js
@@ -1121,7 +1121,7 @@
 						children: [ {
 							type: 'text',
 							id: 'txtGenClass',
-							requiredContent: 'img(cke-xyz)', // Random text like 'xyz' will check if all are allowed.
+							requiredContent: 'img[class]',
 							label: editor.lang.common.cssClass,
 							'default': '',
 							setup: function( type, element ) {


### PR DESCRIPTION
There was a comment before "// Random text like 'xyz' will check if all are allowed."

I interpret this to mean it was intentional but I cannot understand why — inserting random text like 'xyz' will break the expected behaviour of allowedContent. Why should the class attribute only be accessible if all content is allowed? This change matches how the other attributes are handled.
