### PR TITLE
Do not load plugins after editor was destroyed

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -595,10 +595,12 @@
 
 			// Load all plugin specific language files in a row.
 			CKEDITOR.scriptLoader.load( languageFiles, function() {
-				//Ensure the editor has not been destroyed in the mean time
-				if (editor.status === 'destroyed') {
+
+				// Ensure the editor had not been destroyed in the meantime (https://dev.ckeditor.com/ticket/14613).
+				if ( editor.status === 'destroyed' ) {
 					return;
 				}
+
 				// Initialize all plugins that have the "beforeInit" and "init" methods defined.
 				var methods = [ 'beforeInit', 'init', 'afterInit' ];
 				for ( var m = 0; m < methods.length; m++ ) {

--- a/core/editor.js
+++ b/core/editor.js
@@ -595,6 +595,10 @@
 
 			// Load all plugin specific language files in a row.
 			CKEDITOR.scriptLoader.load( languageFiles, function() {
+				//Ensure the editor has not been destroyed in the mean time
+				if (editor.status === 'destroyed') {
+					return;
+				}
 				// Initialize all plugins that have the "beforeInit" and "init" methods defined.
 				var methods = [ 'beforeInit', 'init', 'afterInit' ];
 				for ( var m = 0; m < methods.length; m++ ) {

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -124,6 +124,10 @@
 			doc = win.document,
 			body = doc.body;
 
+		//If the editor has been destroyed we should quit.
+		if (!editor) {
+			return;
+		}
 		// Remove helper scripts from the DOM.
 		var script = doc.getElementById( 'cke_actscrpt' );
 		script && script.parentNode.removeChild( script );

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -124,10 +124,11 @@
 			doc = win.document,
 			body = doc.body;
 
-		//If the editor has been destroyed we should quit.
-		if (!editor) {
+		// Check if editor had been destroyed (https://dev.ckeditor.com/ticket/14613).
+		if ( !editor ) {
 			return;
 		}
+
 		// Remove helper scripts from the DOM.
 		var script = doc.getElementById( 'cke_actscrpt' );
 		script && script.parentNode.removeChild( script );

--- a/tests/plugins/wysiwygarea/destroy.html
+++ b/tests/plugins/wysiwygarea/destroy.html
@@ -1,0 +1,1 @@
+<div id="destroyed"></div>

--- a/tests/plugins/wysiwygarea/destroy.js
+++ b/tests/plugins/wysiwygarea/destroy.js
@@ -1,0 +1,38 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: toolbar */
+
+( function() {
+	'use strict';
+
+	bender.test( {
+		'test destroy editor on instance created': function() {
+			var init = sinon.spy(),
+				editor;
+
+			CKEDITOR.plugins.add( 'test', {
+				init: init
+			} );
+
+			CKEDITOR.tools.setTimeout( function() {
+				resume( function() {
+					editor.destroy();
+
+					setTimeout( function() {
+						resume( function() {
+							assert.isFalse( init.called, 'plugin init called when editor already destroyed' );
+						} );
+					}, 100 );
+
+					wait();
+
+				} );
+			}, 0 );
+
+			editor = CKEDITOR.replace( 'destroyed', {
+				extraPlugins: 'test'
+			} );
+
+			wait();
+		}
+	} );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Closes https://dev.ckeditor.com/ticket/14613.