### PR TITLE
Fix backspacing into empty lists

### DIFF
--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -898,10 +898,20 @@
 								previous.is( 'li' ) )
 							) {
 								if ( !previous.is( 'li' ) ) {
+									var newPrevious;
 									walker.range.selectNodeContents( previous );
 									walker.reset();
 									walker.evaluator = isTextBlock;
-									previous = walker.previous();
+
+									newPrevious = walker.previous();
+									if (newPrevious) {
+										previous = newPrevious;
+									}
+									else {
+										var listItem = editor.document.createElement( 'li' );
+										listItem.appendTo( previous );
+										previous = listItem;
+									}
 								}
 
 								joinWith = previous;

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -901,7 +901,6 @@
 									walker.range.selectNodeContents( previous );
 									walker.reset();
 									walker.evaluator = isTextBlock;
-
 									previous = walker.previous();
 
 									// this can be null if the walker started inside a list with no child list items

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -898,17 +898,17 @@
 								previous.is( 'li' ) )
 							) {
 								if ( !previous.is( 'li' ) ) {
-									var newPrevious;
 									walker.range.selectNodeContents( previous );
 									walker.reset();
 									walker.evaluator = isTextBlock;
 
-									newPrevious = walker.previous();
-									if (newPrevious) {
-										previous = newPrevious;
-									}
-									else {
+									previous = walker.previous();
+
+									// this can be null if the walker started inside a list with no child list items
+									// we know we are in a list, so just add an item
+									if (previous === null) {
 										var listItem = editor.document.createElement( 'li' );
+										previous = walker.range.startContainer;
 										listItem.appendTo( previous );
 										previous = listItem;
 									}

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -735,3 +735,21 @@
 		<li>^zzz@</li>
 	</ol>
 </textarea>
+
+<textarea id="join_list20">
+	<ul>
+		<li>xxx</li>
+		<li>yyy</li>
+	</ul>
+	<ol></ol>
+	<ul></ul>
+	<p>^zzz</p>
+	=>
+	<ul>
+		<li>xxx</li><li>yyy</li>
+	</ul>
+	<ol></ol>
+	<ul>
+		<li>^zzz@</li>
+	</ul>
+</textarea>

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -737,18 +737,9 @@
 </textarea>
 
 <textarea id="join_list20">
-	<ul>
-		<li>xxx</li>
-		<li>yyy</li>
-	</ul>
-	<ol></ol>
 	<ul></ul>
 	<p>^zzz</p>
 	=>
-	<ul>
-		<li>xxx</li><li>yyy</li>
-	</ul>
-	<ol></ol>
 	<ul>
 		<li>^zzz@</li>
 	</ul>

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -719,3 +719,19 @@
 		</li>
 	</ol>
 </textarea>
+
+<textarea id="join_list19">
+	<ul>
+		<li>xxx</li>
+		<li>yyy</li>
+	</ul>
+	<ol></ol>
+	<p>^zzz</p>
+	=>
+	<ul>
+		<li>xxx</li><li>yyy</li>
+	</ul>
+	<ol>
+		<li>^zzz@</li>
+	</ol>
+</textarea>

--- a/tests/plugins/list/backspace.js
+++ b/tests/plugins/list/backspace.js
@@ -51,6 +51,7 @@ addTests( 'test backspace join list items', 'join_list16', BACKSPACE, undefined,
 addTests( 'test backspace join list items', 'join_list17', BACKSPACE );
 addTests( 'test backspace join list items', 'join_list18', BACKSPACE );
 addTests( 'test backspace join list items', 'join_list19', BACKSPACE );
+addTests( 'test backspace join list items', 'join_list20', BACKSPACE );
 
 function assertNotNestedAnchors( editor ) {
 	assert.isNull( editor.editable().findOne( 'a a' ) );

--- a/tests/plugins/list/backspace.js
+++ b/tests/plugins/list/backspace.js
@@ -50,6 +50,7 @@ addTests( 'test backspace join list items', 'join_list15', BACKSPACE, undefined,
 addTests( 'test backspace join list items', 'join_list16', BACKSPACE, undefined, assertNotNestedAnchors );
 addTests( 'test backspace join list items', 'join_list17', BACKSPACE );
 addTests( 'test backspace join list items', 'join_list18', BACKSPACE );
+addTests( 'test backspace join list items', 'join_list19', BACKSPACE );
 
 function assertNotNestedAnchors( editor ) {
 	assert.isNull( editor.editable().findOne( 'a a' ) );


### PR DESCRIPTION
As discovered in https://dev.ckeditor.com/ticket/14395, empty lists cause the list backspace key handler to error out (because of a null element case.)  This causes it to fall back to random default behaviour depending on the browser.

This change makes it so that backspacing into a childless list will instead create a list item in that list to put the backspaced content into. 
