### PR TITLE
[#14291] Fix selection of `required` checkbox in forms plugin

### DIFF
--- a/plugins/forms/dialogs/checkbox.js
+++ b/plugins/forms/dialogs/checkbox.js
@@ -131,7 +131,8 @@ CKEDITOR.dialog.add( 'checkbox', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( data ) {
 					var element = data.element;

--- a/plugins/forms/dialogs/radio.js
+++ b/plugins/forms/dialogs/radio.js
@@ -114,7 +114,8 @@ CKEDITOR.dialog.add( 'radio', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( data ) {
 					var element = data.element;

--- a/plugins/forms/dialogs/select.js
+++ b/plugins/forms/dialogs/select.js
@@ -488,8 +488,10 @@ CKEDITOR.dialog.add( 'select', function( editor ) {
 						accessKey: 'Q',
 						value: 'checked',
 						setup: function( name, element ) {
-							if ( name == 'select' )
-								this.setValue( element.getAttribute( 'required' ) );
+							if ( name == 'select' ) {
+								var required = element.getAttribute( 'required' );
+								this.setValue( required === '' || required === 'required' );
+							}
 						},
 						commit: function( element ) {
 							if ( this.getValue() )

--- a/plugins/forms/dialogs/textarea.js
+++ b/plugins/forms/dialogs/textarea.js
@@ -114,7 +114,8 @@ CKEDITOR.dialog.add( 'textarea', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( element ) {
 					if ( this.getValue() )

--- a/plugins/forms/dialogs/textfield.js
+++ b/plugins/forms/dialogs/textfield.js
@@ -178,7 +178,8 @@ CKEDITOR.dialog.add( 'textfield', function( editor ) {
 				accessKey: 'Q',
 				value: 'required',
 				setup: function( element ) {
-					this.setValue( element.getAttribute( 'required' ) );
+					var required = element.getAttribute( 'required' );
+					this.setValue( required === '' || required === 'required' );
 				},
 				commit: function( data ) {
 					var element = data.element;

--- a/tests/plugins/forms/checkbox.js
+++ b/tests/plugins/forms/checkbox.js
@@ -43,5 +43,55 @@ bender.test( {
 
 			assert.areSame( '<input type="checkbox" />', bot.getData( false, true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required="" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required="required" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="checkbox" required="any value other than empty string or required" />]' );
+
+		bot.dialog( 'checkbox', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/radio.js
+++ b/tests/plugins/forms/radio.js
@@ -51,5 +51,55 @@ bender.test( {
 
 			assert.areSame( '<input type="radio" />', bot.getData( false, true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required="" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required="required" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="radio" required="any value other than empty string or required" />]' );
+
+		bot.dialog( 'radio', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/select.js
+++ b/tests/plugins/forms/select.js
@@ -49,5 +49,55 @@ bender.test( {
 
 			assert.areSame( '<select></select>', bot.getData( false, true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required=""></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required="required"></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<select required="any value other than empty string or required"></select>]' );
+
+		bot.dialog( 'select', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/textarea.js
+++ b/tests/plugins/forms/textarea.js
@@ -88,5 +88,55 @@ bender.test( {
 
 		// Start testing.
 		testValue.call( this, 0 );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required=""></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required="required"></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<textarea required="any value other than empty string or required"></textarea>]' );
+
+		bot.dialog( 'textarea', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );

--- a/tests/plugins/forms/textfield.js
+++ b/tests/plugins/forms/textfield.js
@@ -77,5 +77,55 @@ bender.test( {
 
 			assert.areSame( '<input name="name" type="text" value="test@host.com" />', bot.getData( true ) );
 		} );
+	},
+
+	'test read collapsed required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read empty required attribute': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required="" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with value `required`': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required="required" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isTrue( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test required attribute absent': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
+	},
+
+	'test read required attribute with invalid value': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '[<input type="text" required="any value other than empty string or required" />]' );
+
+		bot.dialog( 'textfield', function( dialog ) {
+			assert.isFalse( dialog.getValueOf( 'info', 'required' ) );
+		} );
 	}
 } );


### PR DESCRIPTION
- according to HTML spec, valid values for the attribute are:
  - no value at all
  - empty string (required="")
  - string `required` (required="required")
- with the current implementation, the checkbox is checked,
  if the attribute contains any value
  -> if there is no value or an empty string, the checkbox
     is not selected, which is wrong
  -> if there is a value other than "required", the checkbox
     is selected, which is wrong
- see ticket #14291
