### PR TITLE
Register commands automatically if toolbar plugin is not present

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -771,6 +771,11 @@
 			if ( this.mode )
 				updateCommand( this, cmd );
 
+			// If there is no toolbar loaded, automatically add feature to the editor (#678).
+			if ( !this.plugins.toolbar ) {
+				this.addFeature( cmd );
+			}
+
 			return this.commands[ commandName ] = cmd;
 		},
 

--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -371,5 +371,41 @@ bender.test( {
 
 			assert.isTrue( bot.editor.execCommand( 'link' ) );
 		} );
+	},
+
+	// #678
+	'test addCommand without toolbar plugin invokes addFeature': function() {
+		bender.editorBot.create( {
+			name: 'test_editor_notoolbar2',
+			config: {
+				plugins: 'wysiwygarea'
+			}
+		}, function( bot ) {
+			var editor = bot.editor,
+				spy = sinon.spy( editor, 'addFeature' );
+
+			editor.addCommand( 'testCommand', {} );
+
+			assert.isTrue( spy.calledOnce );
+			spy.restore();
+		} );
+	},
+
+	// #678
+	'test addCommand with toolbar plugin does not invoke addFeature': function() {
+		bender.editorBot.create( {
+			name: 'test_editor_notoolbar3',
+			config: {
+				plugins: 'wysiwygarea,toolbar'
+			}
+		}, function( bot ) {
+			var editor = bot.editor,
+				spy = sinon.spy( editor, 'addFeature' );
+
+			editor.addCommand( 'testCommand', {} );
+
+			assert.areSame( 0, spy.callCount );
+			spy.restore();
+		} );
 	}
 } );

--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -349,5 +349,27 @@ bender.test( {
 			cmd = new subCommand( editor, commandDefinition );
 
 		assertCommand( editor, cmd, commandDefinition );
+	},
+
+	// #678
+	'test execCommand without toolbar plugin': function() {
+		bender.editorBot.create( {
+			name: 'test_editor_notoolbar',
+			config: {
+				plugins: 'wysiwygarea,link'
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			editor.once( 'dialogShow', function( evt ) {
+				var dialog = evt.data;
+
+				if ( dialog._.name === 'link' ) {
+					dialog.hide();
+				}
+			} );
+
+			assert.isTrue( bot.editor.execCommand( 'link' ) );
+		} );
 	}
 } );

--- a/tests/core/command/manual/notoolbar.html
+++ b/tests/core/command/manual/notoolbar.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Just simple text</p>
+</div>
+
+<script>
+CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/command/manual/notoolbar.md
+++ b/tests/core/command/manual/notoolbar.md
@@ -1,0 +1,14 @@
+@bender-tags: bug, 4.8.0, 678
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, link
+
+1. Select some text inside the editor.
+2. Press <kbd>Ctrl</kbd> + <kbd>L</kbd>.
+
+## Expected
+
+Link dialog is opened.
+
+## Unexpected
+
+Nothing happens.

--- a/tests/core/filter/editor.js
+++ b/tests/core/filter/editor.js
@@ -201,8 +201,8 @@
 					allowedContent: 'b'
 				} );
 
+				// We do not add testcommand as it's automatically added by `editor.addCommand` (#678).
 				editor.addFeature( editor.ui.items.testButton );
-				editor.addFeature( editor.getCommand( 'testCommand' ) );
 
 				var allowed = editor.filter.allowedContent;
 
@@ -213,11 +213,11 @@
 
 				assert.areSame( 'editorbot', allowed[ 1 ].featureName );
 
-				assert.areSame( 'testbutton', allowed[ 2 ].featureName );
-				assert.isTrue( CKEDITOR.tools.objectCompare( { a: true }, allowed[ 2 ].elements ) );
+				assert.areSame( 'testcommand', allowed[ 2 ].featureName );
+				assert.isTrue( CKEDITOR.tools.objectCompare( { b: true }, allowed[ 2 ].elements ) );
 
-				assert.areSame( 'testcommand', allowed[ 3 ].featureName );
-				assert.isTrue( CKEDITOR.tools.objectCompare( { b: true }, allowed[ 3 ].elements ) );
+				assert.areSame( 'testbutton', allowed[ 3 ].featureName );
+				assert.isTrue( CKEDITOR.tools.objectCompare( { a: true }, allowed[ 3 ].elements ) );
 			} );
 		},
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](http://docs.ckeditor.com/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](http://docs.ckeditor.com/#!/guide/dev_tests) and
[how to create tests](http://docs.ckeditor.com/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added `if` statement into `editor.addCommand`, which checks if `toolbar` plugin is loaded. If not, then `editor.addFeature` method is invoked to perform actual command registration. It's very naive approach, but seems to be working and all tests are passing (however one had to modified to reflect the fact that suddenly commands are registered automatically).

Closes #678
