### PR TITLE
Workaround plugin for iOS scrolling bug, #16902.

### DIFF
--- a/plugins/iosscroll/plugin.js
+++ b/plugins/iosscroll/plugin.js
@@ -1,0 +1,110 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+
+/**
+ * @fileOverview Applies a workaround to iOS scrolling issue. The issue occurs when typing into scrolled editor.
+ *                 Editable area gets scrolled to the bottom when typing so input text is not visible on screen.
+ */
+
+( function() {
+	'use strict';
+
+	CKEDITOR.plugins.add( 'iosscroll', {
+		init: function( editor ) {
+			if ( CKEDITOR.env.iOS ) {
+				editor.on( 'contentDom', function() {
+					fixTypingScroll( editor );
+				} );
+			}
+		}
+	} );
+
+	function fixTypingScroll( editor ) {
+		var editable = editor.editable();
+
+		// the bug occurs only in iframe-based editors, so don't do anything for inline editors
+		if ( editable && !editable.isInline() ) {
+			editable.attachListener( editable, 'input', function() {
+				var selection = editor.getSelection();
+
+				if ( !selection ) {
+					return;
+				}
+
+				var range = selection.getRanges()[ 0 ];
+				var nativeSelection = selection.getNative();
+				var nativeRange = getNativeRange( range );
+
+				// there's a collapsed selection when typing on iOS; removing ranges from the selection prevents
+				// weird bug where editable is scrolled on typing and typed text is not visible
+				nativeSelection.removeAllRanges();
+
+				// postpone further execution to let everything what's causing the iOS scrolling bug happen
+				setTimeout( function() {
+					// restore the caret to where it was when typing
+					nativeSelection.addRange( nativeRange );
+
+					// additional scrolling may be needed in case of pasting
+					scrollIfNeeded( range, selection, editor );
+				}, 0 );
+			} );
+		}
+	}
+
+	function getNativeRange( range ) {
+		var nativeRange = document.createRange();
+		nativeRange.setStart( range.startContainer.$, range.startOffset );
+		nativeRange.setEnd( range.endContainer.$, range.endOffset );
+
+		return nativeRange;
+	}
+
+	function scrollIfNeeded( range, selection, editor ) {
+		var clonedRange = range.clone();
+		var nativeRange = getNativeRange( clonedRange );
+		var boundingRect;
+		var wrapper;
+		var currentPos;
+
+		// getBoundingClientRect in order to know caret's position
+		boundingRect = nativeRange.getBoundingClientRect();
+
+		// Safari has a bug where getBoundingClientRect returns all zeroes for collapsed ranges
+		// in such case, expand the range by 1 to the left and then call getBoundingClientRect
+		// expanding to the left is possible because caret is right after input text
+		if ( isBoundingRectZeroed( boundingRect ) && clonedRange.startOffset > 0 ) {
+			clonedRange.setStart( clonedRange.startContainer, clonedRange.startOffset - 1 );
+			nativeRange = getNativeRange( clonedRange );
+			boundingRect = nativeRange.getBoundingClientRect();
+		}
+
+		wrapper = editor.container.findOne( '.cke_contents' );
+
+		if ( !wrapper ) {
+			return;
+		}
+
+		currentPos = wrapper.$.scrollTop + wrapper.$.clientHeight;
+
+		// if caret's position is below editor wrapper's visible area (which is scrollTop + height)
+		if ( boundingRect && currentPos < boundingRect.top ) {
+			selection.scrollIntoView();
+		}
+	}
+
+	function isBoundingRectZeroed( rect ) {
+		for ( var prop in rect ) {
+			if ( !rect.hasOwnProperty( prop ) ) {
+				continue;
+			}
+
+			if ( rect[ prop ] > 0 ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+} )();

--- a/plugins/iosscroll/tests/manual/iosscroll.html
+++ b/plugins/iosscroll/tests/manual/iosscroll.html
@@ -1,0 +1,61 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed rhoncus magna ipsum. Ut auctor dignissim augue, id
+	laoreet turpis blandit sit amet. Sed non libero erat. Vivamus sodales massa erat, at aliquet mi volutpat at. Nulla
+	gravida elit in magna malesuada tincidunt. Nunc malesuada risus vel lacinia lobortis. Vivamus tortor tellus,
+	ultrices et nisl quis, elementum fringilla lorem. Praesent vel purus felis. Vestibulum sed turpis auctor, aliquam ex
+	vel, pharetra tortor. Duis sed quam finibus, condimentum ipsum eget, sodales neque. Curabitur ultricies venenatis
+	lobortis. Nullam ut bibendum quam. Phasellus ut nunc a libero hendrerit suscipit et eget lectus. Ut sed elit vitae
+	enim bibendum elementum. Nullam vehicula, dolor vel lobortis posuere, velit ligula dictum massa, vel blandit dolor
+	erat non sapien.
+
+	Nulla facilisi. Suspendisse auctor neque id libero dignissim dictum. Integer ut dolor dolor. Proin eu orci et ante
+	posuere vestibulum. Maecenas id eleifend urna. Nulla et odio lacus. Suspendisse sit amet mauris interdum, efficitur
+	justo quis, porta tellus. Quisque ac elit sed ex luctus scelerisque sed quis velit. Nullam odio elit, euismod nec
+	lectus ut, laoreet vestibulum enim. Donec mattis vehicula ipsum id suscipit. Sed at nunc ipsum. Aliquam a ligula eu
+	nibh laoreet cursus.
+
+	Curabitur lectus eros, tincidunt a malesuada id, fermentum vitae est. Cras consequat, odio sit amet sagittis
+	ultricies, purus mi ullamcorper elit, nec convallis velit orci et orci. Nulla tristique consectetur orci. Fusce
+	luctus, risus quis vulputate pretium, urna diam pretium purus, at sollicitudin ligula nisl sit amet erat. Morbi
+	consequat purus ut mattis tincidunt. Cras malesuada, neque a condimentum ultricies, erat tellus pretium enim, sed
+	lobortis nisi lacus eu ex. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+	egestas. Proin id erat auctor, scelerisque est ac, aliquet lacus.
+</p>
+<textarea id="editor1">
+	<p><strong>Apollo 11</strong>&nbsp;was the spaceflight that landed <strong>the first</strong> humans, Americans&nbsp;Neil Armstrong&nbsp;and&nbsp;Buzz Aldrin, on the Moon on July 20, <strong>1969</strong>, at 20:18 UTC. Armstrong became the first <strong>to step onto the</strong> lunar surface 6 hours later on July 21 at <strong>02:56</strong> UTC.</p>
+		<p>Armstrong spent about&nbsp;<s>three and a half</s>&nbsp;two and a half hours <strong>outside the spacecraft</strong>, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission,&nbsp;Michael Collins, piloted the&nbsp;command&nbsp;<strong>spacecraft alone in lunar</strong> orbit until Armstrong and Aldrin <strong>returned to it for the trip</strong> back to Earth.</p>
+	<p><strong>Apollo 11</strong>&nbsp;was the spaceflight that landed <strong>the first</strong> humans, Americans&nbsp;Neil Armstrong&nbsp;and&nbsp;Buzz Aldrin, on the Moon on July 20, <strong>1969</strong>, at 20:18 UTC. Armstrong became the first <strong>to step onto the</strong> lunar surface 6 hours later on July 21 at <strong>02:56</strong> UTC.</p>
+		<p>Armstrong spent about&nbsp;<s>three and a half</s>&nbsp;two and a half hours <strong>outside the spacecraft</strong>, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission,&nbsp;Michael Collins, piloted the&nbsp;command&nbsp;<strong>spacecraft alone in lunar</strong> orbit until Armstrong and Aldrin <strong>returned to it for the trip</strong> back to Earth.</p>
+	<p><strong>Apollo 11</strong>&nbsp;was the spaceflight that landed <strong>the first</strong> humans, Americans&nbsp;Neil Armstrong&nbsp;and&nbsp;Buzz Aldrin, on the Moon on July 20, <strong>1969</strong>, at 20:18 UTC. Armstrong became the first <strong>to step onto the</strong> lunar surface 6 hours later on July 21 at <strong>02:56</strong> UTC.</p>
+		<p>Armstrong spent about&nbsp;<s>three and a half</s>&nbsp;two and a half hours <strong>outside the spacecraft</strong>, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission,&nbsp;Michael Collins, piloted the&nbsp;command&nbsp;<strong>spacecraft alone in lunar</strong> orbit until Armstrong and Aldrin <strong>returned to it for the trip</strong> back to Earth.</p>
+</textarea>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed rhoncus magna ipsum. Ut auctor dignissim augue, id
+	laoreet turpis blandit sit amet. Sed non libero erat. Vivamus sodales massa erat, at aliquet mi volutpat at. Nulla
+	gravida elit in magna malesuada tincidunt. Nunc malesuada risus vel lacinia lobortis. Vivamus tortor tellus,
+	ultrices et nisl quis, elementum fringilla lorem. Praesent vel purus felis. Vestibulum sed turpis auctor, aliquam ex
+	vel, pharetra tortor. Duis sed quam finibus, condimentum ipsum eget, sodales neque. Curabitur ultricies venenatis
+	lobortis. Nullam ut bibendum quam. Phasellus ut nunc a libero hendrerit suscipit et eget lectus. Ut sed elit vitae
+	enim bibendum elementum. Nullam vehicula, dolor vel lobortis posuere, velit ligula dictum massa, vel blandit dolor
+	erat non sapien.
+
+	Nulla facilisi. Suspendisse auctor neque id libero dignissim dictum. Integer ut dolor dolor. Proin eu orci et ante
+	posuere vestibulum. Maecenas id eleifend urna. Nulla et odio lacus. Suspendisse sit amet mauris interdum, efficitur
+	justo quis, porta tellus. Quisque ac elit sed ex luctus scelerisque sed quis velit. Nullam odio elit, euismod nec
+	lectus ut, laoreet vestibulum enim. Donec mattis vehicula ipsum id suscipit. Sed at nunc ipsum. Aliquam a ligula eu
+	nibh laoreet cursus.
+
+	Curabitur lectus eros, tincidunt a malesuada id, fermentum vitae est. Cras consequat, odio sit amet sagittis
+	ultricies, purus mi ullamcorper elit, nec convallis velit orci et orci. Nulla tristique consectetur orci. Fusce
+	luctus, risus quis vulputate pretium, urna diam pretium purus, at sollicitudin ligula nisl sit amet erat. Morbi
+	consequat purus ut mattis tincidunt. Cras malesuada, neque a condimentum ultricies, erat tellus pretium enim, sed
+	lobortis nisi lacus eu ex. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+	egestas. Proin id erat auctor, scelerisque est ac, aliquet lacus.
+</p>
+<script>
+	if ( !CKEDITOR.env.iOS ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'iosscroll'
+	} );
+</script>

--- a/plugins/iosscroll/tests/manual/iosscroll.md
+++ b/plugins/iosscroll/tests/manual/iosscroll.md
@@ -1,0 +1,16 @@
+@bender-tags: iosscroll
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, floatingspace, iosscroll, basicstyles, format, undo
+
+Open on iOS device or simulator.
+
+Test case #1:
+1. Scroll the page down a bit.
+2. Tap at the beginning of editor's text.
+3. Type some characters.
+4. Check if editable area is not scrolled and input text is still visible.
+
+Test case #2:
+1. Scroll the page down a bit.
+2. Select some text and copy it.
+3. Paste anywhere in the editor and check if the caret is in correct place.


### PR DESCRIPTION
This is a workaround for this issue: https://dev.ckeditor.com/ticket/16902
Weird bug reproducible only on iOS. It is 'fixed' by removing ranges from selection in `input` event and restoring it shortly after (see comments in the code for more info)

There are no unit test, I tried simulating this bug using `execCommand('insertText')`, however it doesn't reproduce that way. Only manual test is added.