### PR TITLE
[#14514] Display message 'Loading' JAWS message

### DIFF
--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1459,7 +1459,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					var dir = this.getParentEditor().lang.dir,
 						spinnerDef = {
 							attributes: {
-								'class': 'cke_dialog_spinner'
+								'class': 'cke_dialog_spinner',
+								'aria-live': 'polite',
+								'role': 'presentation'
 							},
 							styles: {
 								'float': dir == 'rtl' ? 'right' : 'left'
@@ -1470,7 +1472,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 					this.parts.spinner = CKEDITOR.document.createElement( 'div', spinnerDef );
 
-					this.parts.spinner.setHtml( '&#8987;' );
+					this.parts.spinner.setHtml( editor.lang.common.loading? CKEDITOR.tools.htmlEncode(editor.lang.common.loading) :'&#8987;');
 					this.parts.spinner.appendTo( this.parts.title, 1 );
 				}
 


### PR DESCRIPTION
Proposed fix for [14514](https://dev.ckeditor.com/ticket/14514)
We have customized  'cke_dialog_spinner' class by setting the 'font-size' to 0 so that JAWS message would not be visible.
