### PR TITLE
Styles definition always stores its classes in lexicographical order

### DIFF
--- a/core/style.js
+++ b/core/style.js
@@ -152,6 +152,10 @@ CKEDITOR.STYLE_OBJECT = 3;
 			delete attrs.style;
 		}
 
+		if ( attrs && attrs[ 'class' ] ) {
+			attrs[ 'class' ] = attrs[ 'class' ].split( ' ' ).sort().join( ' ' );
+		}
+
 		if ( variablesValues ) {
 			styleDefinition = CKEDITOR.tools.clone( styleDefinition );
 

--- a/tests/core/filter/check.js
+++ b/tests/core/filter/check.js
@@ -108,6 +108,7 @@
 
 			test( true, st( { element: 'p', attributes: { 'class': 'cl1' } } ) );
 			test( true, st( { element: 'a', attributes: { 'class': 'cl1 cl2' } } ) );
+			test( true, st( { element: 'a', attributes: { 'class': 'cl2 cl1' } } ) );
 			test( true, st( { element: 'p' } ) );
 
 			test( false, st( { element: 'p', styles: { height: '10px' } } ) );

--- a/tests/core/style/editor.js
+++ b/tests/core/style/editor.js
@@ -294,6 +294,22 @@ bender.test( {
 		} );
 	},
 
+	'test editor#removeStyle with multiple classes': function() {
+		bender.editorBot.create( {
+				name: 'editor_multiple_classes',
+				config: {
+					stylesSet: [
+						{ name: 'Marker', element: 'span', attributes: { 'class': 'b-test a-test' } }
+					]
+				}
+			},
+			function( bot ) {
+				bot.setHtmlWithSelection( '<p><span class="a-test b-test">[foobar]</span></p>' );
+				bot.editor.removeStyle( new CKEDITOR.style( { element: 'span', attributes: { 'class': 'b-test a-test' } } ) );
+				assert.areEqual( '<p>foobar</p>', bot.editor.getData(), 'Invalid editor#getData() result for style with multiple classes' );
+			} );
+	},
+
 	'test editor#removeStyle, editor#applyStyle not changing styles _.enterMode value': function() {
 		// We need to make sure that editor#removeStyle() will not revert original
 		// enterMode value after it has done its job.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

Closes #727.