### PR TITLE
Fix dependency between toolbar and clipboard

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -116,7 +116,7 @@
 ( function() {
 	// Register the plugin.
 	CKEDITOR.plugins.add( 'clipboard', {
-		requires: 'notification,toolbar',
+		requires: 'notification',
 		// jscs:disable maximumLineLength
 		lang: 'af,ar,az,bg,bn,bs,ca,cs,cy,da,de,de-ch,el,en,en-au,en-ca,en-gb,eo,es,es-mx,et,eu,fa,fi,fo,fr,fr-ca,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,km,ko,ku,lt,lv,mk,mn,ms,nb,nl,no,oc,pl,pt,pt-br,ro,ru,si,sk,sl,sq,sr,sr-latn,sv,th,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
@@ -1306,8 +1306,13 @@
 			// -------------- DRAGOVER TOP & BOTTOM --------------
 
 			// Not allowing dragging on toolbar and bottom (http://dev.ckeditor.com/ticket/12613).
-			clipboard.preventDefaultDropOnElement( top );
-			clipboard.preventDefaultDropOnElement( bottom );
+			// Remove dependacy on toolbar (#654).
+			if ( top ) {
+				clipboard.preventDefaultDropOnElement( top );
+			}
+			if ( bottom ) {
+				clipboard.preventDefaultDropOnElement( bottom );
+			}
 
 			// -------------- DRAGSTART --------------
 			// Listed on dragstart to mark internal and cross-editor drag & drop

--- a/tests/plugins/autoembed/autoembed.js
+++ b/tests/plugins/autoembed/autoembed.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: embed,autoembed,enterkey,undo,link */
+/* bender-ckeditor-plugins: embed,autoembed,enterkey,undo,link,toolbar */
 /* bender-include: ../embedbase/_helpers/tools.js, ../clipboard/_helpers/pasting.js, ../widget/_helpers/tools.js */
 
 /* global embedTools, assertPasteEvent, widgetTestsTools */

--- a/tests/plugins/autoembed/autoembednotifications.js
+++ b/tests/plugins/autoembed/autoembednotifications.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,13421 */
-/* bender-ckeditor-plugins: embed,autoembed,enterkey,undo,link */
+/* bender-ckeditor-plugins: embed,autoembed,enterkey,undo,link,toolbar */
 /* bender-include: ../embedbase/_helpers/tools.js */
 
 /* global embedTools */

--- a/tests/plugins/autoembed/getwidgetdefinition.js
+++ b/tests/plugins/autoembed/getwidgetdefinition.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autoembed,embed,embedsemantic,link */
+/* bender-ckeditor-plugins: autoembed,embed,embedsemantic,link,toolbar */
 /* bender-include: ../embedbase/_helpers/tools.js */
 
 /* global embedTools */

--- a/tests/plugins/clipboard/clipboard.js
+++ b/tests/plugins/clipboard/clipboard.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,clipboard */
-/* bender-ckeditor-plugins: toolbar,clipboard */
+/* bender-ckeditor-plugins: clipboard */
 
 'use strict';
 

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,clipboard,13690 */
-/* bender-ckeditor-plugins: toolbar,clipboard */
+/* bender-ckeditor-plugins: clipboard */
 /* bender-include: _helpers/pasting.js */
 
 'use strict';

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -1,5 +1,5 @@
 /* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453 */
-/* bender-ckeditor-plugins: toolbar,clipboard,undo */
+/* bender-ckeditor-plugins: clipboard,undo */
 /* bender-include: _helpers/pasting.js */
 
 'use strict';

--- a/tests/plugins/clipboard/manual/removedependancyontoolbar.html
+++ b/tests/plugins/clipboard/manual/removedependancyontoolbar.html
@@ -1,0 +1,9 @@
+<textarea name="" id="editor" cols="30" rows="10">
+	<p>Hello World</p>
+	<p>Some text</p>
+	<p>Foo Bar Baz</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/clipboard/manual/removedependancyontoolbar.md
+++ b/tests/plugins/clipboard/manual/removedependancyontoolbar.md
@@ -1,0 +1,12 @@
+@bender-tags: bug, 4.7.2, 654
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, clipboard
+
+----
+1. Select some text.
+1. *Copy* and *Paste* it via keyboard shortcuts `Ctrl`/`Cmd`+`C` & `Ctrl`/`Cmd`+`V`.
+1. *Cut* and *Paste* it via keyboard shortcuts `Ctrl`/`Cmd`+`X` & `Ctrl`/`Cmd`+`V`.
+
+**Expected:** Copy/Cut and Paste work fine. There is no toolbar in editor
+
+**Unexpected:** Toolbar is visible.

--- a/tests/plugins/clipboard/notoolbardependancy.js
+++ b/tests/plugins/clipboard/notoolbardependancy.js
@@ -1,0 +1,17 @@
+/* bender-ckeditor-plugins: clipboard */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	bender.test( {
+		'test if toolbar plugins is not loaded when clipboard is available': function() {
+			var editor = this.editor;
+
+			assert.isNotUndefined( editor.plugins.clipboard );
+			assert.isUndefined( editor.plugins.toolbar );
+			assert.isNull( editor.ui.space( 'top' ) );
+		}
+	} );
+} )();

--- a/tests/plugins/clipboard/paste.js
+++ b/tests/plugins/clipboard/paste.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: toolbar,wysiwygarea,entities,clipboard,pastetext */
+/* bender-ckeditor-plugins: wysiwygarea,entities,clipboard,pastetext */
 /* bender-include: _helpers/pasting.js */
 /* global assertPasteEvent, simulatePasteCommand */
 

--- a/tests/plugins/clipboard/pastecommands.js
+++ b/tests/plugins/clipboard/pastecommands.js
@@ -1,5 +1,5 @@
-/* bender-tags: editor,clipboard */
-/* bender-ckeditor-plugins: link,clipboard,pastetext,pastefromword */
+/* bender-tags: editor,unit,clipboard */
+/* bender-ckeditor-plugins: link,clipboard,pastetext,pastefromword,toolbar*/
 /* bender-include: _helpers/pasting.js */
 /* global createFixtures, getDefaultNotification, assertPasteCommand, assertPasteNotification, testResetScenario */
 
@@ -59,7 +59,6 @@
 				bot.setData( '', function() {
 					var pasteData = fixtures.get( 'pasteData' ),
 						expected = fixtures.get( 'expectedHtml' );
-
 					assertPasteCommand( editor, expected, null, pasteData );
 				} );
 			},

--- a/tests/plugins/clipboard/pastefilter.js
+++ b/tests/plugins/clipboard/pastefilter.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: toolbar,clipboard,pastetext */
+/* bender-ckeditor-plugins: clipboard,pastetext */
 /* bender-include: _helpers/pasting.js */
 /* global assertPasteEvent */
 

--- a/tests/plugins/clipboard/readonly.js
+++ b/tests/plugins/clipboard/readonly.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor, clipboard, 13872 */
-/* bender-ckeditor-plugins: toolbar, clipboard */
+/* bender-ckeditor-plugins: clipboard */
 
 'use strict';
 

--- a/tests/plugins/tableselection/integrations/clipboard/pasteflow.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pasteflow.js
@@ -1,5 +1,5 @@
 /* bender-tags: tableselection, clipboard */
-/* bender-ckeditor-plugins: undo,tableselection */
+/* bender-ckeditor-plugins: undo,tableselection,toolbar */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */
 

--- a/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastemerge.js
@@ -1,5 +1,5 @@
 /* bender-tags: tableselection, clipboard */
-/* bender-ckeditor-plugins: undo,tableselection */
+/* bender-ckeditor-plugins: undo,tableselection,toolbar */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers, createPasteTestCase */
 

--- a/tests/plugins/tableselection/integrations/clipboard/pastenested.js
+++ b/tests/plugins/tableselection/integrations/clipboard/pastenested.js
@@ -1,5 +1,5 @@
 /* bender-tags: tableselection, clipboard */
-/* bender-ckeditor-plugins: undo,tableselection */
+/* bender-ckeditor-plugins: undo,tableselection,toolbar */
 /* bender-ckeditor-remove-plugins: dialogadvtab */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers, createPasteTestCase */

--- a/tests/plugins/tableselection/integrations/image2/paste.js
+++ b/tests/plugins/tableselection/integrations/image2/paste.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit,widget */
-/* bender-ckeditor-plugins: image2,undo,tableselection */
+/* bender-ckeditor-plugins: image2,undo,tableselection,toolbar */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */
 

--- a/tests/plugins/tableselection/integrations/link/link.js
+++ b/tests/plugins/tableselection/integrations/link/link.js
@@ -1,5 +1,5 @@
 /* bender-tags: tableselection, link */
-/* bender-ckeditor-plugins: link,tableselection */
+/* bender-ckeditor-plugins: link,tableselection,toolbar */
 /* bender-include: ../../_helpers/tableselection.js */
 /* global tableSelectionHelpers */
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

yes

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

* Remove dependancy on toolbar in clipboard plugin
* Improvement in Link and Table plugin to register proper ACF rules even when toolbar is not present. This is required to pass tests (tableselection, autoemebed).

Close #654 