### PR TITLE
Justify widget hooks

### DIFF
--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -7,8 +7,18 @@
  * @fileOverview Justify commands.
  */
 
+var ALIGNMENTS = [ 'left', 'center', 'right', 'justify' ];
 ( function() {
 	function getAlignment( editor, element, useComputedState ) {
+		if ( CKEDITOR.plugins.widget && CKEDITOR.plugins.widget.isDomWidgetWrapper( element ) ) {
+			element = editor.widgets.getByElement( element, true );
+		}
+		for ( var i = 0; i < ALIGNMENTS.length; i++ ) {
+			var cls = editor.config[ALIGNMENTS[i] + 'Class'];
+			if ( cls && element.hasClass( cls ) )
+				return ALIGNMENTS[i];
+		}
+
 		useComputedState = useComputedState === undefined ? ( editor.config.useComputedState || true ) : useComputedState;
 		var align;
 		if ( useComputedState )
@@ -157,6 +167,7 @@
 				}
 				if ( CKEDITOR.plugins.widget.isDomWidgetWrapper( block ) ) {
 					var widget = editor.widgets.getByElement( block, true );
+					var element = widget.element;
 					if ( alignmentIsSupported( widget, command.value ) ) { //If the widget doesn't support this alignment, skip the widget
 						if ( widget.setAlignment ) {
 							if ( widget.setAlignment( editor, command ) ) { //If the widget's align method returns true, recurse into the widget's children
@@ -181,6 +192,18 @@
 								block = block.getParent();
 								if ( block.getName() !== 'body' ) {
 									command.doAlignBlock( editor, block, useComputedState );
+								}
+							} else {
+								for ( var i = 0; i < ALIGNMENTS.length; i++ ) {
+									if ( editor.config[ALIGNMENTS[i] + 'Class'] ) {
+										element.removeClass( editor.config[ALIGNMENTS[i] + 'Class'] );
+									}
+								}
+								var cls = editor.config[command.value + 'Class'];
+								if ( cls ) {
+									element.addClass( cls );
+								} else {
+									command.doAlignBlock( editor, element, useComputedState );
 								}
 							}
 							range.setStartAfter( widget.element );

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -157,7 +157,7 @@
 			}
 			if ( CKEDITOR.plugins.widget.isDomWidgetWrapper( block ) ) {
 				var style = getComputedStyle( block.$, null ).getPropertyValue( 'display' );
-				if ( style !== 'block' && style !== 'table' ) { //If display is not block-like, don't try to align this element
+				if ( style !== 'block' && style !== 'table' && block.getParent().getName() !== 'body' ) { //If display is not block-like, don't try to align this element
 					block = block.getParent();
 				}
 			}

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -176,10 +176,12 @@
 									block.removeClass( 'cke_widget_block' );
 								}
 							}
-						} else if ( widget.inline ) {
-							block = block.getParent();
-							if ( block.getName() !== 'body' ) {
-								command.doAlignBlock( editor, block, useComputedState );
+						} else {
+							if ( widget.inline ) {
+								block = block.getParent();
+								if ( block.getName() !== 'body' ) {
+									command.doAlignBlock( editor, block, useComputedState );
+								}
 							}
 							range.setStartAfter( widget.element );
 						}

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -295,6 +295,8 @@ var ALIGNMENTS = [ 'left', 'center', 'right', 'justify' ];
 				}
 				if ( widget.getAlignment ) {
 					current = widget.getAlignment( editor, this );
+				} else {
+					current = getAlignment( editor, widget.element, editor.config.useComputedState );
 				}
 			}
 			if ( current === undefined ) {

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -102,7 +102,7 @@
 					continue;
 				}
 
-				if ( CKEDITOR.plugins.widget.isDomWidgetWrapper( node ) ) {
+				if ( CKEDITOR.plugins.widget && CKEDITOR.plugins.widget.isDomWidgetWrapper( node ) ) {
 					var widget = editor.widgets.getByElement( node, true );
 					var alignment = getAlignment( editor, node, useComputedState );
 					var command = editor.getCommand( 'justify' + ( alignment === 'justify' ? 'block' : alignment ) );

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -188,17 +188,18 @@ var ALIGNMENTS = [ 'left', 'center', 'right', 'justify' ];
 								}
 							}
 						} else {
+							element.removeAttribute( 'align' );
+							for ( var i = 0; i < ALIGNMENTS.length; i++ ) {
+								if ( editor.config[ALIGNMENTS[i] + 'Class'] ) {
+									element.removeClass( editor.config[ALIGNMENTS[i] + 'Class'] );
+								}
+							}
 							if ( widget.inline ) {
 								block = block.getParent();
 								if ( block.getName() !== 'body' ) {
 									command.doAlignBlock( editor, block, useComputedState );
 								}
 							} else {
-								for ( var i = 0; i < ALIGNMENTS.length; i++ ) {
-									if ( editor.config[ALIGNMENTS[i] + 'Class'] ) {
-										element.removeClass( editor.config[ALIGNMENTS[i] + 'Class'] );
-									}
-								}
 								var cls = editor.config[command.value + 'Class'];
 								if ( cls ) {
 									element.addClass( cls );


### PR DESCRIPTION
This adds functionality to the Justify plugin that provides better hooks for widgets.

The added functionality is as follows:
1. Widgets are able to define _getAlignment_ and _setAlignment_ methods, which the Justify plugin detects and calls in place of its default functionality if they exist.  This allows widgets to easily override the default functionality of the Justify plugin in order to change their alignment, prevent their contents from being realigned, or even define custom alignment classes (note that in this case, both _getAlignment_ must be overridden as well in order for alignment detection to work properly).
   1. The _getAlignment_ function takes the current editor and the command that is currently calling the function as its arguments and returns a value of _left_, _right_, _center_, or _justify_.
   2. The _setAlignment_ function takes the current editor and the command that is currently calling the function as its arguments and returns a value of _true_ if the Justify plugin should recurse into the widget, or _false_ if it should not.
2. For widgets that don't define _getAlignment_ and/or _setAlignment_ methods, the Justify plugin attempts to use configurable default detection and application functions:
   1. The classes used are loaded from the editor's config under the names: _leftClass_, _centerClass_, _rightClass_, _justifyClass_.
   2. Although defining all of these classes is recommended, any combination can be left undefined; however, due to the nature of the button integration, this will _not_ result in the buttons being disabled.
   3. If none of those settings are defined, these default functions are effectively disabled.
   4. In keeping with the current default behavior of the Justify plugin, the plugin will still recurse into the widget's contents.
3. Because some widgets may only support a subset of the alignment commands, widgets can define an _align_ feature. If it is not defined, the widget is assumed to support all alignment types. Otherwise, it's value should be the set of alignment commands supported by the widget (_left_, _right_, _center_, and _justify_).
4. The logic in the Justify plugin's commands was refactored so that widgets can call the original logic from within the _setAlignment_ function. This allows for widgets can forward the original command to their contents (this is useful in the case where the widget uses a custom alignment class but also wants to align its contents).
5. These changes are entirely backwards-compatible. The default behavior is identical to the plugin's behavior prior to these features being added, and the signatures of the four commands added by the plugin have not been changed.
