### PR TITLE
Add support for HOME/END/ARROW keys on fake selection

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -389,8 +389,9 @@
 
 			if ( fakeSelectionNavKeys[ keystroke ] ) {
 				if ( sel.isFake ) {
-					// move to right if key is HOME/LEFT/UP else to left
-					// so non-editable element is selected on SHIFT+HOME/END/UP
+				    // Make non-fake selection and let the default handler do
+				    // the rest. Move to right if key is HOME/LEFT/UP else to
+					// left so non-editable element is selected on SHIFT+KEY.
 					var key = evt.data.getKey(),
 						right = key === 36 || key === 37 || key == 38;
 					range.moveToClosestEditablePosition( evt.selected, right );

--- a/core/selection.js
+++ b/core/selection.js
@@ -355,13 +355,18 @@
 	// Handle left, right, delete and backspace keystrokes next to non-editable elements
 	// by faking selection on them.
 	function getOnKeyDownListener( editor ) {
-		var homeEndKeys = {
+		var fakeSelectionNavKeys = {
 				35: 1,		// END
 				36: 1,		// HOME
 				2228259: 1,	// SHIFT + END
 				2228260: 1,	// SHIFT + HOME
-				1114149: 1,	// COMMAND + LEFT - Mac OS equivalent to HOME
-				1114151: 1,	// COMMAND + RIGHT - Mac OS equivalent to END
+				2228261: 1,	// SHIFT + LEFT
+				2228262: 1,	// SHIFT + UP
+				2228263: 1,	// SHIFT + RIGHT
+				2228264: 1,	// SHIFT + DOWN
+				// Mac OS equivalents for HOME/END...
+				1114149: 1,	// COMMAND + LEFT
+				1114151: 1,	// COMMAND + RIGHT
 				3342373: 1, // SHIFT + COMMAND + LEFT
 				3342375: 1  // SHIFT + COMMAND + RIGHT
 			},
@@ -382,12 +387,12 @@
 				ranges = sel.getRanges(),
 				range = ranges[ 0 ];
 
-			if ( homeEndKeys[ keystroke ] ) {
+			if ( fakeSelectionNavKeys[ keystroke ] ) {
 				if ( sel.isFake ) {
-					// move to right if key is HOME/LEFT else to left
-					// so non-editable element is selected on SHIFT+HOME/END
+					// move to right if key is HOME/LEFT/UP else to left
+					// so non-editable element is selected on SHIFT+HOME/END/UP
 					var key = evt.data.getKey(),
-						right = key === 36 || key === 37;
+						right = key === 36 || key === 37 || key == 38;
 					range.moveToClosestEditablePosition( evt.selected, right );
 					range.select();
 				}

--- a/tests/core/selection/fake.js
+++ b/tests/core/selection/fake.js
@@ -761,11 +761,11 @@ bender.test( {
 		} );
 	},
 
-	'Test moving from non-editable element by home/end keys': function() {
-		// HOME/END key events must not be prevented so they can be handled by
-		// the normal home/end logic. The event handlers we are testing here
-		// simply create a non-fake selection and then let the default logic do
-		// the rest.
+	'Test moving from non-editable element by home/end/arrow keys': function() {
+		// HOME/END/ARROW key events must not be prevented so they can be
+		// handled by the normal home/end logic. The event handlers we are
+		// testing here simply create a non-fake selection and then let the
+		// default logic do the rest.
 		function noPrevent() {
 			throw new Error("event should not be prevented");
 		}
@@ -807,6 +807,14 @@ bender.test( {
 			test( 'SHIFT+END', '<p>bar ^[foo] bom</p>' );
 
 			test( 'SHIFT+HOME', '<p>bar [foo]^ bom</p>' );
+
+			test( 'SHIFT+LEFT', '<p>bar [foo]^ bom</p>' );
+
+			test( 'SHIFT+UP', '<p>bar [foo]^ bom</p>' );
+
+			test( 'SHIFT+RIGHT', '<p>bar ^[foo] bom</p>' );
+
+			test( 'SHIFT+DOWN', '<p>bar ^[foo] bom</p>' );
 
 			test( 'CTRL+LEFT', '<p>bar [foo]^ bom</p>' );
 


### PR DESCRIPTION
I've found it really annoying to have keyboard navigation get stalled when a widget is (fake) selected. This adds support for more navigation and selection keys on fake selection.