### PR TITLE
Introduced the basicEntityNbspOff configuration option to not to esca…

### DIFF
--- a/plugins/entities/plugin.js
+++ b/plugins/entities/plugin.js
@@ -6,6 +6,7 @@
 ( function() {
 	// Basic HTML entities.
 	var htmlbase = 'nbsp,gt,lt,amp';
+	var htmlbasenonbsp = 'gt,lt,amp';
 
 	var entities =
 	// Latin-1 entities
@@ -115,7 +116,10 @@
 				var selectedEntities = [];
 
 				if ( config.basicEntities !== false )
-					selectedEntities.push( htmlbase );
+					if ( config.basicEntityNbspOff == true )
+						selectedEntities.push( htmlbasenonbsp );
+					else
+						selectedEntities.push( htmlbase );
 
 				if ( config.entities ) {
 					if ( selectedEntities.length )
@@ -176,6 +180,20 @@
  * @member CKEDITOR.config
  */
 CKEDITOR.config.basicEntities = true;
+
+/**
+ * Whether to disable escaped nbsp entity 
+ * if basic HTML entities are escaped by config.basicEntities = true
+ *
+ * **Note:** This option has no effect if config.basicEntities = false;
+ *
+ *
+ *		config.basicEntityNbspOff = true;
+ *
+ * @cfg {Boolean} [basicEntityNbspOff=false]
+ * @member CKEDITOR.config
+ */
+CKEDITOR.config.basicEntityNbspOff = false;
 
 /**
  * Whether to use HTML entities in the editor output.


### PR DESCRIPTION
Hi,
there is a problem related to the config.basicEntities = true option. In our case we want only &gt; and &lt; (we use the < and > characters quite often in math, if they are not escaped, CKeditor or even a browser often deletes them as unknown tags), but do not want the &nbsp; entities - unfortunately, browsers usually enter a lot of &nbsp; entities instead of plain spaces. This is is very annoying. This problem has been discussed already at various places, even with suggested workarounds in a form of a special CKEditor plugin, the goal of which  was to clean up the text in postprocessing. 

In this pull request I propose to add a new configuration option config.basicEntityNbspOff. If true, no nbsps are added, if false, CKeditor behaves as before. Thus, no existing configurations are not broken.

Thank you in advance for considering this change.
Milos