### PR TITLE
[17009] Keep ID of inlined element while insertText is used. 

### DIFF
--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1171,24 +1171,13 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 					// queuing them to be moved later. (#5567)
 >>>>>>> Better fix for keeping ID.
 
-					// keep order
-					// debugger;
 					var pendingNodes = [],
 						temporaryElement, node;
 					while ( sibling.data( 'cke-bookmark' ) || sibling.isEmptyInlineRemoveable() ) {
 						pendingNodes.push( sibling );
 						sibling = isNext ? sibling.getNext() : sibling.getPrevious();
 						if ( !sibling || sibling.type != CKEDITOR.NODE_ELEMENT ) {
-							/*
-							while ( node = pendingNodes.pop() ) {
-								if ( node.data( 'cke-bookmark' ) ) {
-									continue;
-								} else {
-									node.remove();
-								}
-							} */
 							return;
-
 						}
 					}
 
@@ -1197,15 +1186,13 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 						// <b><i></i></b><b><i></i></b> => <b><i></i></b>
 						var innerSibling = isNext ? element.getLast() : element.getFirst();
 
-
-						//debugger;
+						// #17009 swap elements, to analyse then in this same order (from lower index to higher)
 						if ( element.getIndex() > sibling.getIndex() ) {
 							temporaryElement = element;
 							element = sibling;
 							sibling = temporaryElement;
 							isNext = !isNext;
 						}
-
 
 						// Move pending nodes first into the target element.
 						while ( pendingNodes.length )

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1174,15 +1174,30 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 					// keep order
 					// debugger;
 					var pendingNodes = [],
-						temporaryElement;
+						temporaryElement, node;
 					while ( sibling.data( 'cke-bookmark' ) || sibling.isEmptyInlineRemoveable() ) {
 						pendingNodes.push( sibling );
 						sibling = isNext ? sibling.getNext() : sibling.getPrevious();
-						if ( !sibling || sibling.type != CKEDITOR.NODE_ELEMENT )
+						if ( !sibling || sibling.type != CKEDITOR.NODE_ELEMENT ) {
+							/*
+							while ( node = pendingNodes.pop() ) {
+								if ( node.data( 'cke-bookmark' ) ) {
+									continue;
+								} else {
+									node.remove();
+								}
+							} */
 							return;
+
+						}
 					}
 
 					if ( element.isIdentical( sibling ) ) {
+						// Save the last child to be checked too, to merge things like
+						// <b><i></i></b><b><i></i></b> => <b><i></i></b>
+						var innerSibling = isNext ? element.getLast() : element.getFirst();
+
+
 						//debugger;
 						if ( element.getIndex() > sibling.getIndex() ) {
 							temporaryElement = element;
@@ -1191,9 +1206,6 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 							isNext = !isNext;
 						}
 
-						// Save the last child to be checked too, to merge things like
-						// <b><i></i></b><b><i></i></b> => <b><i></i></b>
-						var innerSibling = isNext ? element.getLast() : element.getFirst();
 
 						// Move pending nodes first into the target element.
 						while ( pendingNodes.length )

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1164,9 +1164,17 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 			function mergeElements( element, sibling, isNext ) {
 				if ( sibling && sibling.type == CKEDITOR.NODE_ELEMENT ) {
 					// Jumping over bookmark nodes and empty inline elements, e.g. <b><i></i></b>,
+<<<<<<< HEAD
 					// queuing them to be moved later. (http://dev.ckeditor.com/ticket/5567)
 					var pendingNodes = [];
+=======
+					// queuing them to be moved later. (#5567)
+>>>>>>> Better fix for keeping ID.
 
+					// keep order
+					// debugger;
+					var pendingNodes = [],
+						temporaryElement;
 					while ( sibling.data( 'cke-bookmark' ) || sibling.isEmptyInlineRemoveable() ) {
 						pendingNodes.push( sibling );
 						sibling = isNext ? sibling.getNext() : sibling.getPrevious();
@@ -1175,6 +1183,14 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 					}
 
 					if ( element.isIdentical( sibling ) ) {
+						//debugger;
+						if ( element.getIndex() > sibling.getIndex() ) {
+							temporaryElement = element;
+							element = sibling;
+							sibling = temporaryElement;
+							isNext = !isNext;
+						}
+
 						// Save the last child to be checked too, to merge things like
 						// <b><i></i></b><b><i></i></b> => <b><i></i></b>
 						var innerSibling = isNext ? element.getLast() : element.getFirst();

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1164,15 +1164,9 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 			function mergeElements( element, sibling, isNext ) {
 				if ( sibling && sibling.type == CKEDITOR.NODE_ELEMENT ) {
 					// Jumping over bookmark nodes and empty inline elements, e.g. <b><i></i></b>,
-<<<<<<< HEAD
 					// queuing them to be moved later. (http://dev.ckeditor.com/ticket/5567)
-					var pendingNodes = [];
-=======
-					// queuing them to be moved later. (#5567)
->>>>>>> Better fix for keeping ID.
-
 					var pendingNodes = [],
-						temporaryElement, node;
+						temporaryElement;
 					while ( sibling.data( 'cke-bookmark' ) || sibling.isEmptyInlineRemoveable() ) {
 						pendingNodes.push( sibling );
 						sibling = isNext ? sibling.getNext() : sibling.getPrevious();
@@ -1186,7 +1180,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 						// <b><i></i></b><b><i></i></b> => <b><i></i></b>
 						var innerSibling = isNext ? element.getLast() : element.getFirst();
 
-						// #17009 swap elements, to analyse then in this same order (from lower index to higher)
+						// Swap elements to return always this same order: from lowest to highest index (https://dev.ckeditor.com/ticket/17009).
 						if ( element.getIndex() > sibling.getIndex() ) {
 							temporaryElement = element;
 							element = sibling;
@@ -1195,15 +1189,17 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 						}
 
 						// Move pending nodes first into the target element.
-						while ( pendingNodes.length )
+						while ( pendingNodes.length ) {
 							pendingNodes.shift().move( element, !isNext );
+						}
 
 						sibling.moveChildren( element, !isNext );
 						sibling.remove();
 
 						// Now check the last inner child (see two comments above).
-						if ( innerSibling && innerSibling.type == CKEDITOR.NODE_ELEMENT )
+						if ( innerSibling && innerSibling.type == CKEDITOR.NODE_ELEMENT ) {
 							innerSibling.mergeSiblings();
+						}
 					}
 				}
 			}

--- a/core/editable.js
+++ b/core/editable.js
@@ -1663,7 +1663,7 @@
 		function prepareRangeToDataInsertion( that ) {
 			var range = that.range,
 				mergeCandidates = that.mergeCandidates,
-				node, marker, path, startPath, endPath, previous, bm;
+				node, marker, path, startPath, endPath, previous, bm, i, element;
 
 			// If range starts in inline element then insert a marker, so empty
 			// inline elements won't be removed while range.deleteContents
@@ -1716,18 +1716,21 @@
 			// Split inline elements so HTML will be inserted with its own styles.
 			path = range.startPath();
 			if ( ( node = path.contains( isInline, false, 1 ) ) ) {
-				if ( node.hasAttribute( 'id' ) ){
-					that.elementsWithId.push({
-						"node": node,
-						"id": node.getAttribute('id')
-					});
-					node.removeAttribute('id');
+				for ( i=0; i < path.elements.length; i++ ) {
+					element = path.elements[i];
+					if ( element.hasAttribute( 'id' ) ){
+						that.elementsWithId.push({
+							"node": element,
+							"id": element.getAttribute('id')
+						});
+						element.removeAttribute('id');
+					}
 				}
 				range.splitElement( node );
 				that.inlineStylesRoot = node;
 				that.inlineStylesPeak = path.lastElement;
 			}
-			// debugger;
+
 			// Record inline merging candidates for later cleanup in place.
 			bm = range.createBookmark();
 
@@ -1943,7 +1946,7 @@
 				bogusNeededBlocks = that.bogusNeededBlocks,
 				// Create a bookmark to defend against the following range deconstructing operations.
 				bm = range.createBookmark();
-				// debugger;
+
 			// Remove all elements that could be created while splitting nodes
 			// with ranges at its start|end.
 			// E.g. remove <div><p></p></div>
@@ -1975,7 +1978,6 @@
 
 			range.moveToBookmark( bm );
 
-			// debugger;
 			while ( ( element = that.elementsWithId.pop() ) ) {
 				element.node.setAttribute( 'id', element.id );
 			}

--- a/core/editable.js
+++ b/core/editable.js
@@ -1603,7 +1603,7 @@
 		function insert( editable, type, data, range ) {
 			var editor = editable.editor,
 				dontFilter = false;
-
+			// debugger;
 			if ( type == 'unfiltered_html' ) {
 				type = 'html';
 				dontFilter = true;
@@ -1627,6 +1627,7 @@
 					editor: editor,
 					range: range,
 					blockLimit: blockLimit,
+					elementsWithId: [],
 					// During pre-processing / preparations startContainer of affectedRange should be placed
 					// in this element in which inserted or moved (in case when we merge blocks) content
 					// could create situation that will need merging inline elements.
@@ -1715,11 +1716,18 @@
 			// Split inline elements so HTML will be inserted with its own styles.
 			path = range.startPath();
 			if ( ( node = path.contains( isInline, false, 1 ) ) ) {
+				if ( node.hasAttribute( 'id' ) ){
+					that.elementsWithId.push({
+						"node": node,
+						"id": node.getAttribute('id')
+					});
+					node.removeAttribute('id');
+				}
 				range.splitElement( node );
 				that.inlineStylesRoot = node;
 				that.inlineStylesPeak = path.lastElement;
 			}
-
+			// debugger;
 			// Record inline merging candidates for later cleanup in place.
 			bm = range.createBookmark();
 
@@ -1931,11 +1939,11 @@
 
 		function cleanupAfterInsertion( that ) {
 			var range = that.range,
-				node, testRange, movedIntoInline,
+				node, testRange, movedIntoInline, element,
 				bogusNeededBlocks = that.bogusNeededBlocks,
 				// Create a bookmark to defend against the following range deconstructing operations.
 				bm = range.createBookmark();
-
+				// debugger;
 			// Remove all elements that could be created while splitting nodes
 			// with ranges at its start|end.
 			// E.g. remove <div><p></p></div>
@@ -1966,6 +1974,11 @@
 				node.mergeSiblings();
 
 			range.moveToBookmark( bm );
+
+			// debugger;
+			while ( ( element = that.elementsWithId.pop() ) ) {
+				element.node.setAttribute( 'id', element.id );
+			}
 
 			// Rule 3.
 			// Shrink range to the BEFOREEND of previous innermost editable node in source order.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1603,7 +1603,7 @@
 		function insert( editable, type, data, range ) {
 			var editor = editable.editor,
 				dontFilter = false;
-			// debugger;
+
 			if ( type == 'unfiltered_html' ) {
 				type = 'html';
 				dontFilter = true;
@@ -1716,6 +1716,7 @@
 			// Split inline elements so HTML will be inserted with its own styles.
 			path = range.startPath();
 			if ( ( node = path.contains( isInline, false, 1 ) ) ) {
+				// #17009 store elements with id. Beacuse siblings are marged always from lower child index to higher, refrence to node will persist after all operations.
 				for ( i=0; i < path.elements.length; i++ ) {
 					element = path.elements[i];
 					if ( element.hasAttribute( 'id' ) ){
@@ -1978,6 +1979,7 @@
 
 			range.moveToBookmark( bm );
 
+			// #17009 restore id to previously stored elements.
 			while ( ( element = that.elementsWithId.pop() ) ) {
 				element.node.setAttribute( 'id', element.id );
 			}

--- a/core/editable.js
+++ b/core/editable.js
@@ -1663,7 +1663,7 @@
 		function prepareRangeToDataInsertion( that ) {
 			var range = that.range,
 				mergeCandidates = that.mergeCandidates,
-				node, marker, path, startPath, endPath, previous, bm, i, element;
+				node, marker, path, startPath, endPath, previous, bm;
 
 			// If range starts in inline element then insert a marker, so empty
 			// inline elements won't be removed while range.deleteContents
@@ -1716,17 +1716,18 @@
 			// Split inline elements so HTML will be inserted with its own styles.
 			path = range.startPath();
 			if ( ( node = path.contains( isInline, false, 1 ) ) ) {
-				// #17009 store elements with id. Beacuse siblings are marged always from lower child index to higher, refrence to node will persist after all operations.
-				for ( i=0; i < path.elements.length; i++ ) {
-					element = path.elements[i];
-					if ( element.hasAttribute( 'id' ) ){
-						that.elementsWithId.push({
-							"node": element,
-							"id": element.getAttribute('id')
-						});
-						element.removeAttribute('id');
+				// Store elements with id, beacuse siblings are marged always from lowest child index to highest,
+				// refrence to node will persist after all operations (https://dev.ckeditor.com/ticket/17009).
+				CKEDITOR.tools.array.forEach( path.elements, function( element ) {
+					if ( element.hasAttribute( 'id' ) ) {
+						that.elementsWithId.push( {
+							'node': element,
+							'id': element.getAttribute( 'id' )
+						} );
+						element.removeAttribute( 'id' );
 					}
-				}
+				} );
+
 				range.splitElement( node );
 				that.inlineStylesRoot = node;
 				that.inlineStylesPeak = path.lastElement;

--- a/tests/core/dom/element/element.js
+++ b/tests/core/dom/element/element.js
@@ -752,17 +752,17 @@ bender.test( appendDomObjectTests(
 		},
 
 		test_isIdentical: function() {
-				// <b name="a" class="test">tessst</b>
+			// <b name="a" class="test">tessst</b>
 			var element1 = doc.getById( 'isIdentical' ).getFirst(),
-				// <b class="test" name="a"></b>
+			// <b class="test" name="a"></b>
 				element2 = element1.getNext(),
-				// <b class="test"></b>
+			// <b class="test"></b>
 				element3 = element2.getNext(),
-				// <b>tessst</b>
+			// <b>tessst</b>
 				element4 = element3.getNext(),
-				// <b _moz_dirty="" class="test"></b>
+			// <b _moz_dirty="" class="test"></b>
 				element5 = element4.getNext(),
-				// <b class="test" data-cke-expando=53></b>
+			// <b class="test" data-cke-expando=53></b>
 				element6 = element5.getNext();
 
 			assert.isTrue( element1.isIdentical( element2 ), 'different attrs order' );
@@ -787,9 +787,9 @@ bender.test( appendDomObjectTests(
 		},
 
 		test_isIdentical2: function() {
-				// <b style="color: red; width: 10px">a</b>
+			// <b style="color: red; width: 10px">a</b>
 			var element1 = doc.getById( 'isIdentical2' ).getFirst(),
-				// <b style="width:10px;color:red;">a</b>
+			// <b style="width:10px;color:red;">a</b>
 				element2 = element1.getNext(),
 				element3 = new CKEDITOR.dom.element( 'b' ),
 				element4 = new CKEDITOR.dom.element( 'b' );
@@ -1171,6 +1171,13 @@ bender.test( appendDomObjectTests(
 			elem.setSize( 'width', 200, true );
 
 			assert.areSame( expectedWidth, round( parseFloat( elem.$.style.width ) ), 'Computed width' );
+		},
+
+		// https://dev.ckeditor.com/ticket/17009
+		'test mergeSiblings nested tags': function() {
+			var element = CKEDITOR.dom.element.createFromHtml( '<p><strong><em>123456</em><em>abcd</em></strong><strong><em>789</em></strong></p>' );
+			element.getFirst().mergeSiblings();
+			assert.isInnerHtmlMatching( '<p><strong><em>123456abcd789</em></strong></p>', getOuterHtml( element ) );
 		}
 	}
 ) );

--- a/tests/core/editable/insertionpreserveid.html
+++ b/tests/core/editable/insertionpreserveid.html
@@ -1,0 +1,1 @@
+<div style="height:500px"></div>

--- a/tests/core/editable/insertionpreserveid.js
+++ b/tests/core/editable/insertionpreserveid.js
@@ -1,41 +1,40 @@
 /* bender-tags: editor,unit,insertion */
 
-(function() {
+( function() {
 	'use strict';
 
 	bender.editors = {
 		paragraph: {
-			name: "classic",
+			name: 'classic',
 			config: {
-				allowedContent: "span em u p[id](*){*}",
+				allowedContent: 'span em u p[id](*){*}',
 				enterMode: CKEDITOR.ENTER_P
 			}
 		},
 		divarea: {
-			name: "divarea",
+			name: 'divarea',
 			config: {
-				allowedContent: "span em u div[id](*){*}",
+				allowedContent: 'span em u div[id](*){*}',
 				enterMode: CKEDITOR.ENTER_DIV
 			}
 		}
 	};
 
-	bender.test({
+	bender.test( {
 		'test insert nothing into inline element with id': function() {
 			var editor = this.editors.paragraph,
 				bot = this.editorBots.paragraph;
-			bot.setHtmlWithSelection( '<p style="text-align: right;"><span class="marker" id="abc">te^st</span></p>' );
+			bot.setHtmlWithSelection( '<p style="text-align: right"><span class="marker" id="abc">te^st</span></p>' );
 			editor.insertText( '' );
-			debugger;
-			assert.isInnerHtmlMatching( '<p style="text-align: right;"><span class="marker" id="abc">test</span></p>', bot.getData() );
+			assert.isInnerHtmlMatching( '<p style="text-align: right"><span class="marker" id="abc">test</span></p>', bot.getData() );
 		},
 
 		'test insert text into multiple inline element with ids': function() {
 			var editor = this.editors.paragraph,
 				bot = this.editorBots.paragraph;
-			bot.setHtmlWithSelection( '<p style="text-align: right;"><span class="marker" id="abc"><em id="def"><u id="ghj">te^st</u></em></span></p>' );
+			bot.setHtmlWithSelection( '<p style="text-align: right"><span class="marker" id="abc"><em id="def"><u id="ghj">te^st</u></em></span></p>' );
 			editor.insertText( 'foo' );
-			assert.isInnerHtmlMatching( '<p style="text-align: right;"><span class="marker" id="abc"><em id="def"><u id="ghj">tefoost</u></em></span></p>', bot.getData() );
+			assert.isInnerHtmlMatching( '<p style="text-align: right"><span class="marker" id="abc"><em id="def"><u id="ghj">tefoost</u></em></span></p>', bot.getData() );
 		},
 
 		'test insert multiline text into element with id': function() {
@@ -44,9 +43,9 @@
 			bot.setHtmlWithSelection( '<p><span class="marker" id="abc">te^st</span></p>' );
 			// insertText has 'feature' when double \n treat as separate paragraphs text.
 			editor.insertText( 'foo\n\nbar' );
-			assert.isInnerHtmlMatching( '<p><span class="marker" id="abc">te</span></p>'+
-							'<p><span class="marker">foo</span></p>'+
-							'<p><span class="marker">bar</span></p>'+
+			assert.isInnerHtmlMatching( '<p><span class="marker" id="abc">te</span></p>' +
+							'<p><span class="marker">foo</span></p>' +
+							'<p><span class="marker">bar</span></p>' +
 							'<p><span class="marker">st</span></p>', bot.getData() );
 		},
 
@@ -61,9 +60,9 @@
 		'test insert nothing into inline element with id div mode': function() {
 			var editor = this.editors.divarea,
 				bot = this.editorBots.divarea;
-			bot.setHtmlWithSelection( '<div style="text-align: right;"><span class="marker" id="abc"><em>te^st</em></span></div>' );
+			bot.setHtmlWithSelection( '<div style="text-align: right"><span class="marker" id="abc"><em>te^st</em></span></div>' );
 			editor.insertText( '' );
-			assert.isInnerHtmlMatching( '<div style="text-align: right;"><span class="marker" id="abc"><em>test</em></span></div>', bot.getData() );
+			assert.isInnerHtmlMatching( '<div style="text-align: right"><span class="marker" id="abc"><em>test</em></span></div>', bot.getData() );
 		}
-	});
-}());
+	} );
+} )();

--- a/tests/core/editable/insertionpreserveid.js
+++ b/tests/core/editable/insertionpreserveid.js
@@ -1,0 +1,78 @@
+/* bender-tags: editor,unit,insertion */
+
+(function() {
+	'use strict';
+
+	bender.editors = {
+		paragraph: {
+			name: "classic",
+			config: {
+				allowedContent: "span p[id](*){*}",
+				enterMode: CKEDITOR.ENTER_P
+			}
+		},
+		divarea: {
+			name: "divarea",
+			config: {
+				allowedContent: "span div[id](*){*}",
+				enterMode: CKEDITOR.ENTER_DIV
+			}
+		}
+	};
+
+	bender.test({
+		'test insert inline text into inline element with id': function() {
+			var editor = this.editors.paragraph,
+				bot = this.editorBots.paragraph;
+
+			bot.setHtmlWithSelection( '<p><span class="marker" id="abc">te^st</span></p>' );
+			editor.insertText( '789' );
+			assert.areSame( '<p><span class="marker" id="abc">te789st</span></p>', bot.getData() );
+
+		},
+
+		'test insert nothing into inline element with id': function() {
+			var editor = this.editors.paragraph,
+				bot = this.editorBots.paragraph;
+
+			bot.setHtmlWithSelection( '<p style="text-align:right"><span class="marker" id="abc">te^st</span></p>' );
+			editor.insertText( '' );
+			assert.areSame( '<p style="text-align:right"><span class="marker" id="abc">test</span></p>', bot.getData() );
+
+
+		},
+
+		'test insert text into multiple inline element with ids': function() {
+			var editor = this.editors.paragraph,
+				bot = this.editorBots.paragraph;
+
+			bot.setHtmlWithSelection( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">te^st</span></span></span></p>' );
+			editor.insertText( 'stte' );
+			assert.areSame( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">testtest</span></span></span></p>', bot.getData() );
+
+
+		},
+
+		'test insert text into inline element with id div mode': function() {
+			var editor = this.editors.divarea,
+				bot = this.editorBots.divarea;
+
+			bot.setHtmlWithSelection( '<div><span class="marker" id="abc">te^st</span></div>' );
+			editor.insertText( '789' );
+			assert.areSame( '<div><span class="marker" id="abc">te789st</span></div>', bot.getData() );
+		},
+
+		'test insert nothing into inline element with id div mode': function() {
+			var editor = this.editors.divarea,
+				bot = this.editorBots.divarea;
+
+			bot.setHtmlWithSelection( '<div style="text-align:right"><span class="marker" id="abc">te^st</span></div>' );
+			editor.insertText( '' );
+			assert.areSame( '<div style="text-align:right"><span class="marker" id="abc">test</span></div>', bot.getData() );
+		}
+
+
+	});
+
+
+}());

--- a/tests/core/editable/insertionpreserveid.js
+++ b/tests/core/editable/insertionpreserveid.js
@@ -21,15 +21,6 @@
 	};
 
 	bender.test({
-		'test insert inline text into inline element with id': function() {
-			var editor = this.editors.paragraph,
-				bot = this.editorBots.paragraph;
-
-			bot.setHtmlWithSelection( '<p><span class="marker" id="abc">te^st</span></p>' );
-			editor.insertText( '789' );
-			assert.areSame( '<p><span class="marker" id="abc">te789st</span></p>', bot.getData() );
-
-		},
 
 		'test insert nothing into inline element with id': function() {
 			var editor = this.editors.paragraph,
@@ -47,8 +38,8 @@
 				bot = this.editorBots.paragraph;
 
 			bot.setHtmlWithSelection( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">te^st</span></span></span></p>' );
-			editor.insertText( 'stte' );
-			assert.areSame( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">testtest</span></span></span></p>', bot.getData() );
+			editor.insertText( 'foo' );
+			assert.areSame( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">tefoost</span></span></span></p>', bot.getData() );
 
 
 		},

--- a/tests/core/editable/insertionpreserveid.js
+++ b/tests/core/editable/insertionpreserveid.js
@@ -7,63 +7,62 @@
 		paragraph: {
 			name: "classic",
 			config: {
-				allowedContent: "span p[id](*){*}",
+				allowedContent: "span em u p[id](*){*}",
 				enterMode: CKEDITOR.ENTER_P
 			}
 		},
 		divarea: {
 			name: "divarea",
 			config: {
-				allowedContent: "span div[id](*){*}",
+				allowedContent: "span em u div[id](*){*}",
 				enterMode: CKEDITOR.ENTER_DIV
 			}
 		}
 	};
 
 	bender.test({
-
 		'test insert nothing into inline element with id': function() {
 			var editor = this.editors.paragraph,
 				bot = this.editorBots.paragraph;
-
-			bot.setHtmlWithSelection( '<p style="text-align:right"><span class="marker" id="abc">te^st</span></p>' );
+			bot.setHtmlWithSelection( '<p style="text-align: right"><span class="marker" id="abc">te^st</span></p>' );
 			editor.insertText( '' );
-			assert.areSame( '<p style="text-align:right"><span class="marker" id="abc">test</span></p>', bot.getData() );
-
-
+			assert.areSame( '<p style="text-align: right"><span class="marker" id="abc">test</span></p>', bot.getData() );
 		},
 
 		'test insert text into multiple inline element with ids': function() {
 			var editor = this.editors.paragraph,
 				bot = this.editorBots.paragraph;
-
-			bot.setHtmlWithSelection( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">te^st</span></span></span></p>' );
+			bot.setHtmlWithSelection( '<p style="text-align: right"><span class="marker" id="abc"><em id="def"><u id="ghj">te^st</u></em></span></p>' );
 			editor.insertText( 'foo' );
-			assert.areSame( '<p style="text-align:right"><span class="marker" id="abc"><span id="def"><span id="ghj">tefoost</span></span></span></p>', bot.getData() );
+			assert.areSame( '<p style="text-align: right"><span class="marker" id="abc"><em id="def"><u id="ghj">tefoost</u></em></span></p>', bot.getData() );
+		},
 
-
+		'test insert multiline text into element with id': function() {
+			var editor = this.editors.paragraph,
+				bot = this.editorBots.paragraph;
+			bot.setHtmlWithSelection( '<p><span class="marker" id="abc">te^st</span></p>' );
+			// insertText has 'feature' when double \n treat as separate paragraphs text.
+			editor.insertText( 'foo\n\nbar' );
+			assert.areSame( '<p><span class="marker" id="abc">te</span></p>'+
+							'<p><span class="marker">foo</span></p>'+
+							'<p><span class="marker">bar</span></p>'+
+							'<p><span class="marker">st</span></p>', bot.getData() );
 		},
 
 		'test insert text into inline element with id div mode': function() {
 			var editor = this.editors.divarea,
 				bot = this.editorBots.divarea;
-
-			bot.setHtmlWithSelection( '<div><span class="marker" id="abc">te^st</span></div>' );
+			bot.setHtmlWithSelection( '<div><span class="marker" id="abc"><em id="xyz">te^st</em></span></div>' );
 			editor.insertText( '789' );
-			assert.areSame( '<div><span class="marker" id="abc">te789st</span></div>', bot.getData() );
+			assert.areSame( '<div><span class="marker" id="abc"><em id="xyz">te789st</em></span></div>', bot.getData() );
 		},
 
 		'test insert nothing into inline element with id div mode': function() {
 			var editor = this.editors.divarea,
 				bot = this.editorBots.divarea;
-
-			bot.setHtmlWithSelection( '<div style="text-align:right"><span class="marker" id="abc">te^st</span></div>' );
+			bot.setHtmlWithSelection( '<div style="text-align: right"><span class="marker" id="abc"><em>te^st</em></span></div>' );
 			editor.insertText( '' );
-			assert.areSame( '<div style="text-align:right"><span class="marker" id="abc">test</span></div>', bot.getData() );
+			assert.areSame( '<div style="text-align: right"><span class="marker" id="abc"><em>test</em></span></div>', bot.getData() );
 		}
-
-
 	});
-
-
 }());

--- a/tests/core/editable/insertionpreserveid.js
+++ b/tests/core/editable/insertionpreserveid.js
@@ -24,17 +24,18 @@
 		'test insert nothing into inline element with id': function() {
 			var editor = this.editors.paragraph,
 				bot = this.editorBots.paragraph;
-			bot.setHtmlWithSelection( '<p style="text-align: right"><span class="marker" id="abc">te^st</span></p>' );
+			bot.setHtmlWithSelection( '<p style="text-align: right;"><span class="marker" id="abc">te^st</span></p>' );
 			editor.insertText( '' );
-			assert.areSame( '<p style="text-align: right"><span class="marker" id="abc">test</span></p>', bot.getData() );
+			debugger;
+			assert.isInnerHtmlMatching( '<p style="text-align: right;"><span class="marker" id="abc">test</span></p>', bot.getData() );
 		},
 
 		'test insert text into multiple inline element with ids': function() {
 			var editor = this.editors.paragraph,
 				bot = this.editorBots.paragraph;
-			bot.setHtmlWithSelection( '<p style="text-align: right"><span class="marker" id="abc"><em id="def"><u id="ghj">te^st</u></em></span></p>' );
+			bot.setHtmlWithSelection( '<p style="text-align: right;"><span class="marker" id="abc"><em id="def"><u id="ghj">te^st</u></em></span></p>' );
 			editor.insertText( 'foo' );
-			assert.areSame( '<p style="text-align: right"><span class="marker" id="abc"><em id="def"><u id="ghj">tefoost</u></em></span></p>', bot.getData() );
+			assert.isInnerHtmlMatching( '<p style="text-align: right;"><span class="marker" id="abc"><em id="def"><u id="ghj">tefoost</u></em></span></p>', bot.getData() );
 		},
 
 		'test insert multiline text into element with id': function() {
@@ -43,7 +44,7 @@
 			bot.setHtmlWithSelection( '<p><span class="marker" id="abc">te^st</span></p>' );
 			// insertText has 'feature' when double \n treat as separate paragraphs text.
 			editor.insertText( 'foo\n\nbar' );
-			assert.areSame( '<p><span class="marker" id="abc">te</span></p>'+
+			assert.isInnerHtmlMatching( '<p><span class="marker" id="abc">te</span></p>'+
 							'<p><span class="marker">foo</span></p>'+
 							'<p><span class="marker">bar</span></p>'+
 							'<p><span class="marker">st</span></p>', bot.getData() );
@@ -54,15 +55,15 @@
 				bot = this.editorBots.divarea;
 			bot.setHtmlWithSelection( '<div><span class="marker" id="abc"><em id="xyz">te^st</em></span></div>' );
 			editor.insertText( '789' );
-			assert.areSame( '<div><span class="marker" id="abc"><em id="xyz">te789st</em></span></div>', bot.getData() );
+			assert.isInnerHtmlMatching( '<div><span class="marker" id="abc"><em id="xyz">te789st</em></span></div>', bot.getData() );
 		},
 
 		'test insert nothing into inline element with id div mode': function() {
 			var editor = this.editors.divarea,
 				bot = this.editorBots.divarea;
-			bot.setHtmlWithSelection( '<div style="text-align: right"><span class="marker" id="abc"><em>te^st</em></span></div>' );
+			bot.setHtmlWithSelection( '<div style="text-align: right;"><span class="marker" id="abc"><em>te^st</em></span></div>' );
 			editor.insertText( '' );
-			assert.areSame( '<div style="text-align: right"><span class="marker" id="abc"><em>test</em></span></div>', bot.getData() );
+			assert.isInnerHtmlMatching( '<div style="text-align: right;"><span class="marker" id="abc"><em>test</em></span></div>', bot.getData() );
 		}
 	});
 }());

--- a/tests/core/editable/manual/insertionkeepid.html
+++ b/tests/core/editable/manual/insertionkeepid.html
@@ -1,10 +1,10 @@
 <textarea id="classic">
-	<p style="text-align: justify">
+	<p>
 		<span id="SomeId1">Foo</span>
 	</p>
 </textarea>
 <div id="divarea" >
-	<div style="text-align: justify">
+	<div>
 		<span id="SomeId2">Foo</span>
 	</div>
 </div>
@@ -12,12 +12,12 @@
 <script>
 	( function() {
 		CKEDITOR.replace( 'classic', {
-			allowedContent: 'p span[id](*){*}'
-		});
+			allowedContent: 'span[id]'
+		} );
 		CKEDITOR.replace( 'divarea', {
-			allowedContent: 'div span[id](*){*}',
+			allowedContent: 'span[id]',
 			extraPlugins: 'divarea',
 			enterMode: CKEDITOR.ENTER_DIV
-		});
-	}() )
+		} );
+	} )();
 </script>

--- a/tests/core/editable/manual/insertionkeepid.html
+++ b/tests/core/editable/manual/insertionkeepid.html
@@ -1,0 +1,23 @@
+<textarea id="classic">
+	<p style="text-align: justify">
+		<span id="SomeId1">Foo</span>
+	</p>
+</textarea>
+<div id="divarea" >
+	<div style="text-align: justify">
+		<span id="SomeId2">Foo</span>
+	</div>
+</div>
+
+<script>
+	( function() {
+		CKEDITOR.replace( 'classic', {
+			allowedContent: 'p span[id](*){*}'
+		});
+		CKEDITOR.replace( 'divarea', {
+			allowedContent: 'div span[id](*){*}',
+			extraPlugins: 'divarea',
+			enterMode: CKEDITOR.ENTER_DIV
+		});
+	}() )
+</script>

--- a/tests/core/editable/manual/insertionkeepid.md
+++ b/tests/core/editable/manual/insertionkeepid.md
@@ -1,15 +1,17 @@
-@bender-tags: 4.7.1, tc, 17009
+@bender-tags: 4.7.2, bug, trac17009
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, divarea, toolbar, sourcearea, undo, elementspath, justify, specialchar
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, undo, specialchar
 
 ----
 
-### Insert text.
-1. Open `Source` in editor. Make sure there is `span` with `id` attribute.
-1. Put carret in editor.
-1. Insert text, by usinng `Insert Special Character` button.
-1. Check `Source` again
-1. There should remain one `spane` element with `id`
-1. Repeat steps in 2nd editor
+Note: Perform below steps on both editors.
 
-**Unexpected:** As result you will obtain splited text into 2 span elements.
+### Insert text.
+1. Switch to `Source mode` and make sure there is a `span` with `id` attribute.
+1. Switch back to `WYSIWYG mode` and put caret inside `Foo` word.
+1. Insert character usinng `Insert Special Character` button.
+1. Check `Source mode` again.
+
+**Expected:** There should remain one `span` element with `id`.
+
+**Unexpected:** After specal character insertion `span` element was splited into two: e.g. `<span id="SomeId2">Fo#</span><span>o</span>`.

--- a/tests/core/editable/manual/insertionkeepid.md
+++ b/tests/core/editable/manual/insertionkeepid.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.7.1, tc, 17009
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, divarea, toolbar, sourcearea, undo, elementspath, justify, specialchar
+
+----
+
+### Insert text.
+1. Open `Source` in editor. Make sure there is `span` with `id` attribute.
+1. Put carret in editor.
+1. Insert text, by usinng `Insert Special Character` button.
+1. Check `Source` again
+1. There should remain one `spane` element with `id`
+1. Repeat steps in 2nd editor
+
+**Unexpected:** As result you will obtain splited text into 2 span elements.


### PR DESCRIPTION
## What is the purpose of this pull request?
Bug fix

## Does your PR contain necessary tests?
yes

### This PR contains
- [x] Unit tests
- [x] Manual tests

## What changes did you make?
- Change in method `mergeSibling` to always combine elements with higher index to element with lower index.
- Create mechanism to preserve `id`:
-- firstly `id` with reference to element is kept in array
-- because merging siblings was change, I have guarantee that reference to element will remain for entire process
-- then `id` is removed from elements
-- now process of `insert` is going as usual. If there will be possibility to merge inline element, this should happen
-- `id` is restored to elements. If there will be inserted non-inline elements, then `id` will apply to first element.

### Before change:
- `<p><span id="abc">te^st</span></p>` + `insertText('FOO');`
- `<p><span id="abc">te</span><span>FOOst</span></p>`

### After change:
- `<p><span id="abc">te^st</span></p>` + `insertText('FOO');`
- `<p><span id="abc">teFOOst</span></p>`

Closes #697.