### PR TITLE
[#910][#895] Fix problem with using scrollTop on document in Chrome 61+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ API Changes:
 * [#1712](https://github.com/ckeditor/ckeditor-dev/issues/1712): [`extraPlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-extraPlugins), [`removePlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removePlugins) and [`plugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-plugins) configuration options allow whitespace.
 * [#1724](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added option to [`getClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getClientRect) function allowing to retrieve an absolute bounding rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport.
 * [#1498](https://github.com/ckeditor/ckeditor-dev/issues/1498) : Added new method 'getClientRects()' to CKEDITOR.dom.range, which returns list of rects for each selected element.
-* [#910](https://github.com/ckeditor/ckeditor-dev/issues/910): Added new methods to CKEDITOR.dom.element and CKEDITOR.dom.document, which set up scroll position of given element or document.
+* [#910](https://github.com/ckeditor/ckeditor-dev/issues/910): Added new methods to [CKEDITOR.dom.element](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html) and [CKEDITOR.dom.document](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_document.html), which set up scroll position of given element or document.
 
 ## CKEditor 4.9.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ API Changes:
 * [#1712](https://github.com/ckeditor/ckeditor-dev/issues/1712): [`extraPlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-extraPlugins), [`removePlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removePlugins) and [`plugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-plugins) configuration options allow whitespace.
 * [#1724](https://github.com/ckeditor/ckeditor-dev/issues/1724): Added option to [`getClientRect`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-getClientRect) function allowing to retrieve an absolute bounding rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport.
 * [#1498](https://github.com/ckeditor/ckeditor-dev/issues/1498) : Added new method 'getClientRects()' to CKEDITOR.dom.range, which returns list of rects for each selected element.
+* [#910](https://github.com/ckeditor/ckeditor-dev/issues/910): Added new methods to CKEDITOR.dom.element and CKEDITOR.dom.document, which set up scroll position of given element or document.
 
 ## CKEditor 4.9.2
 

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -248,6 +248,15 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	},
 
 	/**
+	 * Gets the DOM scrolling element for this document.
+	 *
+	 * @since 4.8.0
+	 * @returns {CKEDITOR.dom.element} The scrolling element or `null` if element doesn't exists.
+	 */
+	getScrollingElement: function() {
+		return this.$.scrollingElement ? new CKEDITOR.dom.element( this.$.scrollingElement ) : null;
+	},
+	/**
 	 * Defines the document content through `document.write`. Note that the
 	 * previous document content will be lost (cleaned).
 	 *

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -248,13 +248,14 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	},
 
 	/**
-	 * Gets the DOM scrolling element for this document.
+	 * Gets the DOM scrolling element for this document. Scrolling element allows for using `scrollTop` and `scrollLeft` on entire document.
 	 *
 	 * @since 4.8.0
-	 * @returns {CKEDITOR.dom.element} The scrolling element or `null` if element doesn't exists.
+	 * @returns {CKEDITOR.dom.element} Scrolling element.
 	 */
 	getScrollingElement: function() {
-		return this.$.scrollingElement ? new CKEDITOR.dom.element( this.$.scrollingElement ) : null;
+		var scrollingElement = this.$.scrollingElement || this.$.documentElement || this.$.body;
+		return new CKEDITOR.dom.element( scrollingElement );
 	},
 	/**
 	 * Defines the document content through `document.write`. Note that the

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -250,7 +250,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	/**
 	 * Gets the DOM scrolling element for this document. Scrolling element allows for using `scrollTop` and `scrollLeft` on entire document.
 	 *
-	 * @since 4.8.0
+	 * @since 4.8.1
 	 * @returns {CKEDITOR.dom.element} Scrolling element.
 	 */
 	getScrollingElement: function() {

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -250,13 +250,43 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	/**
 	 * Gets the DOM scrolling element for this document. Scrolling element allows for using `scrollTop` and `scrollLeft` on entire document.
 	 *
-	 * @since 4.8.1
+	 * @since 4.10.0
 	 * @returns {CKEDITOR.dom.element} Scrolling element.
 	 */
 	getScrollingElement: function() {
 		var scrollingElement = this.$.scrollingElement || this.$.documentElement || this.$.body;
 		return new CKEDITOR.dom.element( scrollingElement );
 	},
+	/**
+	 * Returns scroll position of the document.
+	 *
+	 * @since 4.10.0
+	 * @returns {Object} Object representing vertical and horizontal scroll position of the document.
+	 * @returns {Number} return.scrollTop vertical scroll position.
+	 * @returns {Number} return.scrollLeft horizontal scroll position.
+	 */
+	getScrollPosition: function() {
+		var	scrollingElement = this.getScrollingElement();
+
+		return { scrollTop: scrollingElement.$.scrollTop, scrollLeft: scrollingElement.$.scrollLeft };
+	},
+
+	/**
+	 * Set scroll position of document.
+	 *
+	 * @since 4.10.0
+	 * @param {Number} scrollTop number of pixels that document is scrolled vertically.
+	 * @param {Number} [scrollLeft] number of pixels that document is scrolled horizontally.
+	 */
+	setScrollPosition: function( scrollTop, scrollLeft ) {
+		var scrollingElement = this.getScrollingElement();
+
+		if ( scrollLeft !== undefined ) {
+			scrollingElement.$.scrollLeft = scrollLeft;
+		}
+		scrollingElement.$.scrollTop = scrollTop;
+	},
+
 	/**
 	 * Defines the document content through `document.write`. Note that the
 	 * previous document content will be lost (cleaned).

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -266,9 +266,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * @returns {Number} return.scrollLeft horizontal scroll position.
 	 */
 	getScrollPosition: function() {
-		var	scrollingElement = this.getScrollingElement();
-
-		return { scrollTop: scrollingElement.$.scrollTop, scrollLeft: scrollingElement.$.scrollLeft };
+		return this.getScrollingElement().getScrollPosition();
 	},
 
 	/**
@@ -279,12 +277,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * @param {Number} [scrollLeft] number of pixels that document is scrolled horizontally.
 	 */
 	setScrollPosition: function( scrollTop, scrollLeft ) {
-		var scrollingElement = this.getScrollingElement();
-
-		if ( scrollLeft !== undefined ) {
-			scrollingElement.$.scrollLeft = scrollLeft;
-		}
-		scrollingElement.$.scrollTop = scrollTop;
+		this.getScrollingElement().setScrollPosition( scrollTop, scrollLeft );
 	},
 
 	/**

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -261,9 +261,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 * Returns scroll position of the document.
 	 *
 	 * @since 4.10.0
-	 * @returns {Object} Object representing vertical and horizontal scroll position of the document.
-	 * @returns {Number} return.scrollTop vertical scroll position.
-	 * @returns {Number} return.scrollLeft horizontal scroll position.
+	 * @returns {CKEDITOR.dom.scrollPosition} Object representing vertical and horizontal scroll position of the document..
 	 */
 	getScrollPosition: function() {
 		return this.getScrollingElement().getScrollPosition();

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2109,8 +2109,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @returns {Object/Number} Object with keys: `scrollTop` and `scrollLeft`, or Number represent scrollTop
 		 */
 		getDocumentScrollPosition: function() {
-			var doc = this.getDocument(),
-				scrollingElement = doc.getScrollingElement();
+			var	scrollingElement = this.getDocument().getScrollingElement();
 
 			return { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
 		},
@@ -2123,11 +2122,12 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 		 */
 		setDocumentScrollPosition: function( scrollTop, scrollLeft ) {
-			var doc = this.getDocument(),
-				scrollingElement = doc.getScrollingElement();
+			var scrollingElement = this.getDocument().getScrollingElement();
 
+			if ( scrollLeft !== undefined ) {
+				scrollingElement.$.scrollLeft = scrollLeft;
+			}
 			scrollingElement.$.scrollTop = scrollTop;
-			scrollingElement.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : scrollingElement.$.scrollLeft;
 		},
 
 		/**
@@ -2148,8 +2148,10 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Number} [scrollLeft] number of pixels that an element's contentt is scrolled horizontally.
 		 */
 		setScrollPosition: function( scrollTop, scrollLeft ) {
+			if ( scrollLeft !== undefined ) {
+				this.$.scrollLeft = scrollLeft;
+			}
 			this.$.scrollTop = scrollTop;
-			this.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : this.$.scrollLeft;
 		}
 	} );
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -493,7 +493,8 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * frame.getClientRect( true );
 		 * ```
 		 *
-		 * @param {Boolean} [isAbsolute=false] The function will retrieve an absolute rectangle of the element i.e. position relative to the upper-left corner of the topmost viewport. This option is available since 4.10.0.
+		 * @param {Boolean} [isAbsolute=false] The function will retrieve an absolute rectangle of the element
+		 * i.e. position relative to the upper-left corner of the topmost viewport. This option is available since 4.10.0.
 		 * @returns {CKEDITOR.dom.rect} The dimensions of the DOM element.
 		 */
 		getClientRect: function( isAbsolute ) {
@@ -2105,47 +2106,44 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		/**
 		 * Returns scroll position of the element's document.
 		 *
-		 * @since 4.8.1
-		 * @returns {Object/Number} Object with keys: `scrollTop` and `scrollLeft`, or Number represent scrollTop
+		 * @since 4.10.0
+		 * @returns {Object} Object representing vertical and horizontal scroll position of the document.
+		 * @returns {Number} return.scrollTop vertical scroll position.
+		 * @returns {Number} return.scrollLeft horizontal scroll position.
 		 */
 		getDocumentScrollPosition: function() {
-			var	scrollingElement = this.getDocument().getScrollingElement();
-
-			return { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
+			return this.getDocument().getScrollPosition();
 		},
 
 		/**
 		 * Set scroll position of element's document.
 		 *
-		 * @since 4.8.1
+		 * @since 4.10.0
 		 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 		 */
 		setDocumentScrollPosition: function( scrollTop, scrollLeft ) {
-			var scrollingElement = this.getDocument().getScrollingElement();
-
-			if ( scrollLeft !== undefined ) {
-				scrollingElement.$.scrollLeft = scrollLeft;
-			}
-			scrollingElement.$.scrollTop = scrollTop;
+			return this.getDocument().setScrollPosition( scrollTop, scrollLeft );
 		},
 
 		/**
 		 * Returns scroll position of the element itself.
 		 *
-		 * @since 4.8.1
-		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
+		 * @since 4.10.0
+		 * @returns {Object} Object representing vertical and horizontal scroll position of the element itself.
+		 * @returns {Number} return.scrollTop vertical scroll position.
+		 * @returns {Number} return.scrollLeft horizontal scroll position.
 		 */
 		getScrollPosition: function() {
-			return { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
+			return { scrollTop: this.$.scrollTop, scrollLeft: this.$.scrollLeft };
 		},
 
 		/**
 		 * Set scroll position of element itself.
 		 *
-		 * @since 4.8.1
-		 * @param {Number} scrollTop number of pixels that an element's contentt is scrolled vertically.
-		 * @param {Number} [scrollLeft] number of pixels that an element's contentt is scrolled horizontally.
+		 * @since 4.10.0
+		 * @param {Number} scrollTop number of pixels that an element's content is scrolled vertically.
+		 * @param {Number} [scrollLeft] number of pixels that an element's content is scrolled horizontally.
 		 */
 		setScrollPosition: function( scrollTop, scrollLeft ) {
 			if ( scrollLeft !== undefined ) {

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2118,19 +2118,19 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * Returns scroll position of the element's document.
 		 *
 		 * @since 4.8.0
-		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
+		 * @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
+		 * @returns {Object/Number} Object with keys: `scrollTop` and `scrollLeft`, or Number represent scrollTop
 		 */
-		'getDocumentScroll': function() {
+		'getDocumentScroll': function( onlyScrollTop ) {
 			var doc = this.getDocument(),
 				scrollingElement = doc.getScrollingElement();
 
 			if ( scrollingElement ) {
-				return { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
+				return onlyScrollTop ? scrollingElement.$.scrollTop : { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
 			} else {
 				scrollingElement = doc.$.documentElement || doc.$.body;
-				return { 'scrollTop': scrollingElement.scrollTop, 'scrollLeft': scrollingElement.scrollLeft };
+				return onlyScrollTop ? scrollingElement.scrollTop : { 'scrollTop': scrollingElement.scrollTop, 'scrollLeft': scrollingElement.scrollLeft };
 			}
-			return;
 		},
 
 		/**
@@ -2158,10 +2158,11 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * Returns scroll position of the element itself.
 		 *
 		 * @since 4.8.0
+		 * @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
 		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
 		 */
-		'getScroll': function() {
-			return { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
+		'getScroll': function( onlyScrollTop ) {
+			return onlyScrollTop ? this.$.scrollTop : { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
 		},
 
 		/**

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2112,6 +2112,68 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 				else if ( !type || node.type == type )
 					callback( node );
 			}
+		},
+
+		/**
+		 * Returns scroll position of the element's document.
+		 *
+		 * @since 4.8.0
+		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
+		 */
+		'getDocumentScroll': function() {
+			var doc = this.getDocument(),
+				scrollingElement = doc.getScrollingElement();
+
+			if ( scrollingElement ) {
+				return { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
+			} else {
+				scrollingElement = doc.$.documentElement || doc.$.body;
+				return { 'scrollTop': scrollingElement.scrollTop, 'scrollLeft': scrollingElement.scrollLeft };
+			}
+			return;
+		},
+
+		/**
+		 * Set scroll position of element's document.
+		 *
+		 * @since 4.8.0
+		 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
+		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
+		 */
+		'setDocumentScroll': function( scrollTop, scrollLeft ) {
+			var doc = this.getDocument(),
+				scrollingElement = doc.getScrollingElement();
+
+			if ( scrollingElement ) {
+				scrollingElement.$.scrollTop = scrollTop;
+				scrollingElement.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : scrollingElement.$.scrollLeft;
+			} else {
+				scrollingElement = doc.$.documentElement || doc.$.body;
+				scrollingElement.scrollTop = scrollTop;
+				scrollingElement.scrollLeft = scrollLeft !== undefined ? scrollLeft : scrollingElement.scrollLeft;
+			}
+		},
+
+		/**
+		 * Returns scroll position of the element itself.
+		 *
+		 * @since 4.8.0
+		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
+		 */
+		'getScroll': function() {
+			return { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
+		},
+
+		/**
+		 * Set scroll position of element itself.
+		 *
+		 * @since 4.8.0
+		 * @param {Number} scrollTop number of pixels that an element's contentt is scrolled vertically.
+		 * @param {Number} [scrollLeft] number of pixels that an element's contentt is scrolled horizontally.
+		 */
+		'setScroll': function( scrollTop, scrollLeft ) {
+			this.$.scrollTop = scrollTop;
+			this.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : this.$.scrollLeft;
 		}
 	} );
 

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2105,7 +2105,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		/**
 		 * Returns scroll position of the element's document.
 		 *
-		 * @since 4.8.0
+		 * @since 4.8.1
 		 * @returns {Object/Number} Object with keys: `scrollTop` and `scrollLeft`, or Number represent scrollTop
 		 */
 		getDocumentScrollPosition: function() {
@@ -2117,7 +2117,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		/**
 		 * Set scroll position of element's document.
 		 *
-		 * @since 4.8.0
+		 * @since 4.8.1
 		 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 		 */
@@ -2133,7 +2133,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		/**
 		 * Returns scroll position of the element itself.
 		 *
-		 * @since 4.8.0
+		 * @since 4.8.1
 		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
 		 */
 		getScrollPosition: function() {
@@ -2143,7 +2143,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		/**
 		 * Set scroll position of element itself.
 		 *
-		 * @since 4.8.0
+		 * @since 4.8.1
 		 * @param {Number} scrollTop number of pixels that an element's contentt is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's contentt is scrolled horizontally.
 		 */

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2109,16 +2109,11 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
 		 * @returns {Object/Number} Object with keys: `scrollTop` and `scrollLeft`, or Number represent scrollTop
 		 */
-		'getDocumentScroll': function( onlyScrollTop ) {
+		getDocumentScroll: function( onlyScrollTop ) {
 			var doc = this.getDocument(),
 				scrollingElement = doc.getScrollingElement();
 
-			if ( scrollingElement ) {
-				return onlyScrollTop ? scrollingElement.$.scrollTop : { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
-			} else {
-				scrollingElement = doc.$.documentElement || doc.$.body;
-				return onlyScrollTop ? scrollingElement.scrollTop : { 'scrollTop': scrollingElement.scrollTop, 'scrollLeft': scrollingElement.scrollLeft };
-			}
+			return onlyScrollTop ? scrollingElement.$.scrollTop : { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
 		},
 
 		/**
@@ -2128,18 +2123,12 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 		 */
-		'setDocumentScroll': function( scrollTop, scrollLeft ) {
+		setDocumentScroll: function( scrollTop, scrollLeft ) {
 			var doc = this.getDocument(),
 				scrollingElement = doc.getScrollingElement();
 
-			if ( scrollingElement ) {
-				scrollingElement.$.scrollTop = scrollTop;
-				scrollingElement.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : scrollingElement.$.scrollLeft;
-			} else {
-				scrollingElement = doc.$.documentElement || doc.$.body;
-				scrollingElement.scrollTop = scrollTop;
-				scrollingElement.scrollLeft = scrollLeft !== undefined ? scrollLeft : scrollingElement.scrollLeft;
-			}
+			scrollingElement.$.scrollTop = scrollTop;
+			scrollingElement.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : scrollingElement.$.scrollLeft;
 		},
 
 		/**
@@ -2149,7 +2138,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
 		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
 		 */
-		'getScroll': function( onlyScrollTop ) {
+		getScroll: function( onlyScrollTop ) {
 			return onlyScrollTop ? this.$.scrollTop : { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
 		},
 
@@ -2160,7 +2149,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Number} scrollTop number of pixels that an element's contentt is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's contentt is scrolled horizontally.
 		 */
-		'setScroll': function( scrollTop, scrollLeft ) {
+		setScroll: function( scrollTop, scrollLeft ) {
 			this.$.scrollTop = scrollTop;
 			this.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : this.$.scrollLeft;
 		}

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1535,7 +1535,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 
 				// https://dev.ckeditor.com/ticket/12747.
 				if ( needAdjustScrollAndBorders ) {
-					var scrollRelative = this.getDocumentScroll();
+					var scrollRelative = this.getDocumentScrollPosition();
 
 					x = box.left + scrollRelative.scrollLeft - clientLeft;
 					y = box.top + scrollRelative.scrollTop - clientTop;
@@ -2106,14 +2106,13 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * Returns scroll position of the element's document.
 		 *
 		 * @since 4.8.0
-		 * @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
 		 * @returns {Object/Number} Object with keys: `scrollTop` and `scrollLeft`, or Number represent scrollTop
 		 */
-		getDocumentScroll: function( onlyScrollTop ) {
+		getDocumentScrollPosition: function() {
 			var doc = this.getDocument(),
 				scrollingElement = doc.getScrollingElement();
 
-			return onlyScrollTop ? scrollingElement.$.scrollTop : { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
+			return { 'scrollTop': scrollingElement.$.scrollTop, 'scrollLeft': scrollingElement.$.scrollLeft };
 		},
 
 		/**
@@ -2123,7 +2122,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 		 */
-		setDocumentScroll: function( scrollTop, scrollLeft ) {
+		setDocumentScrollPosition: function( scrollTop, scrollLeft ) {
 			var doc = this.getDocument(),
 				scrollingElement = doc.getScrollingElement();
 
@@ -2135,11 +2134,10 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * Returns scroll position of the element itself.
 		 *
 		 * @since 4.8.0
-		 * @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
 		 * @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
 		 */
-		getScroll: function( onlyScrollTop ) {
-			return onlyScrollTop ? this.$.scrollTop : { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
+		getScrollPosition: function() {
+			return { 'scrollTop': this.$.scrollTop, 'scrollLeft': this.$.scrollLeft };
 		},
 
 		/**
@@ -2149,7 +2147,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * @param {Number} scrollTop number of pixels that an element's contentt is scrolled vertically.
 		 * @param {Number} [scrollLeft] number of pixels that an element's contentt is scrolled horizontally.
 		 */
-		setScroll: function( scrollTop, scrollLeft ) {
+		setScrollPosition: function( scrollTop, scrollLeft ) {
 			this.$.scrollTop = scrollTop;
 			this.$.scrollLeft = scrollLeft !== undefined ? scrollLeft : this.$.scrollLeft;
 		}

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1535,22 +1535,10 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 
 				// https://dev.ckeditor.com/ticket/12747.
 				if ( needAdjustScrollAndBorders ) {
-					var scrollRelativeLeft,
-						scrollRelativeTop;
+					var scrollRelative = this.getDocumentScroll();
 
-					// See https://dev.ckeditor.com/ticket/12758 to know more about document.(documentElement|body).scroll(Left|Top) in Webkit.
-					if ( CKEDITOR.env.webkit || ( CKEDITOR.env.ie && CKEDITOR.env.version >= 12 ) ) {
-						scrollRelativeLeft = body.$.scrollLeft || $docElem.scrollLeft;
-						scrollRelativeTop = body.$.scrollTop || $docElem.scrollTop;
-					} else {
-						var scrollRelativeElement = quirks ? body.$ : $docElem;
-
-						scrollRelativeLeft = scrollRelativeElement.scrollLeft;
-						scrollRelativeTop = scrollRelativeElement.scrollTop;
-					}
-
-					x = box.left + scrollRelativeLeft - clientLeft;
-					y = box.top + scrollRelativeTop - clientTop;
+					x = box.left + scrollRelative.scrollLeft - clientLeft;
+					y = box.top + scrollRelative.scrollTop - clientTop;
 				}
 			} else {
 				var current = this,

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -2107,9 +2107,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 		 * Returns scroll position of the element itself.
 		 *
 		 * @since 4.10.0
-		 * @returns {Object} Object representing vertical and horizontal scroll position of the element itself.
-		 * @returns {Number} return.scrollTop vertical scroll position.
-		 * @returns {Number} return.scrollLeft horizontal scroll position.
+		 * @returns {CKEDITOR.dom.scrollPosition} Object representing vertical and horizontal scroll position of the element itself.
 		 */
 		getScrollPosition: function() {
 			return { scrollTop: this.$.scrollTop, scrollLeft: this.$.scrollLeft };

--- a/core/dom/element.js
+++ b/core/dom/element.js
@@ -1536,7 +1536,7 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 
 				// https://dev.ckeditor.com/ticket/12747.
 				if ( needAdjustScrollAndBorders ) {
-					var scrollRelative = this.getDocumentScrollPosition();
+					var scrollRelative = this.getDocument().getScrollPosition();
 
 					x = box.left + scrollRelative.scrollLeft - clientLeft;
 					y = box.top + scrollRelative.scrollTop - clientTop;
@@ -2101,29 +2101,6 @@ CKEDITOR.dom.element.clearMarkers = function( database, element, removeFromDatab
 				else if ( !type || node.type == type )
 					callback( node );
 			}
-		},
-
-		/**
-		 * Returns scroll position of the element's document.
-		 *
-		 * @since 4.10.0
-		 * @returns {Object} Object representing vertical and horizontal scroll position of the document.
-		 * @returns {Number} return.scrollTop vertical scroll position.
-		 * @returns {Number} return.scrollLeft horizontal scroll position.
-		 */
-		getDocumentScrollPosition: function() {
-			return this.getDocument().getScrollPosition();
-		},
-
-		/**
-		 * Set scroll position of element's document.
-		 *
-		 * @since 4.10.0
-		 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
-		 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
-		 */
-		setDocumentScrollPosition: function( scrollTop, scrollLeft ) {
-			return this.getDocument().setScrollPosition( scrollTop, scrollLeft );
 		},
 
 		/**

--- a/core/dom/scrollposition.js
+++ b/core/dom/scrollposition.js
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @fileOverview Defines the "virtual" {@link CKEDITOR.dom.scrollPosition} class
+ * which contains the definition of {@link CKEDITOR.dom.element} or {@link CKEDITOR.dom.document} scroll position.
+ * This file is for documentation purposes only.
+ */
+
+/**
+ * Virtual class that illustrates the {@link CKEDITOR.dom.element} or {@link CKEDITOR.dom.document} scroll position.
+ *
+ * @class CKEDITOR.dom.scrollPosition
+ * @abstract
+ */
+
+/**
+ * Number in pixels which represent distance between {@link CKEDITOR.dom.element}'s or {@link CKEDITOR.dom.document}'s top to its topmost visible content.
+ * When {@link CKEDITOR.dom.element}'s or {@link CKEDITOR.dom.document}'s doesn't generate verticall scrollbar,
+ * then its {@link CKEDITOR.dom.scrollPosition#scrollTop} value is `0`.
+ *
+ * @property {Number} scrollTop
+ */
+
+/**
+ * Number in pixels which represent distance between {@link CKEDITOR.dom.element}'s or {@link CKEDITOR.dom.document}'s left to its leftmost visible content.
+ * When {@link CKEDITOR.dom.element}'s or {@link CKEDITOR.dom.document}'s doesn't generate horizontal scrollbar,
+ * then its {@link CKEDITOR.dom.scrollPosition#scrollLeft} value is `0`.
+ *
+ * @property {Number} scrollLeft
+ */

--- a/core/editable.js
+++ b/core/editable.js
@@ -799,6 +799,29 @@
 			},
 
 			/**
+			 * Returns scroll position of editable.
+			 *
+			* @since 4.8.0
+			* @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
+			* @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
+			*/
+			getEditableScroll: function( onlyScrollTop ) {
+				return this.isInline() ? this.getScroll( onlyScrollTop ) : this.getDocumentScroll( onlyScrollTop );
+			},
+
+			/**
+			 * Set scroll position of editable.
+			 *
+			 * @since 4.8.0
+			 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
+			 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
+			 */
+			setEditableScroll: function( scrollTop, scrollLeft ) {
+				this.isInline() ? this.setScroll( scrollTop, scrollLeft ) : this.setDocumentScroll( scrollTop, scrollLeft );
+			},
+
+
+			/**
 			 * Editable element bootstrapping.
 			 *
 			 * @private

--- a/core/editable.js
+++ b/core/editable.js
@@ -78,7 +78,7 @@
 				// causes unexpected scroll. Store scrollTop value so it can be restored after focusing editor.
 				// Scroll only happens if the editor is focused for the first time. (https://dev.ckeditor.com/ticket/14825)
 				if ( CKEDITOR.env.edge && CKEDITOR.env.version > 14 && !this.hasFocus && this.getDocument().equals( CKEDITOR.document ) ) {
-					this.editor._.previousScrollTop = this.$.scrollTop;
+					this.editor._.previousScrollTop = this.getEditableScroll( true );
 				}
 
 				// [IE] Use instead "setActive" method to focus the editable if it belongs to the host page document,
@@ -90,9 +90,9 @@
 						// We have no control over exactly what happens when the native `focus` method is called,
 						// so save the scroll position and restore it later.
 						if ( CKEDITOR.env.chrome ) {
-							var scrollPos = this.$.scrollTop;
+							var scrollPos = this.getEditableScroll( true );
 							this.$.focus();
-							this.$.scrollTop = scrollPos;
+							this.setEditableScroll( scrollPos );
 						} else {
 							this.$.focus();
 						}
@@ -917,7 +917,7 @@
 				if ( CKEDITOR.env.webkit ) {
 					// [WebKit] Save scrollTop value so it can be used when restoring locked selection. (https://dev.ckeditor.com/ticket/14659)
 					this.on( 'scroll', function() {
-						editor._.previousScrollTop = editor.editable().$.scrollTop;
+						editor._.previousScrollTop = editor.editable().getEditableScroll( true );
 					}, null, null, -1 );
 				}
 
@@ -929,7 +929,7 @@
 						var editable = editor.editable();
 
 						if ( editor._.previousScrollTop != null && editable.getDocument().equals( CKEDITOR.document ) ) {
-							editable.$.scrollTop = editor._.previousScrollTop;
+							editable.setEditableScroll( editor._.previousScrollTop );
 							editor._.previousScrollTop = null;
 							this.removeListener( 'scroll', fixScrollOnFocus );
 						}

--- a/core/editable.js
+++ b/core/editable.js
@@ -78,7 +78,7 @@
 				// causes unexpected scroll. Store scrollTop value so it can be restored after focusing editor.
 				// Scroll only happens if the editor is focused for the first time. (https://dev.ckeditor.com/ticket/14825)
 				if ( CKEDITOR.env.edge && CKEDITOR.env.version > 14 && !this.hasFocus && this.getDocument().equals( CKEDITOR.document ) ) {
-					this.editor._.previousScrollTop = this.getEditableScroll( true );
+					this.editor._.previousScrollTop = this.getEditableScrollPosition().scrollTop;
 				}
 
 				// [IE] Use instead "setActive" method to focus the editable if it belongs to the host page document,
@@ -90,9 +90,9 @@
 						// We have no control over exactly what happens when the native `focus` method is called,
 						// so save the scroll position and restore it later.
 						if ( CKEDITOR.env.chrome ) {
-							var scrollPos = this.getEditableScroll( true );
+							var scrollPos = this.getEditableScrollPosition().scrollTop;
 							this.$.focus();
-							this.setEditableScroll( scrollPos );
+							this.setEditableScrollPosition( scrollPos );
 						} else {
 							this.$.focus();
 						}
@@ -802,11 +802,10 @@
 			 * Returns scroll position of editable.
 			 *
 			* @since 4.8.0
-			* @param {Boolean} [onlyScrollTop] If set to `true` returns only scrollTop value
 			* @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
 			*/
-			getEditableScroll: function( onlyScrollTop ) {
-				return this.isInline() ? this.getScroll( onlyScrollTop ) : this.getDocumentScroll( onlyScrollTop );
+			getEditableScrollPosition: function() {
+				return this.isInline() ? this.getScrollPosition() : this.getDocumentScrollPosition();
 			},
 
 			/**
@@ -816,8 +815,8 @@
 			 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 			 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 			 */
-			setEditableScroll: function( scrollTop, scrollLeft ) {
-				this.isInline() ? this.setScroll( scrollTop, scrollLeft ) : this.setDocumentScroll( scrollTop, scrollLeft );
+			setEditableScrollPosition: function( scrollTop, scrollLeft ) {
+				this.isInline() ? this.setScrollPosition( scrollTop, scrollLeft ) : this.setDocumentScrollPosition( scrollTop, scrollLeft );
 			},
 
 
@@ -917,7 +916,7 @@
 				if ( CKEDITOR.env.webkit ) {
 					// [WebKit] Save scrollTop value so it can be used when restoring locked selection. (https://dev.ckeditor.com/ticket/14659)
 					this.on( 'scroll', function() {
-						editor._.previousScrollTop = editor.editable().getEditableScroll( true );
+						editor._.previousScrollTop = editor.editable().getEditableScrollPosition().scrollTop;
 					}, null, null, -1 );
 				}
 
@@ -929,7 +928,7 @@
 						var editable = editor.editable();
 
 						if ( editor._.previousScrollTop != null && editable.getDocument().equals( CKEDITOR.document ) ) {
-							editable.setEditableScroll( editor._.previousScrollTop );
+							editable.setEditableScrollPosition( editor._.previousScrollTop );
 							editor._.previousScrollTop = null;
 							this.removeListener( 'scroll', fixScrollOnFocus );
 						}

--- a/core/editable.js
+++ b/core/editable.js
@@ -801,7 +801,7 @@
 			/**
 			 * Returns scroll position of editable.
 			 *
-			* @since 4.8.0
+			* @since 4.8.1
 			* @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
 			*/
 			getEditableScrollPosition: function() {
@@ -811,7 +811,7 @@
 			/**
 			 * Set scroll position of editable.
 			 *
-			 * @since 4.8.0
+			 * @since 4.8.1
 			 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 			 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 			 */

--- a/core/editable.js
+++ b/core/editable.js
@@ -799,10 +799,12 @@
 			},
 
 			/**
-			 * Returns scroll position of editable.
+			 * Returns scroll position of the editable.
 			 *
-			* @since 4.8.1
-			* @returns {Object} Object with keys: `scrollTop` and `scrollLeft`
+			 * @since 4.10.0
+			 * @returns {Object} Object representing vertical and horizontal scroll position of the editable.
+			 * @returns {Number} return.scrollTop vertical scroll position.
+			 * @returns {Number} return.scrollLeft horizontal scroll position.
 			*/
 			getEditableScrollPosition: function() {
 				return this.isInline() ? this.getScrollPosition() : this.getDocumentScrollPosition();
@@ -811,7 +813,7 @@
 			/**
 			 * Set scroll position of editable.
 			 *
-			 * @since 4.8.1
+			 * @since 4.10.0
 			 * @param {Number} scrollTop number of pixels that an element's document is scrolled vertically.
 			 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 			 */

--- a/core/editable.js
+++ b/core/editable.js
@@ -807,7 +807,7 @@
 			 * @returns {Number} return.scrollLeft horizontal scroll position.
 			*/
 			getEditableScrollPosition: function() {
-				return this.isInline() ? this.getScrollPosition() : this.getDocumentScrollPosition();
+				return this.isInline() ? this.getScrollPosition() : this.getDocument().getScrollPosition();
 			},
 
 			/**
@@ -818,7 +818,7 @@
 			 * @param {Number} [scrollLeft] number of pixels that an element's document is scrolled horizontally.
 			 */
 			setEditableScrollPosition: function( scrollTop, scrollLeft ) {
-				this.isInline() ? this.setScrollPosition( scrollTop, scrollLeft ) : this.setDocumentScrollPosition( scrollTop, scrollLeft );
+				this.isInline() ? this.setScrollPosition( scrollTop, scrollLeft ) : this.getDocument().setScrollPosition( scrollTop, scrollLeft );
 			},
 
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -802,9 +802,7 @@
 			 * Returns scroll position of the editable.
 			 *
 			 * @since 4.10.0
-			 * @returns {Object} Object representing vertical and horizontal scroll position of the editable.
-			 * @returns {Number} return.scrollTop vertical scroll position.
-			 * @returns {Number} return.scrollLeft horizontal scroll position.
+			 * @returns {CKEDITOR.dom.scrollPosition} Object representing vertical and horizontal scroll position of the editable.
 			*/
 			getEditableScrollPosition: function() {
 				return this.isInline() ? this.getScrollPosition() : this.getDocument().getScrollPosition();

--- a/core/selection.js
+++ b/core/selection.js
@@ -773,8 +773,8 @@
 					// On Webkit when editor uses divarea, native focus causes editable viewport to scroll
 					// to the top (when there is no active selection inside while focusing) so the scroll
 					// position should be restored after focusing back editable area. (https://dev.ckeditor.com/ticket/14659)
-					if ( restoreSel && editor._.previousScrollTop != null && editor._.previousScrollTop != editable.getEditableScroll( true ) ) {
-						editable.setEditableScroll( editor._.previousScrollTop );
+					if ( restoreSel && editor._.previousScrollTop != null && editor._.previousScrollTop != editable.getEditableScrollPosition().scrollTop ) {
+						editable.setEditableScrollPosition( editor._.previousScrollTop );
 					}
 				}
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -773,8 +773,8 @@
 					// On Webkit when editor uses divarea, native focus causes editable viewport to scroll
 					// to the top (when there is no active selection inside while focusing) so the scroll
 					// position should be restored after focusing back editable area. (https://dev.ckeditor.com/ticket/14659)
-					if ( restoreSel && editor._.previousScrollTop != null && editor._.previousScrollTop != editable.$.scrollTop ) {
-						editable.$.scrollTop = editor._.previousScrollTop;
+					if ( restoreSel && editor._.previousScrollTop != null && editor._.previousScrollTop != editable.getEditableScroll( true ) ) {
+						editable.setEditableScroll( editor._.previousScrollTop );
 					}
 				}
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3165,7 +3165,7 @@
 			listener2 = widget.repository.on( 'checkSelection', cancel, null, null, 0 );
 
 		if ( needsScrollHack ) {
-			var scrollTop = editor.editable().getDocumentScroll( true );
+			var scrollTop = editor.editable().getDocumentScrollPosition().scrollTop;
 		}
 
 		// Once the clone of the widget is inside of copybin, select
@@ -3176,7 +3176,7 @@
 		range.select();
 
 		if ( needsScrollHack ) {
-			editor.editable().setDocumentScroll( scrollTop );
+			editor.editable().setDocumentScrollPosition( scrollTop );
 		}
 
 		setTimeout( function() {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3165,8 +3165,7 @@
 			listener2 = widget.repository.on( 'checkSelection', cancel, null, null, 0 );
 
 		if ( needsScrollHack ) {
-			var docElement = doc.getDocumentElement().$,
-				scrollTop = docElement.scrollTop;
+			var scrollTop = editor.editable().getDocumentScroll( true );
 		}
 
 		// Once the clone of the widget is inside of copybin, select
@@ -3176,8 +3175,9 @@
 		range.selectNodeContents( copybin );
 		range.select();
 
-		if ( needsScrollHack )
-			docElement.scrollTop = scrollTop;
+		if ( needsScrollHack ) {
+			editor.editable().setDocumentScroll( scrollTop );
+		}
 
 		setTimeout( function() {
 			// [IE] Focus widget before removing copybin to avoid scroll jump.

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3176,7 +3176,7 @@
 		range.select();
 
 		if ( needsScrollHack ) {
-			editor.editable().getDocument().ScrollPosition( scrollTop );
+			editor.editable().getDocument().setScrollPosition( scrollTop );
 		}
 
 		setTimeout( function() {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3165,7 +3165,7 @@
 			listener2 = widget.repository.on( 'checkSelection', cancel, null, null, 0 );
 
 		if ( needsScrollHack ) {
-			var scrollTop = editor.editable().getDocumentScrollPosition().scrollTop;
+			var scrollTop = editor.editable().getDocument().getScrollPosition().scrollTop;
 		}
 
 		// Once the clone of the widget is inside of copybin, select
@@ -3176,7 +3176,7 @@
 		range.select();
 
 		if ( needsScrollHack ) {
-			editor.editable().setDocumentScrollPosition( scrollTop );
+			editor.editable().getDocument().ScrollPosition( scrollTop );
 		}
 
 		setTimeout( function() {

--- a/tests/core/dom/document.js
+++ b/tests/core/dom/document.js
@@ -136,31 +136,17 @@ bender.test( appendDomObjectTests(
 			assert.areSame( $frag, CKEDITOR.document._getHtml5ShivFrag(), 'Document fragment is cached' );
 		},
 
-		// #910
+		// (#910)
 		'test getScrollingElement': function() {
-			// IE doesn't support `scrollingElement`
-			if ( CKEDITOR.env.ie ) {
-				assert.ignore();
+			var scrollingElement = CKEDITOR.document.getScrollingElement(),
+				nativeEl = document.scrollingElement || document.documentElement || document.body;
+
+			if ( !( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
+				// IE8 doesn't support isEqualNode
+				assert.isTrue( scrollingElement.$.isEqualNode( nativeEl ) );
 			}
 
-			var doc = CKEDITOR.document;
-
-			assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.scrollingElement ) );
-			assert.isTrue( doc.getScrollingElement().equals( new CKEDITOR.dom.element( document.scrollingElement ) ) );
-		},
-
-		// #910
-		'test scrollingElement is not present': function() {
-			if ( !CKEDITOR.env.ie ) {
-				assert.ignore();
-			}
-
-			var doc = CKEDITOR.document;
-			if ( CKEDITOR.env.version > 8 ) {
-				// isEqualNode is suported in IE9+
-				assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.documentElement || document.body ) );
-			}
-			assert.isTrue( doc.getScrollingElement().equals( new CKEDITOR.dom.element( document.documentElement || document.body ) ) );
+			assert.isTrue( scrollingElement.equals( new CKEDITOR.dom.element( nativeEl ) ) );
 		}
 
 	}

--- a/tests/core/dom/document.js
+++ b/tests/core/dom/document.js
@@ -82,14 +82,6 @@ bender.test( appendDomObjectTests(
 				'Create text node content doesn\'t match.' );
 		},
 
-// 		test_getByAddress1: function()
-// 		{
-// 			var doc = new CKEDITOR.dom.document( document );
-// 			var node = doc.getByAddress( [ 1, 1, 0, 1, 0, 0 ] );
-// 			assert.areSame( 'target', node.getText(),
-// 				'Addressing target doesn\'t match.' );
-// 		},
-
 		test_getElementsByTag: function() {
 			var nodeList = new CKEDITOR.dom.document( document ).getElementsByTag( 'span' ),
 				results = [];
@@ -142,6 +134,19 @@ bender.test( appendDomObjectTests(
 			assert.areSame( 1, div.find( 'video' ).count(), 'Second edge element' );
 
 			assert.areSame( $frag, CKEDITOR.document._getHtml5ShivFrag(), 'Document fragment is cached' );
+		},
+
+		// #910
+		'test getScrollingElement': function() {
+			// IE doesn't support `scrollingElement`
+			if ( CKEDITOR.env.ie ) {
+				assert.ignore();
+			}
+
+			var doc = CKEDITOR.document;
+
+			assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.scrollingElement ) );
+			assert.isTrue( doc.getScrollingElement().equals( new CKEDITOR.dom.element( document.scrollingElement ) ) );
 		}
 	}
 ) );

--- a/tests/core/dom/document.js
+++ b/tests/core/dom/document.js
@@ -147,6 +147,19 @@ bender.test( appendDomObjectTests(
 
 			assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.scrollingElement ) );
 			assert.isTrue( doc.getScrollingElement().equals( new CKEDITOR.dom.element( document.scrollingElement ) ) );
+		},
+
+		// #910
+		'test scrollingElement is not present': function() {
+			if ( !CKEDITOR.env.ie ) {
+				assert.ignore();
+			}
+
+			var doc = CKEDITOR.document;
+
+			assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.documentElement || document.body ) );
+			assert.isTrue( doc.getScrollingElement().equals( new CKEDITOR.dom.element( document.documentElement || document.body ) ) );
 		}
+
 	}
 ) );

--- a/tests/core/dom/document.js
+++ b/tests/core/dom/document.js
@@ -156,8 +156,10 @@ bender.test( appendDomObjectTests(
 			}
 
 			var doc = CKEDITOR.document;
-
-			assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.documentElement || document.body ) );
+			if ( CKEDITOR.env.version > 8 ) {
+				// isEqualNode is suported in IE9+
+				assert.isTrue( doc.getScrollingElement().$.isEqualNode( document.documentElement || document.body ) );
+			}
 			assert.isTrue( doc.getScrollingElement().equals( new CKEDITOR.dom.element( document.documentElement || document.body ) ) );
 		}
 

--- a/tests/core/dom/document.js
+++ b/tests/core/dom/document.js
@@ -141,12 +141,7 @@ bender.test( appendDomObjectTests(
 			var scrollingElement = CKEDITOR.document.getScrollingElement(),
 				nativeEl = document.scrollingElement || document.documentElement || document.body;
 
-			if ( !( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
-				// IE8 doesn't support isEqualNode
-				assert.isTrue( scrollingElement.$.isEqualNode( nativeEl ) );
-			}
-
-			assert.isTrue( scrollingElement.equals( new CKEDITOR.dom.element( nativeEl ) ) );
+			assert.isTrue( scrollingElement.$ === nativeEl );
 		}
 
 	}

--- a/tests/core/dom/element/manual/scrolldocument.html
+++ b/tests/core/dom/element/manual/scrolldocument.html
@@ -24,8 +24,8 @@
 	var scrl = function( top, left ) {
 		return function() {
 			var element = editor.editable().findOne( '#nested' );
-			element.setDocumentScroll( top, left );
-			var scroll = element.getDocumentScroll();
+			element.setDocumentScrollPosition( top, left );
+			var scroll = element.getDocumentScrollPosition();
 			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
 				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
 		}

--- a/tests/core/dom/element/manual/scrolldocument.html
+++ b/tests/core/dom/element/manual/scrolldocument.html
@@ -1,0 +1,38 @@
+<pre id="values" style="min-width:100px;min-height:50px;background-color:lightgreen;">
+</pre>
+<textarea id="editor" >
+	<div style="width:1000px;height:1000px;background-color:grey;" ></div>
+	<p>Some <strong>content with <em id="nested">nested elements</em></strong></p>
+</textarea>
+<button id="id1">Scroll left-down</button>
+<button id="id2">Scroll right-down</button>
+<button id="id3">Scroll left-up</button>
+<button id="id4">Scroll right-up</button>
+<script>
+	var editor = CKEDITOR.replace( 'editor', {
+		width: 300,
+		height: 400,
+		extraAllowedContent: 'em[id]'
+	} );
+
+	var id1 = document.getElementById( 'id1' );
+	var id2 = document.getElementById( 'id2' );
+	var id3 = document.getElementById( 'id3' );
+	var id4 = document.getElementById( 'id4' );
+	var val = document.getElementById( 'values' );
+
+	var scrl = function( top, left ) {
+		return function() {
+			var element = editor.editable().findOne( '#nested' );
+			element.setDocumentScroll( top, left );
+			var scroll = element.getDocumentScroll();
+			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
+				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
+		}
+	}
+
+	id1.onclick = scrl( 1000, 0 );
+	id2.onclick = scrl( 1000, 1000 );
+	id3.onclick = scrl( 0, 0 );
+	id4.onclick = scrl( 0, 1000 );
+</script>

--- a/tests/core/dom/element/manual/scrolldocument.html
+++ b/tests/core/dom/element/manual/scrolldocument.html
@@ -4,10 +4,18 @@
 	<div style="width:1000px;height:1000px;background-color:grey;" ></div>
 	<p>Some <strong>content with <em id="nested">nested elements</em></strong></p>
 </textarea>
-<button id="id1">Scroll left-down</button>
-<button id="id2">Scroll right-down</button>
-<button id="id3">Scroll left-up</button>
-<button id="id4">Scroll right-up</button>
+<div style="display: inline-block; border: 1px solid black; padding: 3px;"><p>Button based on element</p>
+	<button id="id1">Scroll left-down</button>
+	<button id="id2">Scroll right-down</button>
+	<button id="id3">Scroll left-up</button>
+	<button id="id4">Scroll right-up</button>
+</div>
+<div style="display: inline-block; border: 1px solid black;padding: 3px;"><p>Buttons based on document</p>
+	<button id="id5">Scroll left-down</button>
+	<button id="id6">Scroll right-down</button>
+	<button id="id7">Scroll left-up</button>
+	<button id="id8">Scroll right-up</button>
+</div>
 <script>
 	var editor = CKEDITOR.replace( 'editor', {
 		width: 300,
@@ -19,13 +27,25 @@
 	var id2 = document.getElementById( 'id2' );
 	var id3 = document.getElementById( 'id3' );
 	var id4 = document.getElementById( 'id4' );
+	var id5 = document.getElementById( 'id5' );
+	var id6 = document.getElementById( 'id6' );
+	var id7 = document.getElementById( 'id7' );
+	var id8 = document.getElementById( 'id8' );
 	var val = document.getElementById( 'values' );
 
-	var scrl = function( top, left ) {
+	var scrl = function( top, left, isDoc ) {
 		return function() {
-			var element = editor.editable().findOne( '#nested' );
-			element.setDocumentScrollPosition( top, left );
-			var scroll = element.getDocumentScrollPosition();
+			var scroll,
+				element = editor.editable().findOne( '#nested' ),
+				doc = element.getDocument();
+
+			if ( !isDoc ) {
+				element.setDocumentScrollPosition( top, left );
+				scroll = element.getDocumentScrollPosition();
+			} else {
+				doc.setScrollPosition( top, left );
+				scroll = doc.getScrollPosition();
+			}
 			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
 				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
 		}
@@ -35,4 +55,8 @@
 	id2.onclick = scrl( 1000, 1000 );
 	id3.onclick = scrl( 0, 0 );
 	id4.onclick = scrl( 0, 1000 );
+	id5.onclick = scrl( 1000, 0, true );
+	id6.onclick = scrl( 1000, 1000, true );
+	id7.onclick = scrl( 0, 0, true );
+	id8.onclick = scrl( 0, 1000, true );
 </script>

--- a/tests/core/dom/element/manual/scrolldocument.html
+++ b/tests/core/dom/element/manual/scrolldocument.html
@@ -40,8 +40,8 @@
 				doc = element.getDocument();
 
 			if ( !isDoc ) {
-				element.setDocumentScrollPosition( top, left );
-				scroll = element.getDocumentScrollPosition();
+				element.getDocument().setScrollPosition( top, left );
+				scroll = element.getDocument().getScrollPosition();
 			} else {
 				doc.setScrollPosition( top, left );
 				scroll = doc.getScrollPosition();

--- a/tests/core/dom/element/manual/scrolldocument.html
+++ b/tests/core/dom/element/manual/scrolldocument.html
@@ -4,17 +4,11 @@
 	<div style="width:1000px;height:1000px;background-color:grey;" ></div>
 	<p>Some <strong>content with <em id="nested">nested elements</em></strong></p>
 </textarea>
-<div style="display: inline-block; border: 1px solid black; padding: 3px;"><p>Button based on element</p>
+<div style="display: inline-block; border: 1px solid black; padding: 3px;"><p>Buttons based on element</p>
 	<button id="id1">Scroll left-down</button>
 	<button id="id2">Scroll right-down</button>
 	<button id="id3">Scroll left-up</button>
 	<button id="id4">Scroll right-up</button>
-</div>
-<div style="display: inline-block; border: 1px solid black;padding: 3px;"><p>Buttons based on document</p>
-	<button id="id5">Scroll left-down</button>
-	<button id="id6">Scroll right-down</button>
-	<button id="id7">Scroll left-up</button>
-	<button id="id8">Scroll right-up</button>
 </div>
 <script>
 	var editor = CKEDITOR.replace( 'editor', {
@@ -27,10 +21,6 @@
 	var id2 = document.getElementById( 'id2' );
 	var id3 = document.getElementById( 'id3' );
 	var id4 = document.getElementById( 'id4' );
-	var id5 = document.getElementById( 'id5' );
-	var id6 = document.getElementById( 'id6' );
-	var id7 = document.getElementById( 'id7' );
-	var id8 = document.getElementById( 'id8' );
 	var val = document.getElementById( 'values' );
 
 	var scrl = function( top, left, isDoc ) {
@@ -39,13 +29,10 @@
 				element = editor.editable().findOne( '#nested' ),
 				doc = element.getDocument();
 
-			if ( !isDoc ) {
-				element.getDocument().setScrollPosition( top, left );
-				scroll = element.getDocument().getScrollPosition();
-			} else {
-				doc.setScrollPosition( top, left );
-				scroll = doc.getScrollPosition();
-			}
+
+			element.getDocument().setScrollPosition( top, left );
+			scroll = element.getDocument().getScrollPosition();
+
 			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
 				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
 		}
@@ -55,8 +42,4 @@
 	id2.onclick = scrl( 1000, 1000 );
 	id3.onclick = scrl( 0, 0 );
 	id4.onclick = scrl( 0, 1000 );
-	id5.onclick = scrl( 1000, 0, true );
-	id6.onclick = scrl( 1000, 1000, true );
-	id7.onclick = scrl( 0, 0, true );
-	id8.onclick = scrl( 0, 1000, true );
 </script>

--- a/tests/core/dom/element/manual/scrolldocument.md
+++ b/tests/core/dom/element/manual/scrolldocument.md
@@ -1,7 +1,7 @@
-@bender-tags: 4.8.0, feature
+@bender-tags: 4.8.0, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
 
 ----
 
-Press bottom buttons and check if editor is scroleld properly. Compare scroll position with values displayed above editor.
+Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.

--- a/tests/core/dom/element/manual/scrolldocument.md
+++ b/tests/core/dom/element/manual/scrolldocument.md
@@ -1,0 +1,7 @@
+@bender-tags: 4.8.0, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
+
+----
+
+Press bottom buttons and check if editor is scroleld properly. Compare scroll position with values displayed above editor.

--- a/tests/core/dom/element/manual/scrolldocument.md
+++ b/tests/core/dom/element/manual/scrolldocument.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.8.0, bug
+@bender-tags: 4.8.1, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
 

--- a/tests/core/dom/element/manual/scrolldocument.md
+++ b/tests/core/dom/element/manual/scrolldocument.md
@@ -1,7 +1,8 @@
-@bender-tags: 4.8.1, bug
+@bender-tags: 4.10.0, bug, 910
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
 
 ----
 
 Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.
+Repeat steps for both sets of buttons.

--- a/tests/core/dom/element/manual/scrolldocument.md
+++ b/tests/core/dom/element/manual/scrolldocument.md
@@ -4,5 +4,5 @@
 
 ----
 
-Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.
-Repeat steps for both sets of buttons.
+1. Press each of the bottom buttons and check if editor is scrolled properly.
+2. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.

--- a/tests/core/dom/element/manual/scrollelement.html
+++ b/tests/core/dom/element/manual/scrollelement.html
@@ -24,8 +24,8 @@
 	var scrl = function( top, left ) {
 		return function() {
 			var editable = editor.editable();
-			editable.setScroll( top, left );
-			var scroll = editable.getScroll();
+			editable.setScrollPosition( top, left );
+			var scroll = editable.getScrollPosition();
 			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
 				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
 		}

--- a/tests/core/dom/element/manual/scrollelement.html
+++ b/tests/core/dom/element/manual/scrollelement.html
@@ -1,0 +1,38 @@
+<pre id="values" style="min-width:100px;min-height:50px;background-color:lightgreen;">
+</pre>
+<div id="editor" >
+	<div style="width:1000px;height:1000px;background-color:grey;" ></div>
+	<p>Some <strong>content with <em id="nested">nested elements</em></strong></p>
+</div>
+<button id="id1">Scroll left-down</button>
+<button id="id2">Scroll right-down</button>
+<button id="id3">Scroll left-up</button>
+<button id="id4">Scroll right-up</button>
+<script>
+	var editor = CKEDITOR.replace( 'editor', {
+		width: 300,
+		height: 400,
+		extraAllowedContent: 'em[id]'
+	} );
+
+	var id1 = document.getElementById( 'id1' );
+	var id2 = document.getElementById( 'id2' );
+	var id3 = document.getElementById( 'id3' );
+	var id4 = document.getElementById( 'id4' );
+	var val = document.getElementById( 'values' );
+
+	var scrl = function( top, left ) {
+		return function() {
+			var editable = editor.editable();
+			editable.setScroll( top, left );
+			var scroll = editable.getScroll();
+			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
+				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
+		}
+	}
+
+	id1.onclick = scrl( 1000, 0 );
+	id2.onclick = scrl( 1000, 1000 );
+	id3.onclick = scrl( 0, 0 );
+	id4.onclick = scrl( 0, 1000 );
+</script>

--- a/tests/core/dom/element/manual/scrollelement.md
+++ b/tests/core/dom/element/manual/scrollelement.md
@@ -1,7 +1,7 @@
-@bender-tags: 4.8.0, feature
+@bender-tags: 4.8.0, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, divarea, undo, sourcearea, basicstyles, div
 
 ----
 
-Press bottom buttons and check if editor is scroleld properly. Compare scroll position with values displayed above editor.
+Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.

--- a/tests/core/dom/element/manual/scrollelement.md
+++ b/tests/core/dom/element/manual/scrollelement.md
@@ -1,0 +1,7 @@
+@bender-tags: 4.8.0, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, divarea, undo, sourcearea, basicstyles, div
+
+----
+
+Press bottom buttons and check if editor is scroleld properly. Compare scroll position with values displayed above editor.

--- a/tests/core/dom/element/manual/scrollelement.md
+++ b/tests/core/dom/element/manual/scrollelement.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.8.0, bug
+@bender-tags: 4.8.1, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, divarea, undo, sourcearea, basicstyles, div
 

--- a/tests/core/dom/element/manual/scrollelement.md
+++ b/tests/core/dom/element/manual/scrollelement.md
@@ -1,7 +1,8 @@
-@bender-tags: 4.8.1, bug
+@bender-tags: 4.10.0, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, divarea, undo, sourcearea, basicstyles, div
 
 ----
 
-Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.
+1. Press bottom buttons and check if editor is scrolled properly.
+2. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.

--- a/tests/core/dom/element/scrolls.html
+++ b/tests/core/dom/element/scrolls.html
@@ -1,0 +1,5 @@
+<div style="width: 5000px;height: 5000px">
+	<div id="small" style="width:50px;height:50px;overflow:scroll;margin:100px;border:1px solid blue;">
+		<p style="width:1000px;height:1000px;">&nbsp;</p>
+	</div>
+</div>

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -4,10 +4,16 @@
 	'use strict';
 	bender.editor = true;
 	bender.test( {
+		_assertBothScrolls: function( expected, actual ) {
+			assert.areSame( expected.x, actual.scrollLeft );
+			assert.areSame( expected.y, actual.scrollTop );
+		},
+
 		'test getDocumentScroll': function() {
-			var element = document.getElementById( 'small' );
-			var ckEl = new CKEDITOR.dom.element( element );
-			var doc, docEl, result, resultOnlyTop;
+			var element = document.getElementById( 'small' ),
+				ckEl = new CKEDITOR.dom.element( element ),
+				doc,
+				docEl;
 
 			// Reset position with native methods
 			doc = ckEl.getDocument();
@@ -18,44 +24,33 @@
 			ckEl.$.scrollLeft = 0;
 
 			// document no-scroll, element no-scroll
-			result = ckEl.getDocumentScroll();
-			resultOnlyTop = ckEl.getDocumentScroll( true );
-			assert.areSame( 0, resultOnlyTop );
-			assert.areSame( 0, result.scrollTop );
-			assert.areSame( 0, result.scrollLeft );
+			assert.areSame( 0, ckEl.getDocumentScroll( true ) );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
 
 			// document no-scroll, element scroll
 			ckEl.$.scrollTop = 123;
 			ckEl.$.scrollLeft = 123;
-			result = ckEl.getDocumentScroll();
-			resultOnlyTop = ckEl.getDocumentScroll( true );
-			assert.areSame( 0, resultOnlyTop );
-			assert.areSame( 0, result.scrollTop );
-			assert.areSame( 0, result.scrollLeft );
+			assert.areSame( 0, ckEl.getDocumentScroll( true ) );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
 
 			// document scroll, element scroll
 			docEl.scrollTop = 20;
 			docEl.scrollLeft = 20;
-			result = ckEl.getDocumentScroll();
-			resultOnlyTop = ckEl.getDocumentScroll( true );
-			assert.areSame( 20, resultOnlyTop );
-			assert.areSame( 20, result.scrollTop );
-			assert.areSame( 20, result.scrollLeft );
+			assert.areSame( 20, ckEl.getDocumentScroll( true ) );
+			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScroll() );
 
 			// document scroll, element no-scroll
 			ckEl.$.scrollTop = 0;
 			ckEl.$.scrollLeft = 0;
-			result = ckEl.getDocumentScroll();
-			resultOnlyTop = ckEl.getDocumentScroll( true );
-			assert.areSame( 20, resultOnlyTop );
-			assert.areSame( 20, result.scrollTop );
-			assert.areSame( 20, result.scrollLeft );
+			assert.areSame( 20, ckEl.getDocumentScroll( true ) );
+			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScroll() );
 		},
 
 		'test getScroll': function() {
-			var element = document.getElementById( 'small' );
-			var ckEl = new CKEDITOR.dom.element( element );
-			var doc, docEl, result, resultOnlyTop;
+			var element = document.getElementById( 'small' ),
+				ckEl = new CKEDITOR.dom.element( element ),
+				doc,
+				docEl;
 
 			// Reset position with native methods
 			doc = ckEl.getDocument();
@@ -66,90 +61,66 @@
 			ckEl.$.scrollLeft = 0;
 
 			// document no-scroll, element no-scroll
-			result = ckEl.getScroll();
-			resultOnlyTop = ckEl.getScroll( true );
-			assert.areSame( 0, resultOnlyTop );
-			assert.areSame( 0, result.scrollTop );
-			assert.areSame( 0, result.scrollLeft );
+			assert.areSame( 0, ckEl.getScroll( true ) );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
 
 			// document no-scroll, element scroll
 			ckEl.$.scrollTop = 321;
 			ckEl.$.scrollLeft = 321;
-			result = ckEl.getScroll();
-			resultOnlyTop = ckEl.getScroll( true );
-			assert.areSame( 321, resultOnlyTop );
-			assert.areSame( 321, result.scrollTop );
-			assert.areSame( 321, result.scrollLeft );
+			assert.areSame( 321, ckEl.getScroll( true ) );
+			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScroll() );
 
 			// document scroll, element scroll
-			doc = ckEl.getDocument();
-			docEl = doc.$.documentElement || doc.$.body;
 			docEl.scrollTop = 20;
 			docEl.scrollLeft = 20;
-			result = ckEl.getScroll();
-			resultOnlyTop = ckEl.getScroll( true );
-			assert.areSame( 321, resultOnlyTop );
-			assert.areSame( 321, result.scrollTop );
-			assert.areSame( 321, result.scrollLeft );
+			assert.areSame( 321, ckEl.getScroll( true ) );
+			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScroll() );
 
 			// document scroll, element no-scroll
 			ckEl.$.scrollTop = 0;
 			ckEl.$.scrollLeft = 0;
-			result = ckEl.getScroll();
-			resultOnlyTop = ckEl.getScroll( true );
-			assert.areSame( 0, resultOnlyTop );
-			assert.areSame( 0, result.scrollTop );
-			assert.areSame( 0, result.scrollLeft );
+			assert.areSame( 0, ckEl.getScroll( true ) );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
 		},
 
 		'test setDocumentScroll': function() {
-			var element = document.getElementById( 'small' );
-			var ckEl = new CKEDITOR.dom.element( element );
+			var element = document.getElementById( 'small' ),
+				ckEl = new CKEDITOR.dom.element( element );
 
 			ckEl.setDocumentScroll( 0, 0 );
-			assert.areSame( 0, ckEl.getDocumentScroll().scrollTop );
-			assert.areSame( 0, ckEl.getDocumentScroll().scrollLeft );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
 
 			ckEl.setDocumentScroll( 100 );
-			assert.areSame( 100, ckEl.getDocumentScroll().scrollTop );
-			assert.areSame( 0, ckEl.getDocumentScroll().scrollLeft );
+			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getDocumentScroll() );
 
 			ckEl.setDocumentScroll( 123, 23 );
-			assert.areSame( 123, ckEl.getDocumentScroll().scrollTop );
-			assert.areSame( 23, ckEl.getDocumentScroll().scrollLeft );
+			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getDocumentScroll() );
 
 			ckEl.setDocumentScroll( 0 );
-			assert.areSame( 0, ckEl.getDocumentScroll().scrollTop );
-			assert.areSame( 23, ckEl.getDocumentScroll().scrollLeft );
+			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getDocumentScroll() );
 
 			ckEl.setDocumentScroll( 0, 0 );
-			assert.areSame( 0, ckEl.getDocumentScroll().scrollTop );
-			assert.areSame( 0, ckEl.getDocumentScroll().scrollLeft );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
 		},
 
 		'test setScroll': function() {
-			var element = document.getElementById( 'small' );
-			var ckEl = new CKEDITOR.dom.element( element );
+			var element = document.getElementById( 'small' ),
+				ckEl = new CKEDITOR.dom.element( element );
 
 			ckEl.setScroll( 0, 0 );
-			assert.areSame( 0, ckEl.getScroll().scrollTop );
-			assert.areSame( 0, ckEl.getScroll().scrollLeft );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
 
 			ckEl.setScroll( 100 );
-			assert.areSame( 100, ckEl.getScroll().scrollTop );
-			assert.areSame( 0, ckEl.getScroll().scrollLeft );
+			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getScroll() );
 
 			ckEl.setScroll( 123, 23 );
-			assert.areSame( 123, ckEl.getScroll().scrollTop );
-			assert.areSame( 23, ckEl.getScroll().scrollLeft );
+			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getScroll() );
 
 			ckEl.setScroll( 0 );
-			assert.areSame( 0, ckEl.getScroll().scrollTop );
-			assert.areSame( 23, ckEl.getScroll().scrollLeft );
+			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getScroll() );
 
 			ckEl.setScroll( 0, 0 );
-			assert.areSame( 0, ckEl.getScroll().scrollTop );
-			assert.areSame( 0, ckEl.getScroll().scrollLeft );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
 		}
 
 	} );

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -9,7 +9,7 @@
 			assert.areSame( expected.y, actual.scrollTop );
 		},
 
-		'test getDocumentScroll': function() {
+		'test getDocumentScrollPosition': function() {
 			var element = document.getElementById( 'small' ),
 				ckEl = new CKEDITOR.dom.element( element ),
 				doc,
@@ -23,29 +23,25 @@
 			ckEl.$.scrollLeft = 0;
 
 			// document no-scroll, element no-scroll
-			assert.areSame( 0, ckEl.getDocumentScroll( true ) );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
 
 			// document no-scroll, element scroll
 			ckEl.$.scrollTop = 123;
 			ckEl.$.scrollLeft = 123;
-			assert.areSame( 0, ckEl.getDocumentScroll( true ) );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
 
 			// document scroll, element scroll
 			docEl.scrollTop = 20;
 			docEl.scrollLeft = 20;
-			assert.areSame( 20, ckEl.getDocumentScroll( true ) );
-			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScroll() );
+			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScrollPosition() );
 
 			// document scroll, element no-scroll
 			ckEl.$.scrollTop = 0;
 			ckEl.$.scrollLeft = 0;
-			assert.areSame( 20, ckEl.getDocumentScroll( true ) );
-			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScroll() );
+			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScrollPosition() );
 		},
 
-		'test getScroll': function() {
+		'test getScrollPosition': function() {
 			var element = document.getElementById( 'small' ),
 				ckEl = new CKEDITOR.dom.element( element ),
 				doc,
@@ -60,66 +56,62 @@
 			ckEl.$.scrollLeft = 0;
 
 			// document no-scroll, element no-scroll
-			assert.areSame( 0, ckEl.getScroll( true ) );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
 
 			// document no-scroll, element scroll
 			ckEl.$.scrollTop = 321;
 			ckEl.$.scrollLeft = 321;
-			assert.areSame( 321, ckEl.getScroll( true ) );
-			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScroll() );
+			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScrollPosition() );
 
 			// document scroll, element scroll
 			docEl.scrollTop = 20;
 			docEl.scrollLeft = 20;
-			assert.areSame( 321, ckEl.getScroll( true ) );
-			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScroll() );
+			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScrollPosition() );
 
 			// document scroll, element no-scroll
 			ckEl.$.scrollTop = 0;
 			ckEl.$.scrollLeft = 0;
-			assert.areSame( 0, ckEl.getScroll( true ) );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
 		},
 
-		'test setDocumentScroll': function() {
+		'test setDocumentScrollPosition': function() {
 			var element = document.getElementById( 'small' ),
 				ckEl = new CKEDITOR.dom.element( element );
 
-			ckEl.setDocumentScroll( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
+			ckEl.setDocumentScrollPosition( 0, 0 );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
 
-			ckEl.setDocumentScroll( 100 );
-			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getDocumentScroll() );
+			ckEl.setDocumentScrollPosition( 100 );
+			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getDocumentScrollPosition() );
 
-			ckEl.setDocumentScroll( 123, 23 );
-			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getDocumentScroll() );
+			ckEl.setDocumentScrollPosition( 123, 23 );
+			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getDocumentScrollPosition() );
 
-			ckEl.setDocumentScroll( 0 );
-			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getDocumentScroll() );
+			ckEl.setDocumentScrollPosition( 0 );
+			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getDocumentScrollPosition() );
 
-			ckEl.setDocumentScroll( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScroll() );
+			ckEl.setDocumentScrollPosition( 0, 0 );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
 		},
 
-		'test setScroll': function() {
+		'test setScrollPosition': function() {
 			var element = document.getElementById( 'small' ),
 				ckEl = new CKEDITOR.dom.element( element );
 
-			ckEl.setScroll( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
+			ckEl.setScrollPosition( 0, 0 );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
 
-			ckEl.setScroll( 100 );
-			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getScroll() );
+			ckEl.setScrollPosition( 100 );
+			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getScrollPosition() );
 
-			ckEl.setScroll( 123, 23 );
-			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getScroll() );
+			ckEl.setScrollPosition( 123, 23 );
+			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getScrollPosition() );
 
-			ckEl.setScroll( 0 );
-			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getScroll() );
+			ckEl.setScrollPosition( 0 );
+			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getScrollPosition() );
 
-			ckEl.setScroll( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScroll() );
+			ckEl.setScrollPosition( 0, 0 );
+			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
 		}
 
 	} );

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -14,10 +14,9 @@
 				ckEl = new CKEDITOR.dom.element( element ),
 				doc,
 				docEl;
-
 			// Reset position with native methods
 			doc = ckEl.getDocument();
-			docEl = doc.$.documentElement || doc.$.body;
+			docEl = doc.$.scrollingElement || doc.$.documentElement || doc.$.body;
 			docEl.scrollTop = 0;
 			docEl.scrollLeft = 0;
 			ckEl.$.scrollTop = 0;
@@ -54,7 +53,7 @@
 
 			// Reset position with native methods
 			doc = ckEl.getDocument();
-			docEl = doc.$.documentElement || doc.$.body;
+			docEl = doc.$.scrollingElement || doc.$.documentElement || doc.$.body;
 			docEl.scrollTop = 0;
 			docEl.scrollLeft = 0;
 			ckEl.$.scrollTop = 0;

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -7,7 +7,7 @@
 		'test getDocumentScroll': function() {
 			var element = document.getElementById( 'small' );
 			var ckEl = new CKEDITOR.dom.element( element );
-			var doc, docEl, result;
+			var doc, docEl, result, resultOnlyTop;
 
 			// Reset position with native methods
 			doc = ckEl.getDocument();
@@ -19,6 +19,8 @@
 
 			// document no-scroll, element no-scroll
 			result = ckEl.getDocumentScroll();
+			resultOnlyTop = ckEl.getDocumentScroll( true );
+			assert.areSame( 0, resultOnlyTop );
 			assert.areSame( 0, result.scrollTop );
 			assert.areSame( 0, result.scrollLeft );
 
@@ -26,6 +28,8 @@
 			ckEl.$.scrollTop = 123;
 			ckEl.$.scrollLeft = 123;
 			result = ckEl.getDocumentScroll();
+			resultOnlyTop = ckEl.getDocumentScroll( true );
+			assert.areSame( 0, resultOnlyTop );
 			assert.areSame( 0, result.scrollTop );
 			assert.areSame( 0, result.scrollLeft );
 
@@ -33,6 +37,8 @@
 			docEl.scrollTop = 20;
 			docEl.scrollLeft = 20;
 			result = ckEl.getDocumentScroll();
+			resultOnlyTop = ckEl.getDocumentScroll( true );
+			assert.areSame( 20, resultOnlyTop );
 			assert.areSame( 20, result.scrollTop );
 			assert.areSame( 20, result.scrollLeft );
 
@@ -40,6 +46,8 @@
 			ckEl.$.scrollTop = 0;
 			ckEl.$.scrollLeft = 0;
 			result = ckEl.getDocumentScroll();
+			resultOnlyTop = ckEl.getDocumentScroll( true );
+			assert.areSame( 20, resultOnlyTop );
 			assert.areSame( 20, result.scrollTop );
 			assert.areSame( 20, result.scrollLeft );
 		},
@@ -47,7 +55,7 @@
 		'test getScroll': function() {
 			var element = document.getElementById( 'small' );
 			var ckEl = new CKEDITOR.dom.element( element );
-			var doc, docEl, result;
+			var doc, docEl, result, resultOnlyTop;
 
 			// Reset position with native methods
 			doc = ckEl.getDocument();
@@ -59,6 +67,8 @@
 
 			// document no-scroll, element no-scroll
 			result = ckEl.getScroll();
+			resultOnlyTop = ckEl.getScroll( true );
+			assert.areSame( 0, resultOnlyTop );
 			assert.areSame( 0, result.scrollTop );
 			assert.areSame( 0, result.scrollLeft );
 
@@ -66,6 +76,8 @@
 			ckEl.$.scrollTop = 321;
 			ckEl.$.scrollLeft = 321;
 			result = ckEl.getScroll();
+			resultOnlyTop = ckEl.getScroll( true );
+			assert.areSame( 321, resultOnlyTop );
 			assert.areSame( 321, result.scrollTop );
 			assert.areSame( 321, result.scrollLeft );
 
@@ -75,6 +87,8 @@
 			docEl.scrollTop = 20;
 			docEl.scrollLeft = 20;
 			result = ckEl.getScroll();
+			resultOnlyTop = ckEl.getScroll( true );
+			assert.areSame( 321, resultOnlyTop );
 			assert.areSame( 321, result.scrollTop );
 			assert.areSame( 321, result.scrollLeft );
 
@@ -82,6 +96,8 @@
 			ckEl.$.scrollTop = 0;
 			ckEl.$.scrollLeft = 0;
 			result = ckEl.getScroll();
+			resultOnlyTop = ckEl.getScroll( true );
+			assert.areSame( 0, resultOnlyTop );
 			assert.areSame( 0, result.scrollTop );
 			assert.areSame( 0, result.scrollLeft );
 		},

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -1,0 +1,140 @@
+/* bender-tags: editor */
+
+( function() {
+	'use strict';
+	bender.editor = true;
+	bender.test( {
+		'test getDocumentScroll': function() {
+			var element = document.getElementById( 'small' );
+			var ckEl = new CKEDITOR.dom.element( element );
+			var doc, docEl, result;
+
+			// Reset position with native methods
+			doc = ckEl.getDocument();
+			docEl = doc.$.documentElement || doc.$.body;
+			docEl.scrollTop = 0;
+			docEl.scrollLeft = 0;
+			ckEl.$.scrollTop = 0;
+			ckEl.$.scrollLeft = 0;
+
+			// document no-scroll, element no-scroll
+			result = ckEl.getDocumentScroll();
+			assert.areSame( 0, result.scrollTop );
+			assert.areSame( 0, result.scrollLeft );
+
+			// document no-scroll, element scroll
+			ckEl.$.scrollTop = 123;
+			ckEl.$.scrollLeft = 123;
+			result = ckEl.getDocumentScroll();
+			assert.areSame( 0, result.scrollTop );
+			assert.areSame( 0, result.scrollLeft );
+
+			// document scroll, element scroll
+			docEl.scrollTop = 20;
+			docEl.scrollLeft = 20;
+			result = ckEl.getDocumentScroll();
+			assert.areSame( 20, result.scrollTop );
+			assert.areSame( 20, result.scrollLeft );
+
+			// document scroll, element no-scroll
+			ckEl.$.scrollTop = 0;
+			ckEl.$.scrollLeft = 0;
+			result = ckEl.getDocumentScroll();
+			assert.areSame( 20, result.scrollTop );
+			assert.areSame( 20, result.scrollLeft );
+		},
+
+		'test getScroll': function() {
+			var element = document.getElementById( 'small' );
+			var ckEl = new CKEDITOR.dom.element( element );
+			var doc, docEl, result;
+
+			// Reset position with native methods
+			doc = ckEl.getDocument();
+			docEl = doc.$.documentElement || doc.$.body;
+			docEl.scrollTop = 0;
+			docEl.scrollLeft = 0;
+			ckEl.$.scrollTop = 0;
+			ckEl.$.scrollLeft = 0;
+
+			// document no-scroll, element no-scroll
+			result = ckEl.getScroll();
+			assert.areSame( 0, result.scrollTop );
+			assert.areSame( 0, result.scrollLeft );
+
+			// document no-scroll, element scroll
+			ckEl.$.scrollTop = 321;
+			ckEl.$.scrollLeft = 321;
+			result = ckEl.getScroll();
+			assert.areSame( 321, result.scrollTop );
+			assert.areSame( 321, result.scrollLeft );
+
+			// document scroll, element scroll
+			doc = ckEl.getDocument();
+			docEl = doc.$.documentElement || doc.$.body;
+			docEl.scrollTop = 20;
+			docEl.scrollLeft = 20;
+			result = ckEl.getScroll();
+			assert.areSame( 321, result.scrollTop );
+			assert.areSame( 321, result.scrollLeft );
+
+			// document scroll, element no-scroll
+			ckEl.$.scrollTop = 0;
+			ckEl.$.scrollLeft = 0;
+			result = ckEl.getScroll();
+			assert.areSame( 0, result.scrollTop );
+			assert.areSame( 0, result.scrollLeft );
+		},
+
+		'test setDocumentScroll': function() {
+			var element = document.getElementById( 'small' );
+			var ckEl = new CKEDITOR.dom.element( element );
+
+			ckEl.setDocumentScroll( 0, 0 );
+			assert.areSame( 0, ckEl.getDocumentScroll().scrollTop );
+			assert.areSame( 0, ckEl.getDocumentScroll().scrollLeft );
+
+			ckEl.setDocumentScroll( 100 );
+			assert.areSame( 100, ckEl.getDocumentScroll().scrollTop );
+			assert.areSame( 0, ckEl.getDocumentScroll().scrollLeft );
+
+			ckEl.setDocumentScroll( 123, 23 );
+			assert.areSame( 123, ckEl.getDocumentScroll().scrollTop );
+			assert.areSame( 23, ckEl.getDocumentScroll().scrollLeft );
+
+			ckEl.setDocumentScroll( 0 );
+			assert.areSame( 0, ckEl.getDocumentScroll().scrollTop );
+			assert.areSame( 23, ckEl.getDocumentScroll().scrollLeft );
+
+			ckEl.setDocumentScroll( 0, 0 );
+			assert.areSame( 0, ckEl.getDocumentScroll().scrollTop );
+			assert.areSame( 0, ckEl.getDocumentScroll().scrollLeft );
+		},
+
+		'test setScroll': function() {
+			var element = document.getElementById( 'small' );
+			var ckEl = new CKEDITOR.dom.element( element );
+
+			ckEl.setScroll( 0, 0 );
+			assert.areSame( 0, ckEl.getScroll().scrollTop );
+			assert.areSame( 0, ckEl.getScroll().scrollLeft );
+
+			ckEl.setScroll( 100 );
+			assert.areSame( 100, ckEl.getScroll().scrollTop );
+			assert.areSame( 0, ckEl.getScroll().scrollLeft );
+
+			ckEl.setScroll( 123, 23 );
+			assert.areSame( 123, ckEl.getScroll().scrollTop );
+			assert.areSame( 23, ckEl.getScroll().scrollLeft );
+
+			ckEl.setScroll( 0 );
+			assert.areSame( 0, ckEl.getScroll().scrollTop );
+			assert.areSame( 23, ckEl.getScroll().scrollLeft );
+
+			ckEl.setScroll( 0, 0 );
+			assert.areSame( 0, ckEl.getScroll().scrollTop );
+			assert.areSame( 0, ckEl.getScroll().scrollLeft );
+		}
+
+	} );
+} )();

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -2,116 +2,125 @@
 
 ( function() {
 	'use strict';
+
+	var helpers = {
+		resetScrolls: function( obj ) {
+			this.setNativeScroll( obj, 0, 0 );
+		},
+		setNativeScroll: function( obj, top, left ) {
+			obj.scrollLeft = left;
+			obj.scrollTop = top;
+		},
+		assertBothScrolls: function( expected, actual, message ) {
+			assert.areSame( expected.left, actual.scrollLeft, message + ' (Scroll Left)' );
+			assert.areSame( expected.top, actual.scrollTop, message + ' (Scroll Top)' );
+		},
+		/**
+		 * @param element {CKEDTOR.dom.element}
+		 * @param doc {CKEDTOR.dom.document}
+		 * @param expected {Array} meaning of 4 values in array -> [ elementTop, elementLeft, documentTop, documentLeft ]
+		 */
+		assertAllScrolls: function( element, doc, expected ) {
+			this.assertBothScrolls( { left: expected[ 1 ], top: expected[ 0 ] }, element.getScrollPosition(), '`element.getScrollPosition` should return equal values' );
+			this.assertBothScrolls( { left: expected[ 3 ], top: expected[ 2 ] }, doc.getScrollPosition(), '`document.getScrollPosition` should return equal values' );
+			this.assertBothScrolls( { left: expected[ 3 ], top: expected[ 2 ] }, element.getDocumentScrollPosition(), '`element.getDocumentScrollPosition` should return equal values' );
+		}
+	};
+
 	bender.editor = true;
 	bender.test( {
-		_assertBothScrolls: function( expected, actual ) {
-			assert.areSame( expected.x, actual.scrollLeft );
-			assert.areSame( expected.y, actual.scrollTop );
-		},
+		'test getScroll and getDocumentScroll for element and document': function() {
+			var element = new CKEDITOR.dom.element( document.getElementById( 'small' ) ),
+				doc = element.getDocument(),
+				docScrollElement = doc.$.scrollingElement || doc.$.documentElement || doc.$.body;
 
-		'test getDocumentScrollPosition': function() {
-			var element = document.getElementById( 'small' ),
-				ckEl = new CKEDITOR.dom.element( element ),
-				doc,
-				docEl;
-			// Reset position with native methods
-			doc = ckEl.getDocument();
-			docEl = doc.$.scrollingElement || doc.$.documentElement || doc.$.body;
-			docEl.scrollTop = 0;
-			docEl.scrollLeft = 0;
-			ckEl.$.scrollTop = 0;
-			ckEl.$.scrollLeft = 0;
-
-			// document no-scroll, element no-scroll
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
+			helpers.resetScrolls( element.$ );
+			helpers.resetScrolls( docScrollElement );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 
 			// document no-scroll, element scroll
-			ckEl.$.scrollTop = 123;
-			ckEl.$.scrollLeft = 123;
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
+			helpers.setNativeScroll( element.$, 100, 100 );
+			helpers.assertAllScrolls( element, doc, [ 100, 100, 0, 0 ] );
 
 			// document scroll, element scroll
-			docEl.scrollTop = 20;
-			docEl.scrollLeft = 20;
-			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScrollPosition() );
+			helpers.setNativeScroll( docScrollElement, 50, 50 );
+			helpers.assertAllScrolls( element, doc, [ 100, 100, 50, 50 ] );
 
 			// document scroll, element no-scroll
-			ckEl.$.scrollTop = 0;
-			ckEl.$.scrollLeft = 0;
-			this._assertBothScrolls( { x: 20, y: 20 }, ckEl.getDocumentScrollPosition() );
-		},
-
-		'test getScrollPosition': function() {
-			var element = document.getElementById( 'small' ),
-				ckEl = new CKEDITOR.dom.element( element ),
-				doc,
-				docEl;
-
-			// Reset position with native methods
-			doc = ckEl.getDocument();
-			docEl = doc.$.scrollingElement || doc.$.documentElement || doc.$.body;
-			docEl.scrollTop = 0;
-			docEl.scrollLeft = 0;
-			ckEl.$.scrollTop = 0;
-			ckEl.$.scrollLeft = 0;
-
-			// document no-scroll, element no-scroll
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
-
-			// document no-scroll, element scroll
-			ckEl.$.scrollTop = 321;
-			ckEl.$.scrollLeft = 321;
-			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScrollPosition() );
-
-			// document scroll, element scroll
-			docEl.scrollTop = 20;
-			docEl.scrollLeft = 20;
-			this._assertBothScrolls( { x: 321, y: 321 }, ckEl.getScrollPosition() );
+			helpers.setNativeScroll( element.$, 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 50, 50 ] );
 
 			// document scroll, element no-scroll
-			ckEl.$.scrollTop = 0;
-			ckEl.$.scrollLeft = 0;
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
+			helpers.setNativeScroll( docScrollElement, 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
+
 		},
 
-		'test setDocumentScrollPosition': function() {
-			var element = document.getElementById( 'small' ),
-				ckEl = new CKEDITOR.dom.element( element );
+		'test setScrollPosition for element': function() {
+			var element = new CKEDITOR.dom.element( document.getElementById( 'small' ) ),
+				doc = element.getDocument();
 
-			ckEl.setDocumentScrollPosition( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
+			helpers.resetScrolls( doc.$.scrollingElement || doc.$.documentElement || doc.$.body );
 
-			ckEl.setDocumentScrollPosition( 100 );
-			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getDocumentScrollPosition() );
+			element.setScrollPosition( 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 
-			ckEl.setDocumentScrollPosition( 123, 23 );
-			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getDocumentScrollPosition() );
+			element.setScrollPosition( 111, 222 );
+			helpers.assertAllScrolls( element, doc, [ 111, 222, 0, 0 ] );
 
-			ckEl.setDocumentScrollPosition( 0 );
-			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getDocumentScrollPosition() );
+			element.setScrollPosition( 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 222, 0, 0 ] );
 
-			ckEl.setDocumentScrollPosition( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getDocumentScrollPosition() );
+			element.setScrollPosition( 123 );
+			helpers.assertAllScrolls( element, doc, [ 123, 222, 0, 0 ] );
+
+			element.setScrollPosition( 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 		},
 
-		'test setScrollPosition': function() {
-			var element = document.getElementById( 'small' ),
-				ckEl = new CKEDITOR.dom.element( element );
+		'test setScrollPosition for document': function() {
+			var element = new CKEDITOR.dom.element( document.getElementById( 'small' ) ),
+				doc = element.getDocument();
 
-			ckEl.setScrollPosition( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
+			helpers.resetScrolls( element.$ );
 
-			ckEl.setScrollPosition( 100 );
-			this._assertBothScrolls( { x: 0, y: 100 }, ckEl.getScrollPosition() );
+			doc.setScrollPosition( 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 
-			ckEl.setScrollPosition( 123, 23 );
-			this._assertBothScrolls( { x: 23, y: 123 }, ckEl.getScrollPosition() );
+			doc.setScrollPosition( 55, 77 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 55, 77 ] );
 
-			ckEl.setScrollPosition( 0 );
-			this._assertBothScrolls( { x: 23, y: 0 }, ckEl.getScrollPosition() );
+			doc.setScrollPosition( 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 77 ] );
 
-			ckEl.setScrollPosition( 0, 0 );
-			this._assertBothScrolls( { x: 0, y: 0 }, ckEl.getScrollPosition() );
+			doc.setScrollPosition( 33 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 33, 77 ] );
+
+			doc.setScrollPosition( 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
+
+		},
+
+		'test setDocumentScrollPosition for element': function() {
+			var element = new CKEDITOR.dom.element( document.getElementById( 'small' ) ),
+				doc = element.getDocument();
+
+			helpers.resetScrolls( element.$ );
+
+			element.setDocumentScrollPosition( 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
+
+			element.setDocumentScrollPosition( 87, 65 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 87, 65 ] );
+
+			element.setDocumentScrollPosition( 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 65 ] );
+
+			element.setDocumentScrollPosition( 43 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 43, 65 ] );
+
+			element.setDocumentScrollPosition( 0, 0 );
+			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 		}
 
 	} );

--- a/tests/core/dom/element/scrolls.js
+++ b/tests/core/dom/element/scrolls.js
@@ -23,7 +23,6 @@
 		assertAllScrolls: function( element, doc, expected ) {
 			this.assertBothScrolls( { left: expected[ 1 ], top: expected[ 0 ] }, element.getScrollPosition(), '`element.getScrollPosition` should return equal values' );
 			this.assertBothScrolls( { left: expected[ 3 ], top: expected[ 2 ] }, doc.getScrollPosition(), '`document.getScrollPosition` should return equal values' );
-			this.assertBothScrolls( { left: expected[ 3 ], top: expected[ 2 ] }, element.getDocumentScrollPosition(), '`element.getDocumentScrollPosition` should return equal values' );
 		}
 	};
 
@@ -99,28 +98,6 @@
 			doc.setScrollPosition( 0, 0 );
 			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 
-		},
-
-		'test setDocumentScrollPosition for element': function() {
-			var element = new CKEDITOR.dom.element( document.getElementById( 'small' ) ),
-				doc = element.getDocument();
-
-			helpers.resetScrolls( element.$ );
-
-			element.setDocumentScrollPosition( 0, 0 );
-			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
-
-			element.setDocumentScrollPosition( 87, 65 );
-			helpers.assertAllScrolls( element, doc, [ 0, 0, 87, 65 ] );
-
-			element.setDocumentScrollPosition( 0 );
-			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 65 ] );
-
-			element.setDocumentScrollPosition( 43 );
-			helpers.assertAllScrolls( element, doc, [ 0, 0, 43, 65 ] );
-
-			element.setDocumentScrollPosition( 0, 0 );
-			helpers.assertAllScrolls( element, doc, [ 0, 0, 0, 0 ] );
 		}
 
 	} );

--- a/tests/core/editable/manual/scrolleditable.html
+++ b/tests/core/editable/manual/scrolleditable.html
@@ -49,8 +49,8 @@
 				val = values2;
 			}
 			var editable = editor.editable();
-			editable.setEditableScroll( top, left );
-			var scroll = editable.getEditableScroll();
+			editable.setEditableScrollPosition( top, left );
+			var scroll = editable.getEditableScrollPosition();
 			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
 				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
 		}

--- a/tests/core/editable/manual/scrolleditable.html
+++ b/tests/core/editable/manual/scrolleditable.html
@@ -1,0 +1,67 @@
+<pre id="values1" style="min-width:100px;min-height:50px;background-color:lightgreen;">
+</pre>
+<textarea id="classic">
+		<div style="width:1000px;height:1000px;background-color:grey;" ></div>
+</textarea>
+<button id="id1">Scroll classic left-down</button>
+<button id="id2">Scroll classic right-down</button>
+<button id="id3">Scroll classic left-up</button>
+<button id="id4">Scroll classic right-up</button>
+<hr />
+<pre id="values2" style="min-width:100px;min-height:50px;background-color:lightgreen;">
+	</pre>
+<div id="divarea">
+	<div style="width:1000px;height:1000px;background-color:grey;" ></div>
+</div>
+<button id="id5">Scroll diveditor left-down</button>
+<button id="id6">Scroll diveditor right-down</button>
+<button id="id7">Scroll diveditor left-up</button>
+<button id="id8">Scroll diveditor right-up</button>
+<script>
+	var classic = CKEDITOR.replace( 'classic', {
+		width: 300,
+		height: 200,
+		extraAllowedContent: 'em[id]'
+	} );
+	var divarea = CKEDITOR.replace( 'divarea', {
+		width: 300,
+		height: 200,
+		extraPlugins: 'divarea',
+		extraAllowedContent: 'em[id]'
+	} );
+
+	var id1 = document.getElementById( 'id1' );
+	var id2 = document.getElementById( 'id2' );
+	var id3 = document.getElementById( 'id3' );
+	var id4 = document.getElementById( 'id4' );
+	var id5 = document.getElementById( 'id5' );
+	var id6 = document.getElementById( 'id6' );
+	var id7 = document.getElementById( 'id7' );
+	var id8 = document.getElementById( 'id8' );
+	var values1 = document.getElementById( 'values1' );
+	var values2 = document.getElementById( 'values2' );
+
+	var scrl = function( top, left, editor ) {
+		return function() {
+			if ( editor.name == 'classic' ) {
+				val = values1;
+			} else {
+				val = values2;
+			}
+			var editable = editor.editable();
+			editable.setEditableScroll( top, left );
+			var scroll = editable.getEditableScroll();
+			val.innerHTML = '<p>Scroll Top: ' + scroll.scrollTop + '</p>' +
+				'<p>Scroll Left: ' + scroll.scrollLeft + '</p>';
+		}
+	}
+
+	id1.onclick = scrl( 1000, 0, classic );
+	id2.onclick = scrl( 1000, 1000, classic );
+	id3.onclick = scrl( 0, 0, classic );
+	id4.onclick = scrl( 0, 1000, classic );
+	id5.onclick = scrl( 1000, 0, divarea );
+	id6.onclick = scrl( 1000, 1000, divarea );
+	id7.onclick = scrl( 0, 0, divarea );
+	id8.onclick = scrl( 0, 1000, divarea );
+</script>

--- a/tests/core/editable/manual/scrolleditable.html
+++ b/tests/core/editable/manual/scrolleditable.html
@@ -18,6 +18,10 @@
 <button id="id7">Scroll diveditor left-up</button>
 <button id="id8">Scroll diveditor right-up</button>
 <script>
+	// Upstream: https://bugs.webkit.org/show_bug.cgi?id=172854
+	if ( CKEDITOR.end.iOS ) {
+		bender.ignore();
+	}
 	var classic = CKEDITOR.replace( 'classic', {
 		width: 300,
 		height: 200,

--- a/tests/core/editable/manual/scrolleditable.html
+++ b/tests/core/editable/manual/scrolleditable.html
@@ -19,7 +19,7 @@
 <button id="id8">Scroll diveditor right-up</button>
 <script>
 	// Upstream: https://bugs.webkit.org/show_bug.cgi?id=172854
-	if ( CKEDITOR.end.iOS ) {
+	if ( CKEDITOR.env.iOS ) {
 		bender.ignore();
 	}
 	var classic = CKEDITOR.replace( 'classic', {

--- a/tests/core/editable/manual/scrolleditable.md
+++ b/tests/core/editable/manual/scrolleditable.md
@@ -1,7 +1,7 @@
-@bender-tags: 4.8.0, feature
+@bender-tags: 4.8.0, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
 
 ----
 
-Press bottom buttons and check if editor is scroleld properly.
+Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.

--- a/tests/core/editable/manual/scrolleditable.md
+++ b/tests/core/editable/manual/scrolleditable.md
@@ -1,0 +1,7 @@
+@bender-tags: 4.8.0, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
+
+----
+
+Press bottom buttons and check if editor is scroleld properly.

--- a/tests/core/editable/manual/scrolleditable.md
+++ b/tests/core/editable/manual/scrolleditable.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.8.0, bug
+@bender-tags: 4.8.1, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
 

--- a/tests/core/editable/manual/scrolleditable.md
+++ b/tests/core/editable/manual/scrolleditable.md
@@ -1,7 +1,8 @@
-@bender-tags: 4.8.1, bug
+@bender-tags: 4.10.0, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, undo, sourcearea, basicstyles, div
 
 ----
 
-Press bottom buttons and check if editor is scrolled properly. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.
+1. Press bottom buttons and check if editor is scrolled properly.
+2. Compare scroll position with values displayed above editor. Buttons should scroll editor to its edges.

--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -110,27 +110,5 @@ bender.test( {
 
 			assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
 		} );
-	},
-
-	'test scroll editable and focus': function() {
-		if ( !CKEDITOR.env.chrome ) {
-			assert.ignore();
-		}
-
-		var bot = this.editorBots.scrollable,
-			editable = this.editors.scrollable.editable();
-
-		bot.setData( '<p>Test</p><p>Test</p><p>Test</p><p>Test</p>' +
-			'<p>Test</p><p>Test</p><p>Test</p><p>Test</p>' +
-			'<p>Test</p><p>Test</p><p>Test</p><p>Test</p>' +
-			'<p>Test</p><p>Test</p><p>Test</p><p>Test</p>' +
-			'<p>Test</p><p>Test</p><p>Test</p><p>Test</p>', function() {
-			var scrollPos = 100;
-
-			editable.$.scrollTop = scrollPos;
-			editable.focus();
-
-			assert.areSame( scrollPos, editable.$.scrollTop );
-		} );
 	}
 } );

--- a/tests/core/editable/scrolls.html
+++ b/tests/core/editable/scrolls.html
@@ -1,0 +1,8 @@
+<style>
+	#inline {
+		width: 300px;
+		height: 300px;
+		overflow: auto;
+	}
+</style>
+<div id="inline" contenteditable="true"></div>

--- a/tests/core/editable/scrolls.js
+++ b/tests/core/editable/scrolls.js
@@ -23,13 +23,26 @@
 
 	var tests = {
 		'test getEditableScroll': function( editor ) {
-			var sel = bender.tools.selection.setWithHtml( editor, '<div style="width:4000px;height:4000px;border:1px solid blue;"></div><p style="margin-left:3800px">[selection]</p>' );
-			var editable = editor.editable();
+			var sel = bender.tools.selection.setWithHtml( editor, '<div style="width:4000px;height:4000px;border:1px solid blue;"></div><p style="margin-left:3800px">[selection]</p>' ),
+				editable = editor.editable(),
+				doc,
+				docEl;
+
+			// IE automatically scrolls to selection, we need to reset that.
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+				doc = editable.getDocument();
+				docEl = doc.$.documentElement || doc.$.body;
+				docEl.scrollTop = 0;
+				docEl.scrollLeft = 0;
+				editable.$.scrollTop = 0;
+				editable.$.scrollLeft = 0;
+			}
 
 			assert.areSame( 0, editable.getEditableScroll( true ) );
 			assert.areSame( 0, editable.getEditableScroll().scrollTop );
 			assert.areSame( 0, editable.getEditableScroll().scrollLeft );
 
+			// Usage of some good working old method.
 			sel.scrollIntoView();
 
 			assert.areNotSame( 0, editable.getEditableScroll( true ) );

--- a/tests/core/editable/scrolls.js
+++ b/tests/core/editable/scrolls.js
@@ -1,0 +1,60 @@
+( function() {
+	'use strict';
+
+	bender.editors = {
+		divarea: {
+			creator: 'replace',
+			name: 'divarea',
+			config: {
+				extraPlugins: 'divarea',
+				height: 300,
+				width: 300
+			}
+		},
+		classic: {
+			creator: 'replace',
+			name: 'classic',
+			config: {
+				height: 300,
+				width: 300
+			}
+		}
+	};
+
+	var tests = {
+		'test getEditableScroll': function( editor ) {
+			var sel = bender.tools.selection.setWithHtml( editor, '<div style="width:4000px;height:4000px;border:1px solid blue;"></div><p style="margin-left:3800px">[selection]</p>' );
+			var editable = editor.editable();
+
+			assert.areSame( 0, editable.getEditableScroll( true ) );
+			assert.areSame( 0, editable.getEditableScroll().scrollTop );
+			assert.areSame( 0, editable.getEditableScroll().scrollLeft );
+
+			sel.scrollIntoView();
+
+			assert.areNotSame( 0, editable.getEditableScroll( true ) );
+			assert.areNotSame( 0, editable.getEditableScroll().scrollTop );
+			assert.areNotSame( 0, editable.getEditableScroll().scrollLeft );
+		},
+
+		'test setEditableScroll': function( editor ) {
+			bender.tools.selection.setWithHtml( editor, '<div style="width:2000px;height:4000px;border:1px solid blue;"></div>' );
+			var editable = editor.editable();
+
+			editable.setEditableScroll( 0, 0 );
+
+			assert.areSame( 0, editable.getEditableScroll( true ) );
+			assert.areSame( 0, editable.getEditableScroll().scrollTop );
+			assert.areSame( 0, editable.getEditableScroll().scrollLeft );
+
+
+			editable.setEditableScroll( 10, 9 );
+			assert.areSame( 10, editable.getEditableScroll( true ) );
+			assert.areSame( 10, editable.getEditableScroll().scrollTop );
+			assert.areSame( 9, editable.getEditableScroll().scrollLeft );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.objectKeys( bender.editors ), tests );
+	bender.test( tests );
+} )();

--- a/tests/core/editable/scrolls.js
+++ b/tests/core/editable/scrolls.js
@@ -22,7 +22,7 @@
 	};
 
 	var tests = {
-		'test getEditableScroll': function( editor ) {
+		'test getEditableScrollPosition': function( editor ) {
 			var sel = bender.tools.selection.setWithHtml( editor, '<div style="width:4000px;height:4000px;border:1px solid blue;"></div><p style="margin-left:3800px">[selection]</p>' ),
 				editable = editor.editable(),
 				doc,
@@ -38,33 +38,29 @@
 				editable.$.scrollLeft = 0;
 			}
 
-			assert.areSame( 0, editable.getEditableScroll( true ) );
-			assert.areSame( 0, editable.getEditableScroll().scrollTop );
-			assert.areSame( 0, editable.getEditableScroll().scrollLeft );
+			assert.areSame( 0, editable.getEditableScrollPosition().scrollTop );
+			assert.areSame( 0, editable.getEditableScrollPosition().scrollLeft );
 
 			// Usage of some good working old method.
 			sel.scrollIntoView();
 
-			assert.areNotSame( 0, editable.getEditableScroll( true ) );
-			assert.areNotSame( 0, editable.getEditableScroll().scrollTop );
-			assert.areNotSame( 0, editable.getEditableScroll().scrollLeft );
+			assert.areNotSame( 0, editable.getEditableScrollPosition().scrollTop );
+			assert.areNotSame( 0, editable.getEditableScrollPosition().scrollLeft );
 		},
 
-		'test setEditableScroll': function( editor ) {
+		'test setEditableScrollPosition': function( editor ) {
 			bender.tools.selection.setWithHtml( editor, '<div style="width:2000px;height:4000px;border:1px solid blue;"></div>' );
 			var editable = editor.editable();
 
-			editable.setEditableScroll( 0, 0 );
+			editable.setEditableScrollPosition( 0, 0 );
 
-			assert.areSame( 0, editable.getEditableScroll( true ) );
-			assert.areSame( 0, editable.getEditableScroll().scrollTop );
-			assert.areSame( 0, editable.getEditableScroll().scrollLeft );
+			assert.areSame( 0, editable.getEditableScrollPosition().scrollTop );
+			assert.areSame( 0, editable.getEditableScrollPosition().scrollLeft );
 
 
-			editable.setEditableScroll( 10, 9 );
-			assert.areSame( 10, editable.getEditableScroll( true ) );
-			assert.areSame( 10, editable.getEditableScroll().scrollTop );
-			assert.areSame( 9, editable.getEditableScroll().scrollLeft );
+			editable.setEditableScrollPosition( 10, 9 );
+			assert.areSame( 10, editable.getEditableScrollPosition().scrollTop );
+			assert.areSame( 9, editable.getEditableScrollPosition().scrollLeft );
 		}
 	};
 

--- a/tests/core/editable/scrolls.js
+++ b/tests/core/editable/scrolls.js
@@ -31,6 +31,11 @@
 
 	var tests = {
 		'test getEditableScrollPosition': function( editor ) {
+			// iOS cannot scroll iframe content.
+			// Upstream: https://bugs.webkit.org/show_bug.cgi?id=172854
+			if ( CKEDITOR.env.iOS ) {
+				assert.ignore();
+			}
 			var sel = bender.tools.selection.setWithHtml( editor, '<div style="width:4000px;height:4000px;border:1px solid blue;"></div><p style="margin-left:3800px">[selection]</p>' ),
 				editable = editor.editable(),
 				doc,
@@ -57,6 +62,11 @@
 		},
 
 		'test setEditableScrollPosition': function( editor ) {
+			// iOS cannot scroll iframe content.
+			// Upstream: https://bugs.webkit.org/show_bug.cgi?id=172854
+			if ( CKEDITOR.env.iOS ) {
+				assert.ignore();
+			}
 			bender.tools.selection.setWithHtml( editor, '<div style="width:2000px;height:4000px;border:1px solid blue;"></div>' );
 			var editable = editor.editable();
 

--- a/tests/core/editable/scrolls.js
+++ b/tests/core/editable/scrolls.js
@@ -18,6 +18,14 @@
 				height: 300,
 				width: 300
 			}
+		},
+		inline: {
+			creator: 'inline',
+			name: 'inline',
+			config: {
+				height: 300,
+				width: 300
+			}
 		}
 	};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?
yes

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

- Add bunch of new methods to API, which set and get scroll of element, document and editable.
- Add method to get scrollingElement from document.
- Change most of the methods where `scrollTop` from document was read by using native methods.
- remove failing test, which is not needed any longer. Test reproduce this part of the code: https://github.com/ckeditor/ckeditor-dev/blob/dee99e283ce259f8e16f1092e3d7613a5e45a499/core/editable.js#L92-L98 This code now look different, so test is no longer needed.

Close #895 #910 