### PR TITLE
Rich combos reflects whole selection

### DIFF
--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -163,75 +163,17 @@
 			},
 
 			onRender: function() {
-				editor.on( 'selectionChange', function( evt ) {
-					var combo = this,
-						ranges = evt.data.selection.getRanges(),
-						elementPath = evt.data.path,
-						forEach = CKEDITOR.tools.array.forEach,
-						markers = {},
-						previous = {};
+				var combo = this;
 
-					function processNode( node ) {
-						var path = new CKEDITOR.dom.elementPath( node );
+				CKEDITOR.plugins.richcombo.createSelectionListener( editor, combo, function( node, getNewValue ) {
+					var value;
 
-						function getNewValue( value, node ) {
-							if ( previous.node && node.contains( previous.node ) ) {
-								return previous.value;
-							}
-
-							if ( !previous.value || previous.value === value ) {
-								previous = {
-									value: value,
-									node: node
-								};
-
-								return value;
-							}
-
-							return '';
+					for ( value in styles ) {
+						if ( styles[ value ].checkElementMatch( node, true, editor ) ) {
+							combo.setValue( getNewValue( value, node ) );
 						}
-
-						function checkStyles( node ) {
-							if ( node.getCustomData( 'processed_font' ) ) {
-								return;
-							}
-
-							CKEDITOR.dom.element.setMarker( markers, node, 'processed_font', true );
-							for ( var value in styles ) {
-								if ( styles[ value ].checkElementMatch( node, true, editor ) ) {
-									combo.setValue( getNewValue( value, node ) );
-								}
-							}
-						}
-
-						// Check if the element is removable by any of
-						// the styles.
-						forEach( path.elements, checkStyles );
 					}
-
-					forEach( ranges, function( range ) {
-						var element,
-							walker;
-
-						if ( range.collapsed ) {
-							processNode( elementPath.lastElement );
-						} else {
-							walker = new CKEDITOR.dom.walker( range );
-
-							walker.evaluator = function( node ) {
-								return node.type === CKEDITOR.NODE_TEXT;
-							};
-
-							walker.reset();
-
-							while ( element = walker.next() ) {
-								processNode( element );
-							}
-						}
-					} );
-
-					CKEDITOR.dom.element.clearAllMarkers( markers );
-				}, this );
+				} );
 			},
 
 			refresh: function() {

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -76,81 +76,21 @@ CKEDITOR.plugins.add( 'format', {
 			},
 
 			onRender: function() {
-				editor.on( 'selectionChange', function( evt ) {
-					var combo = this,
-						ranges = evt.data.selection.getRanges(),
-						elementPath = evt.data.path,
-						forEach = CKEDITOR.tools.array.forEach,
-						markers = {},
-						previous = {};
+				var combo = this;
 
-					this.refresh();
+				CKEDITOR.plugins.richcombo.createSelectionListener( editor, combo, function( node, getNewValue ) {
+					var path = new CKEDITOR.dom.elementPath( node ),
+						value,
+						newValue;
 
-					function processNode( node ) {
-						var path = new CKEDITOR.dom.elementPath( node );
+					for ( value in styles ) {
+						if ( styles[ value ].checkActive( path, editor ) ) {
+							newValue = getNewValue( value, node );
 
-						function getNewValue( value, node ) {
-							if ( previous.node && node.contains( previous.node ) ) {
-								return previous.value;
-							}
-
-							if ( !previous.value || previous.value === value ) {
-								previous = {
-									value: value,
-									node: node
-								};
-
-								return value;
-							}
-
-							return '';
+							combo.setValue( newValue, editor.lang.format[ 'tag_' + newValue ] );
 						}
-
-						function checkStyles( node ) {
-							var newValue;
-
-							if ( node.getCustomData( 'processed_font' ) ) {
-								return;
-							}
-
-							CKEDITOR.dom.element.setMarker( markers, node, 'processed_font', true );
-							for ( var value in styles ) {
-								if ( styles[ value ].checkActive( path, editor ) ) {
-									newValue = getNewValue( value, node );
-
-									combo.setValue( newValue, editor.lang.format[ 'tag_' + newValue ] );
-								}
-							}
-						}
-
-						// Check if the element is removable by any of
-						// the styles.
-						forEach( path.elements, checkStyles );
 					}
-
-					forEach( ranges, function( range ) {
-						var element,
-							walker;
-
-						if ( range.collapsed ) {
-							processNode( elementPath.lastElement );
-						} else {
-							walker = new CKEDITOR.dom.walker( range );
-
-							walker.evaluator = function( node ) {
-								return node.type === CKEDITOR.NODE_TEXT;
-							};
-
-							walker.reset();
-
-							while ( element = walker.next() ) {
-								processNode( element );
-							}
-						}
-					} );
-
-					CKEDITOR.dom.element.clearAllMarkers( markers );
-				}, this );
+				} );
 			},
 
 			onOpen: function() {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -114,7 +114,9 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * to this button.
 			 */
 			render: function( editor, output ) {
-				var env = CKEDITOR.env;
+				var env = CKEDITOR.env,
+					instance,
+					selLocked;
 
 				var id = 'cke_' + this.id;
 				var clickFn = CKEDITOR.tools.addFunction( function( el ) {
@@ -127,7 +129,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 				}, this );
 
 				var combo = this;
-				var instance = {
+				instance = {
 					id: id,
 					combo: this,
 					focus: function() {
@@ -209,7 +211,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 					instance.onfocus && instance.onfocus();
 				} );
 
-				var selLocked = 0;
+				selLocked = 0;
 
 				// For clean up
 				instance.keyDownFn = keyDownFn;

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -114,75 +114,17 @@
 				},
 
 				onRender: function() {
-					editor.on( 'selectionChange', function( evt ) {
-						var combo = this,
-							ranges = evt.data.selection.getRanges(),
-							elementPath = evt.data.path,
-							forEach = CKEDITOR.tools.array.forEach,
-							markers = {},
-							previous = {};
+					var combo = this;
 
-						function processNode( node ) {
-							var path = new CKEDITOR.dom.elementPath( node );
+					CKEDITOR.plugins.richcombo.createSelectionListener( editor, combo, function( node, getNewValue ) {
+						var value;
 
-							function getNewValue( value, node ) {
-								if ( previous.node && node.contains( previous.node ) ) {
-									return previous.value;
-								}
-
-								if ( !previous.value || previous.value === value ) {
-									previous = {
-										value: value,
-										node: node
-									};
-
-									return value;
-								}
-
-								return '';
+						for ( value in styles ) {
+							if ( styles[ value ].checkElementRemovable( node, true, editor ) ) {
+								combo.setValue( getNewValue( value, node ) );
 							}
-
-							function checkStyles( node ) {
-								if ( node.getCustomData( 'processed_font' ) ) {
-									return;
-								}
-
-								CKEDITOR.dom.element.setMarker( markers, node, 'processed_font', true );
-								for ( var value in styles ) {
-									if ( styles[ value ].checkElementRemovable( node, true, editor ) ) {
-										combo.setValue( getNewValue( value, node ) );
-									}
-								}
-							}
-
-							// Check if the element is removable by any of
-							// the styles.
-							forEach( path.elements, checkStyles );
 						}
-
-						forEach( ranges, function( range ) {
-							var element,
-								walker;
-
-							if ( range.collapsed ) {
-								processNode( elementPath.lastElement );
-							} else {
-								walker = new CKEDITOR.dom.walker( range );
-
-								walker.evaluator = function( node ) {
-									return node.type === CKEDITOR.NODE_TEXT;
-								};
-
-								walker.reset();
-
-								while ( element = walker.next() ) {
-									processNode( element );
-								}
-							}
-						} );
-
-						CKEDITOR.dom.element.clearAllMarkers( markers );
-					}, this );
+					} );
 				},
 
 				onOpen: function() {

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -114,28 +114,74 @@
 				},
 
 				onRender: function() {
-					editor.on( 'selectionChange', function( ev ) {
-						var currentValue = this.getValue(),
-							elementPath = ev.data.path,
-							elements = elementPath.elements;
+					editor.on( 'selectionChange', function( evt ) {
+						var combo = this,
+							ranges = evt.data.selection.getRanges(),
+							elementPath = evt.data.path,
+							forEach = CKEDITOR.tools.array.forEach,
+							markers = {},
+							previous = {};
 
-						// For each element into the elements path.
-						for ( var i = 0, count = elements.length, element; i < count; i++ ) {
-							element = elements[ i ];
+						function processNode( node ) {
+							var path = new CKEDITOR.dom.elementPath( node );
+
+							function getNewValue( value, node ) {
+								if ( previous.node && node.contains( previous.node ) ) {
+									return previous.value;
+								}
+
+								if ( !previous.value || previous.value === value ) {
+									previous = {
+										value: value,
+										node: node
+									};
+
+									return value;
+								}
+
+								return '';
+							}
+
+							function checkStyles( node ) {
+								if ( node.getCustomData( 'processed_font' ) ) {
+									return;
+								}
+
+								CKEDITOR.dom.element.setMarker( markers, node, 'processed_font', true );
+								for ( var value in styles ) {
+									if ( styles[ value ].checkElementRemovable( node, true, editor ) ) {
+										combo.setValue( getNewValue( value, node ) );
+									}
+								}
+							}
 
 							// Check if the element is removable by any of
 							// the styles.
-							for ( var value in styles ) {
-								if ( styles[ value ].checkElementRemovable( element, true, editor ) ) {
-									if ( value != currentValue )
-										this.setValue( value );
-									return;
-								}
-							}
+							forEach( path.elements, checkStyles );
 						}
 
-						// If no styles match, just empty it.
-						this.setValue( '' );
+						forEach( ranges, function( range ) {
+							var element,
+								walker;
+
+							if ( range.collapsed ) {
+								processNode( elementPath.lastElement );
+							} else {
+								walker = new CKEDITOR.dom.walker( range );
+
+								walker.evaluator = function( node ) {
+									return node.type === CKEDITOR.NODE_TEXT;
+								};
+
+								walker.reset();
+
+								while ( element = walker.next() ) {
+									processNode( element );
+								}
+							}
+						} );
+
+						CKEDITOR.dom.element.clearAllMarkers( markers );
 					}, this );
 				},
 

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -171,10 +171,18 @@
 		},
 
 		// #525
+		'test combo value for selection with same multiple font families': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + ffArial + '">f{oo</span><span style="' + ffArial + '">ba}r</span></p>' );
+			this.assertComboValue( editor, 'Font', 'Arial' );
+		},
+
+		// #525
 		'test combo value for selection with multiple font families': function() {
 			var editor = this.editor;
 
-			bender.tools.selection.setWithHtml( editor, '<p><span style="font-family: Georgia;">f{oo</span><span style="font-family: Arial;">ba}r</span></p>' );
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + ffArial + '">f{oo</span><span style="' + ffCS + '">ba}r</span></p>' );
 			this.assertComboValue( editor, 'Font', '' );
 		},
 

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -170,6 +170,74 @@
 				'<p>x<span style="font-size:12px"><em>foo</em></span><em><span style="font-size:24px">bar</span></em>x@</p>' );
 		},
 
+		// #525
+		'test combo value for selection with multiple font families': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="font-family: Georgia;">f{oo</span><span style="font-family: Arial;">ba}r</span></p>' );
+			this.assertComboValue( editor, 'Font', '' );
+		},
+
+		// #525
+		'test combo value for selection with nested font families (case #1)': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + ffArial + '">foo<span style="' + ffCS + '">b{}ar</span></span></p>' );
+			this.assertComboValue( editor, 'Font', 'Comic Sans MS' );
+		},
+
+		// #525
+		'test combo value for selection with nested font families (case #2)': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + ffArial + '">foo<span style="' + ffCS + '">b{a}r</span></span></p>' );
+			this.assertComboValue( editor, 'Font', 'Comic Sans MS' );
+		},
+
+		// #525
+		'test combo value for selection with nested font families (case #3)': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + ffArial + '">fo{o<span style="' + ffCS + '">ba}r</span></span></p>' );
+			this.assertComboValue( editor, 'Font', '' );
+		},
+
+		// #525
+		'test combo value after reselecting from the same beginning': function() {
+			var editor = this.editor,
+				spans,
+				range;
+
+			bender.tools.selection.setWithHtml( editor, '<p>x<span style="font-size: 12px;">f{o}o</span><span style="font-size: 24px;">bar</span></p>' );
+			this.assertComboValue( editor, 'FontSize', '12' );
+
+			spans = editor.editable().find( 'span' );
+			range = editor.getSelection().getRanges()[ 0 ];
+
+			range.setEnd( spans.getItem( 1 ).getChild( 0 ), 1 );
+			range.select();
+
+			this.assertComboValue( editor, 'FontSize', '' );
+		},
+
+		assertComboValue: function( editor, comboName, expectedValue ) {
+			var combo = editor.ui.get( comboName );
+
+			assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+		},
+
+		/*assertComboValue: function( editor, comboName, expectedValue, callback ) {
+			bot.combo( comboName, function( combo ) {
+				assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+
+				if ( callback ) {
+					//combo.onClick( expectedValue );
+
+					this.wait( callback, 0 );
+				}
+			} );
+		},*/
+
 		assertCombo: function( comboName, comboValue, collapsed, bot, resultHtml, callback ) {
 			bot.combo( comboName, function( combo ) {
 				combo.onClick( comboValue );

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -203,40 +203,29 @@
 		},
 
 		// #525
-		'test combo value after reselecting from the same beginning': function() {
-			var editor = this.editor,
-				spans,
-				range;
+		// Currently unfixable as richcombo is based on selectionChange event
+		// 'test combo value after reselecting from the same beginning': function() {
+		// 	var editor = this.editor,
+		// 		spans,
+		// 		range;
 
-			bender.tools.selection.setWithHtml( editor, '<p>x<span style="font-size: 12px;">f{o}o</span><span style="font-size: 24px;">bar</span></p>' );
-			this.assertComboValue( editor, 'FontSize', '12' );
+		// 	bender.tools.selection.setWithHtml( editor, '<p>x<span style="font-size: 12px;">f{o}o</span><span style="font-size: 24px;">bar</span></p>' );
+		// 	this.assertComboValue( editor, 'FontSize', '12' );
 
-			spans = editor.editable().find( 'span' );
-			range = editor.getSelection().getRanges()[ 0 ];
+		// 	spans = editor.editable().find( 'span' );
+		// 	range = editor.getSelection().getRanges()[ 0 ];
 
-			range.setEnd( spans.getItem( 1 ).getChild( 0 ), 1 );
-			range.select();
+		// 	range.setEnd( spans.getItem( 1 ).getChild( 0 ), 1 );
+		// 	range.select();
 
-			this.assertComboValue( editor, 'FontSize', '' );
-		},
+		// 	this.assertComboValue( editor, 'FontSize', '' );
+		// },
 
 		assertComboValue: function( editor, comboName, expectedValue ) {
 			var combo = editor.ui.get( comboName );
 
 			assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
 		},
-
-		/*assertComboValue: function( editor, comboName, expectedValue, callback ) {
-			bot.combo( comboName, function( combo ) {
-				assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
-
-				if ( callback ) {
-					//combo.onClick( expectedValue );
-
-					this.wait( callback, 0 );
-				}
-			} );
-		},*/
 
 		assertCombo: function( comboName, comboValue, collapsed, bot, resultHtml, callback ) {
 			bot.combo( comboName, function( combo ) {

--- a/tests/plugins/font/font.js
+++ b/tests/plugins/font/font.js
@@ -211,6 +211,14 @@
 		},
 
 		// #525
+		'test combo value for selection with no font family': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + ffArial + '">f{oo</span>ba}r</p>' );
+			this.assertComboValue( editor, 'Font', '' );
+		},
+
+		// #525
 		// Currently unfixable as richcombo is based on selectionChange event
 		// 'test combo value after reselecting from the same beginning': function() {
 		// 	var editor = this.editor,

--- a/tests/plugins/font/manual/combovalue.html
+++ b/tests/plugins/font/manual/combovalue.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p><span style="font-family: 'Comic Sans MS', cursive;"><span style="font-size: 20px;">test1</span></span></p>
+	<p><span style="font-family: Georgia,serif;"><span style="font-size: 24px;">test2</span></span></p>
+	<p><span style="font-family: 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;"><span style="font-size: 36px;">test3</span></span></p>
+	<p><span style="font-family: 'Comic Sans MS', cursive;">foo<span style="font-family: Arial, Helvetica, sans-serif;">bar</span></span></p>
+</div>
+<script>
+	CKEDITOR.replace( 'editor', { height: 400 } );
+</script>

--- a/tests/plugins/font/manual/combovalue.md
+++ b/tests/plugins/font/manual/combovalue.md
@@ -1,0 +1,27 @@
+@bender-tags: 4.7.2, 525, trac13553, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, font, elementspath
+
+## Case 1
+
+1. Select all content inside the editor.
+
+**Expected result:**
+
+Font style and size combos have default (not set value).
+
+**Unexpected result:**
+
+Font style and size combos have values matching styles from the first paragraph.
+
+## Case 2
+
+1. Select `a` in the last paragraph (`foob{a}r`).
+
+**Expected result:**
+
+Font style has value of "Arial".
+
+**Unexpected result:**
+
+Font style has value of "Comic Sans MS".

--- a/tests/plugins/format/manual/combovalue.html
+++ b/tests/plugins/format/manual/combovalue.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<h3>Heading 3</h3>
+	<address>Address</address>
+	<pre>Formatted</pre>
+	<div>Foo<address>bar</address></div>
+</div>
+<script>
+	CKEDITOR.replace( 'editor', { height: 400 } );
+</script>

--- a/tests/plugins/format/manual/combovalue.md
+++ b/tests/plugins/format/manual/combovalue.md
@@ -1,0 +1,27 @@
+@bender-tags: 4.7.2, 525, trac13553, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, format, elementspath
+
+## Case 1
+
+1. Select all content inside the editor.
+
+**Expected result:**
+
+Format combo has default (not set) value.
+
+**Unexpected result:**
+
+Format combo has value matching styles from the first paragraph.
+
+## Case 2
+
+1. Select `a` in the last paragraph (`foob{a}r`).
+
+**Expected result:**
+
+Format combo has value of "Address".
+
+**Unexpected result:**
+
+Format combo has value of "Formatted".

--- a/tests/plugins/format/plugin.js
+++ b/tests/plugins/format/plugin.js
@@ -3,6 +3,12 @@
 
 bender.editor = true;
 
+function assertComboValue( editor, comboName, expectedValue ) {
+	var combo = editor.ui.get( comboName );
+
+	assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+}
+
 bender.test( {
 	'test apply format style': function() {
 		var bot = this.editorBot, ed = this.editor;
@@ -25,5 +31,29 @@ bender.test( {
 		bot.setHtmlWithSelection( '<fieldset><legend>^foo</legend><form>bar</form></fieldset>' );
 		var name = 'Format', combo = ed.ui.get( name );
 		assert.areSame( CKEDITOR.TRISTATE_DISABLED, combo._.state, 'check state disabled when not in context' );
+	},
+
+	// #525
+	'test multiple same formatted blocks': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<h3>Hea{ding</h3><h3>Hea}ding</h3>' );
+		assertComboValue( editor, 'Format', 'h3' );
+	},
+
+	// #525
+	'test multiple different formatted blocks': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<h3>Hea{ding</h3><address>Addr}ess</address>' );
+		assertComboValue( editor, 'Format', '' );
+	},
+
+	// #525
+	'test nested formatted blocks': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<div>foo<address>b{a}r</address></div>' );
+		assertComboValue( editor, 'Format', 'address' );
 	}
 } );

--- a/tests/plugins/richcombo/createselectionlistener.js
+++ b/tests/plugins/richcombo/createselectionlistener.js
@@ -1,0 +1,30 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: richcombo,toolbar */
+
+bender.editor = true;
+
+bender.test( {
+	'test creating selection listener': function() {
+		var editor = this.editor,
+			spy = sinon.spy();
+
+		CKEDITOR.plugins.richcombo.createSelectionListener( editor, {}, spy );
+
+		editor.once( 'selectionChange', function( evt ) {
+			resume( function() {
+				var elements = evt.data.path.elements,
+					i;
+
+				assert.areSame( elements.length, spy.callCount, 'Spy was called for every node in path' );
+
+				for ( i = 0; i < elements.length; i++ ) {
+					assert.isTrue( elements[ i ].equals( spy.getCall( i ).args[ 0 ] ),
+						'Appropriate node was passed to spy call #' + i );
+				}
+			} );
+		}, null, null, 999 );
+
+		bender.tools.selection.setWithHtml( editor, '<p>T{es}t</p>' );
+		wait();
+	}
+} );

--- a/tests/plugins/stylescombo/combovalue.js
+++ b/tests/plugins/stylescombo/combovalue.js
@@ -1,0 +1,44 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: stylescombo,toolbar */
+
+bender.editor = true;
+
+function assertComboValue( editor, comboName, expectedValue ) {
+	var combo = editor.ui.get( comboName );
+
+	assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+}
+
+bender.test( {
+	// #525
+	'test multiple same styled blocks': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<h3 style="color:#aaaaaa; font-style:italic">Bl{ock</h3><h3 style="color:#aaaaaa; font-style:italic">Blo}ck</h3>' );
+		assertComboValue( editor, 'Styles', 'Subtitle' );
+	},
+
+	// #525
+	'test multiple different styled blocks': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<h3 style="color:#aaaaaa; font-style:italic">Bl{ock</h3><h2 style="font-style:italic">Blo}ck</h2>' );
+		assertComboValue( editor, 'Styles', '' );
+	},
+
+	// #525
+	'test nested inline style in block': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<h2 style="font-style:italic">foo<tt>b{a}r</tt></h2>' );
+		assertComboValue( editor, 'Styles', 'Typewriter' );
+	},
+
+	// #525
+	'test nested inline style in inline': function() {
+		var editor = this.editor;
+
+		bender.tools.selection.setWithHtml( editor, '<tt>foo<span class="marker">b{a}r</span></tt>' );
+		assertComboValue( editor, 'Styles', 'Marker' );
+	}
+} );

--- a/tests/plugins/stylescombo/manual/combovalue.html
+++ b/tests/plugins/stylescombo/manual/combovalue.html
@@ -1,0 +1,10 @@
+<div id="editor">
+	<div style="background: #eeeeee;border: 1px solid #cccccc;padding: 5px 10px;">Special container</div>
+	<h2 style="font-style: italic;">Italic title</h2>
+	<h3 style="color: #aaaaaa;font-style: italic;">Subtitle</h3>
+	<p><span class="marker">mar<tt>ked</tt></span></p>
+	<h2 style="font-style: italic;">Italic <span class="marker">marked</span></h2>
+</div>
+<script>
+	CKEDITOR.replace( 'editor', { height: 400 } );
+</script>

--- a/tests/plugins/stylescombo/manual/combovalue.md
+++ b/tests/plugins/stylescombo/manual/combovalue.md
@@ -1,0 +1,27 @@
+@bender-tags: 4.7.2, 525, trac13553, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, elementspath
+
+## Case 1
+
+1. Select all content inside the editor.
+
+**Expected result:**
+
+Styles combo has default (not set) value.
+
+**Unexpected result:**
+
+Styles combo has value matching styles from the first paragraph.
+
+## Case 2
+
+1. Select `e` in the last paragraph (`mark{e}d`).
+
+**Expected result:**
+
+Styles combo has value of "Marker".
+
+**Unexpected result:**
+
+Styles combo has value of "Italic Title".

--- a/tests/plugins/tableselection/integrations/font/font.html
+++ b/tests/plugins/tableselection/integrations/font/font.html
@@ -1,0 +1,21 @@
+<textarea id="same-size">
+	<table>
+		<tr>
+			<td>[<span style="font-size: 20px;">Cell</span>]</td>
+		</tr>
+		<tr>
+			<td>[<span style="font-size: 20px;">Cell</span>]</td>
+		</tr>
+	</table>
+</textarea>
+
+<textarea id="different-size">
+	<table>
+		<tr>
+			<td>[<span style="font-size: 12px;">Cell</span>]</td>
+		</tr>
+		<tr>
+			<td>[<span style="font-size: 20px;">Cell</span>]</td>
+		</tr>
+	</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/font/font.js
+++ b/tests/plugins/tableselection/integrations/font/font.js
@@ -1,0 +1,44 @@
+/* bender-tags: tableselection, font */
+/* bender-ckeditor-plugins: font, tableselection */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+		divarea: {
+			extraPlugins: 'divarea'
+		},
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	function assertComboValue( editor, comboName, expectedValue ) {
+		var combo = editor.ui.get( comboName );
+
+		assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+	}
+
+	var tests = {
+		'test same font size in multiple cells': function( editor, bot ) {
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'same-size' ).getValue() );
+
+			assertComboValue( editor, 'FontSize', '20' );
+		},
+
+		'test different font size in multiple cells': function( editor, bot ) {
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'different-size' ).getValue() );
+
+			assertComboValue( editor, 'FontSize', '' );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/tableselection/integrations/format/format.html
+++ b/tests/plugins/tableselection/integrations/format/format.html
@@ -1,0 +1,21 @@
+<textarea id="same-format">
+	<table>
+		<tr>
+			<td>[<h3>Cell</h3>]</td>
+		</tr>
+		<tr>
+			<td>[<h3>Cell</h3>]</td>
+		</tr>
+	</table>
+</textarea>
+
+<textarea id="different-format">
+	<table>
+		<tr>
+			<td>[<h3>Cell</h3>]</td>
+		</tr>
+		<tr>
+			<td>[<address>Cell</address>]</td>
+		</tr>
+	</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/format/format.js
+++ b/tests/plugins/tableselection/integrations/format/format.js
@@ -1,0 +1,44 @@
+/* bender-tags: tableselection, font */
+/* bender-ckeditor-plugins: format, tableselection */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+		divarea: {
+			extraPlugins: 'divarea'
+		},
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	function assertComboValue( editor, comboName, expectedValue ) {
+		var combo = editor.ui.get( comboName );
+
+		assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+	}
+
+	var tests = {
+		'test same format in multiple cells': function( editor, bot ) {
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'same-format' ).getValue() );
+
+			assertComboValue( editor, 'Format', 'h3' );
+		},
+
+		'test different format in multiple cells': function( editor, bot ) {
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'different-format' ).getValue() );
+
+			assertComboValue( editor, 'Format', '' );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/tableselection/integrations/stylescombo/stylescombo.html
+++ b/tests/plugins/tableselection/integrations/stylescombo/stylescombo.html
@@ -1,0 +1,21 @@
+<textarea id="same-styles">
+	<table>
+		<tr>
+			<td>[<h3 style="color:#aaaaaa; font-style:italic">Cell</h3>]</td>
+		</tr>
+		<tr>
+			<td>[<h3 style="color:#aaaaaa; font-style:italic">Cell</h3>]</td>
+		</tr>
+	</table>
+</textarea>
+
+<textarea id="different-styles">
+	<table>
+		<tr>
+			<td>[<h3 style="color:#aaaaaa; font-style:italic">Cell</h3>]</td>
+		</tr>
+		<tr>
+			<td>[<h2 style="font-style:italic">Cell</h2>]</td>
+		</tr>
+	</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/stylescombo/stylescombo.js
+++ b/tests/plugins/tableselection/integrations/stylescombo/stylescombo.js
@@ -1,0 +1,44 @@
+/* bender-tags: tableselection, font */
+/* bender-ckeditor-plugins: stylescombo, tableselection */
+/* bender-include: ../../_helpers/tableselection.js */
+/* global tableSelectionHelpers */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+		divarea: {
+			extraPlugins: 'divarea'
+		},
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	function assertComboValue( editor, comboName, expectedValue ) {
+		var combo = editor.ui.get( comboName );
+
+		assert.areSame( expectedValue, combo.getValue(), 'Combo ' + comboName + ' has appropriate value' );
+	}
+
+	var tests = {
+		'test same styles in multiple cells': function( editor, bot ) {
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'same-styles' ).getValue() );
+
+			assertComboValue( editor, 'Styles', 'Subtitle' );
+		},
+
+		'test different styles in multiple cells': function( editor, bot ) {
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'different-styles' ).getValue() );
+
+			assertComboValue( editor, 'Styles', '' );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+
+	tableSelectionHelpers.ignoreUnsupportedEnvironment( tests );
+
+	bender.test( tests );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature
## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've introduced `CKEDITOR.plugins.richcombo` namespace, which currently holds only one method – `createSelectionListener`. It contains common logic for creating `selectionChange` listeners for rich combos (Font, Font Size, Styles and Format). These listeners ensures that when determining the displayed value of rich combo state from the whole, not only the beginning, of selection is considered.

There are however some issues with selecting new text, starting from the same element as previous selection. Such selection does not refresh the state of rich combo.

I'm also not 100% sure about `createSelectionListener`. It simplifies a logic and put it into one place, but at the same time I feel it somehow illogical. Probably it's a place that could be further improved.

closes #525.
