### PR TITLE
 Fixed: Dropdowns does not show hover state inside balloon toolbar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#2721](https://github.com/ckeditor/ckeditor-dev/issues/2721): Fixed: Sublist items are reversed when higher level list item is removed.
 * [#2527](https://github.com/ckeditor/ckeditor-dev/issues/2527): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) autocomplete order now prioritize emojis with name started from used string.
+* [#1268](https://github.com/ckeditor/ckeditor-dev/issues/1268): Fixed: Dropdown doesn't show hover state inside [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar).
 
 ## CKEditor 4.11.2
 
@@ -231,7 +232,6 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
-* [#1268](https://github.com/ckeditor/ckeditor-dev/issues/1268): Fixed: Dropdown doesn't show hover state inside balloon toolbar.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Fixed Issues:
 * [#2527](https://github.com/ckeditor/ckeditor-dev/issues/2527): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) autocomplete order now prioritize emojis with name started from used string.
 * [#1268](https://github.com/ckeditor/ckeditor-dev/issues/1268): Fixed: Dropdown doesn't show hover state inside [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar).
 
+API Changes:
+
+* [#1268](https://github.com/ckeditor/ckeditor-dev/issues/1268): Exposed the [`CKEDITOR.ui.richCombo.updateState`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-updateState) method.
+
 ## CKEditor 4.11.2
 
 Fixed Issues:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -231,6 +231,7 @@ Fixed Issues:
 * [#1516](https://github.com/ckeditor/ckeditor-dev/issues/1516): Fixed: Fake selection allows removing content in read-only mode using the <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 * [#1570](https://github.com/ckeditor/ckeditor-dev/issues/1570): Fixed: Fake selection allows cutting content in read-only mode using the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>X</kbd> keys.
 * [#1363](https://github.com/ckeditor/ckeditor-dev/issues/1363): Fixed: Paste notification is unclear and it might confuse users.
+* [#1268](https://github.com/ckeditor/ckeditor-dev/issues/1268): Fixed: Dropdown doesn't show hover state inside balloon toolbar.
 
 API Changes:
 

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -794,11 +794,10 @@
 					element.setAttribute( 'draggable', 'false' );
 					this.registerFocusable( element );
 				}, this );
-
 				// We need to initially set status of richCombo items.
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 						if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
-							this._updateStatus( items[ itemKey ] );
+							( items[ itemKey ] ).updateState( editor );
 						}
 					}, this );
 			};

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -767,7 +767,7 @@
 					element.setAttribute( 'draggable', 'false' );
 					this.registerFocusable( element );
 				}, this );
-				// We need to initially set status of richCombo items #1268.
+				// We need to initially set status of richCombo items (#1268).
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 					if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
 						( items[ itemKey ] ).updateState( editor );

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -730,7 +730,7 @@
 			/**
 			 * Updates status of passed element.
 			 *
-			 * @param {CKEDITOR.ui.richCombo} item which is instace of richCombo.
+			 * @param {CKEDITOR.ui.button/CKEDITOR.ui.richCombo} item which is instace of richCombo.
 			 * @since 4.9.0
 			 * @private
 			 * @member CKEDITOR.ui.balloonToolbarView

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -770,7 +770,7 @@
 				// We need to initially set status of richCombo items (#1268).
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 					if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
-						( items[ itemKey ] ).updateState( editor );
+						items[ itemKey ].updateState( editor );
 					}
 				}, this );
 			};

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -730,14 +730,15 @@
 			/**
 			 * Updates status of passed element.
 			 *
-			 * @param {CKEDITOR.ui.button/CKEDITOR.ui.richCombo} item which is instace of richCombo.
 			 * @since 4.9.0
 			 * @private
+			 * @param {CKEDITOR.ui.button/CKEDITOR.ui.richCombo}
 			 * @member CKEDITOR.ui.balloonToolbarView
 			 */
 			CKEDITOR.ui.balloonToolbarView.prototype._updateStatus = function( item ) {
-				if ( item.getState() == CKEDITOR.TRISTATE_ON )
+				if ( item.getState() == CKEDITOR.TRISTATE_ON ) {
 					return;
+				}
 
 				var state = item.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
 
@@ -761,8 +762,7 @@
 			CKEDITOR.ui.balloonToolbarView.prototype.renderItems = function( items ) {
 				var output = [],
 					keys = CKEDITOR.tools.objectKeys( items ),
-					groupStarted = false,
-					_this = this;
+					groupStarted = false;
 
 				// When we rerender toolbar we want to clear focusable in case of removing some items.
 				this._deregisterItemFocusables();
@@ -798,9 +798,9 @@
 				// We need to initially set status of richCombo items.
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 						if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
-							_this._updateStatus( items[ itemKey ] );
+							this._updateStatus( items[ itemKey ] );
 						}
-					} );
+					}, this );
 			};
 
 			/**

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -768,11 +768,13 @@
 					this.registerFocusable( element );
 				}, this );
 				// We need to initially set status of richCombo items (#1268).
-				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
-					if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
-						items[ itemKey ].updateState( editor );
-					}
-				}, this );
+				if ( CKEDITOR.ui.richCombo ) {
+					CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
+						if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
+							items[ itemKey ].updateState( editor );
+						}
+					}, this );
+				}
 			};
 
 			/**

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -728,32 +728,6 @@
 			};
 
 			/**
-			 * Updates status of passed element.
-			 *
-			 * @since 4.9.0
-			 * @private
-			 * @param {CKEDITOR.ui.button/CKEDITOR.ui.richCombo}
-			 * @member CKEDITOR.ui.balloonToolbarView
-			 */
-			CKEDITOR.ui.balloonToolbarView.prototype._updateStatus = function( item ) {
-				if ( item.getState() == CKEDITOR.TRISTATE_ON ) {
-					return;
-				}
-
-				var state = item.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
-
-				if ( editor.readOnly && !item.readOnly )
-					state = CKEDITOR.TRISTATE_DISABLED;
-
-				item.setState( state );
-				item.setValue( '' );
-
-				// Let plugin to disable button.
-				if ( state != CKEDITOR.TRISTATE_DISABLED && item.refresh )
-					item.refresh();
-			};
-
-			/**
 			 * Renders provided UI elements inside the view.
 			 *
 			 * @param {CKEDITOR.ui.button[]/CKEDITOR.ui.richCombo[]} items An array of UI element objects.

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -728,6 +728,31 @@
 			};
 
 			/**
+			 * Updates status of passed element.
+			 *
+			 * @param {CKEDITOR.ui.richCombo} item which is instace of richCombo.
+			 * @since 4.9.0
+			 * @private
+			 * @member CKEDITOR.ui.balloonToolbarView
+			 */
+			CKEDITOR.ui.balloonToolbarView.prototype._updateStatus = function( item ) {
+				if ( item.getState() == CKEDITOR.TRISTATE_ON )
+					return;
+
+				var state = item.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
+
+				if ( editor.readOnly && !item.readOnly )
+					state = CKEDITOR.TRISTATE_DISABLED;
+
+				item.setState( state );
+				item.setValue( '' );
+
+				// Let plugin to disable button.
+				if ( state != CKEDITOR.TRISTATE_DISABLED && item.refresh )
+					item.refresh();
+			};
+
+			/**
 			 * Renders provided UI elements inside the view.
 			 *
 			 * @param {CKEDITOR.ui.button[]/CKEDITOR.ui.richCombo[]} items An array of UI element objects.
@@ -736,7 +761,8 @@
 			CKEDITOR.ui.balloonToolbarView.prototype.renderItems = function( items ) {
 				var output = [],
 					keys = CKEDITOR.tools.objectKeys( items ),
-					groupStarted = false;
+					groupStarted = false,
+					_this = this;
 
 				// When we rerender toolbar we want to clear focusable in case of removing some items.
 				this._deregisterItemFocusables();
@@ -763,10 +789,18 @@
 
 				this.parts.content.setHtml( output.join( '' ) );
 				this.parts.content.unselectable();
+
 				CKEDITOR.tools.array.forEach( this.parts.content.find( 'a' ).toArray(), function( element ) {
 					element.setAttribute( 'draggable', 'false' );
 					this.registerFocusable( element );
 				}, this );
+
+				// We need to initially set status of richCombo items.
+				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
+						if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
+							_this._updateStatus( items[ itemKey ] );
+						}
+					} );
 			};
 
 			/**

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -767,7 +767,7 @@
 					element.setAttribute( 'draggable', 'false' );
 					this.registerFocusable( element );
 				}, this );
-				// We need to initially set status of richCombo items.
+				// We need to initially set status of richCombo items #1268.
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
 					if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
 						( items[ itemKey ] ).updateState( editor );

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -789,17 +789,16 @@
 
 				this.parts.content.setHtml( output.join( '' ) );
 				this.parts.content.unselectable();
-
 				CKEDITOR.tools.array.forEach( this.parts.content.find( 'a' ).toArray(), function( element ) {
 					element.setAttribute( 'draggable', 'false' );
 					this.registerFocusable( element );
 				}, this );
 				// We need to initially set status of richCombo items.
 				CKEDITOR.tools.array.forEach( keys, function( itemKey ) {
-						if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
-							( items[ itemKey ] ).updateState( editor );
-						}
-					}, this );
+					if ( CKEDITOR.ui.richCombo && items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
+						( items[ itemKey ] ).updateState( editor );
+					}
+				}, this );
 			};
 
 			/**

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -773,7 +773,7 @@
 						if ( items[ itemKey ] instanceof CKEDITOR.ui.richCombo ) {
 							items[ itemKey ].updateState( editor );
 						}
-					}, this );
+					} );
 				}
 			};
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -109,7 +109,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Updates state of the combo.
 			 *
-			 * @since 4.11.0
+			 * @since 4.11.2
 			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo is to be used by.
 			 */
 			updateState: function( editor ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -114,19 +114,23 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 */
 			updateState: function( editor ) {
 				// Don't change state while richcombo is active (https://dev.ckeditor.com/ticket/11793).
-				if ( this.getState() == CKEDITOR.TRISTATE_ON )
+				if ( this.getState() == CKEDITOR.TRISTATE_ON ) {
 					return;
+				}
 
 				var state = this.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
 
-				if ( editor.readOnly && !this.readOnly )
+				if ( editor.readOnly && !this.readOnly ) {
 					state = CKEDITOR.TRISTATE_DISABLED;
+				}
 
 				this.setState( state );
 				this.setValue( '' );
+
 				// Let plugin to disable button.
-				if ( state != CKEDITOR.TRISTATE_DISABLED && this.refresh )
+				if ( state != CKEDITOR.TRISTATE_DISABLED && this.refresh ) {
 					this.refresh();
+				}
 			},
 			/**
 			 * Renders the combo.

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -109,9 +109,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Updates state of the combo.
 			 *
-			 * @since 4.9.0
-			 * @param {CKEDITOR.editor} editor The editor instance which this button is
-			 * to be used by.
+			 * @since 4.9.1
+			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo instance.
 			 */
 			updateState: function( editor ) {
 				// Don't change state while richcombo is active (https://dev.ckeditor.com/ticket/11793).

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -109,7 +109,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Updates state of the combo.
 			 *
-			 * @since 4.9.1
+			 * @since 4.10.2
 			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo instance.
 			 */
 			updateState: function( editor ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -187,11 +187,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 				};
 
 				// Update status when activeFilter, mode, selection or readOnly changes.
-				this._.listeners.push( editor.on( 'activeFilterChange', this.updateState, this ) );
-				this._.listeners.push( editor.on( 'mode', this.updateState, this ) );
-				this._.listeners.push( editor.on( 'selectionChange', this.updateState, this ) );
+				this._.listeners.push( editor.on( 'activeFilterChange', updateState, this ) );
+				this._.listeners.push( editor.on( 'mode', updateState, this ) );
+				this._.listeners.push( editor.on( 'selectionChange', updateState, this ) );
 				// If this combo is sensitive to readOnly state, update it accordingly.
-				!this.readOnly && this._.listeners.push( editor.on( 'readOnly', this.updateState, this ) );
+				!this.readOnly && this._.listeners.push( editor.on( 'readOnly', updateState, this ) );
 
 				var keyDownFn = CKEDITOR.tools.addFunction( function( ev, element ) {
 					ev = new CKEDITOR.dom.event( ev );

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -110,7 +110,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * Updates state of the combo.
 			 *
 			 * @since 4.11.2
-			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo is to be used by.
+			 * @param {CKEDITOR.editor} editor The editor instance, which owns this rich combo.
 			 */
 			updateState: function( editor ) {
 				// Don't change state while richcombo is active (https://dev.ckeditor.com/ticket/11793).

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -109,7 +109,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Updates state of the combo.
 			 *
-			 * @since 4.10.2
+			 * @since 4.11.0
 			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo instance.
 			 */
 			updateState: function( editor ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -110,7 +110,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * Updates state of the combo.
 			 *
 			 * @since 4.11.0
-			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo instance.
+			 * @param {CKEDITOR.editor} editor The editor instance which this rich combo is to be used by.
 			 */
 			updateState: function( editor ) {
 				// Don't change state while richcombo is active (https://dev.ckeditor.com/ticket/11793).

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -237,6 +237,10 @@ CKEDITOR.plugins.add( 'richcombo', {
 					this.onRender();
 
 				return instance;
+
+				function updateState( evt ) {
+					this.updateState( evt.editor );
+				}
 			},
 
 			createPanel: function( editor ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -107,7 +107,30 @@ CKEDITOR.plugins.add( 'richcombo', {
 			},
 
 			/**
-			 * Renders the rich combo.
+			 * Updates state of the combo.
+			 *
+			 * @since 4.9.0
+			 * @param {CKEDITOR.editor} editor The editor instance which this button is
+			 * to be used by.
+			 */
+			updateState: function( editor ) {
+				// Don't change state while richcombo is active (https://dev.ckeditor.com/ticket/11793).
+				if ( this.getState() == CKEDITOR.TRISTATE_ON )
+					return;
+
+				var state = this.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
+
+				if ( editor.readOnly && !this.readOnly )
+					state = CKEDITOR.TRISTATE_DISABLED;
+
+				this.setState( state );
+				this.setValue( '' );
+				// Let plugin to disable button.
+				if ( state != CKEDITOR.TRISTATE_DISABLED && this.refresh )
+					this.refresh();
+			},
+			/**
+			 * Renders the combo.
 			 *
 			 * @param {CKEDITOR.editor} editor The editor instance which this button is
 			 * to be used by.
@@ -160,30 +183,12 @@ CKEDITOR.plugins.add( 'richcombo', {
 					clickFn: clickFn
 				};
 
-				function updateState() {
-					// Don't change state while richcombo is active (https://dev.ckeditor.com/ticket/11793).
-					if ( this.getState() == CKEDITOR.TRISTATE_ON )
-						return;
-
-					var state = this.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED;
-
-					if ( editor.readOnly && !this.readOnly )
-						state = CKEDITOR.TRISTATE_DISABLED;
-
-					this.setState( state );
-					this.setValue( '' );
-
-					// Let plugin to disable button.
-					if ( state != CKEDITOR.TRISTATE_DISABLED && this.refresh )
-						this.refresh();
-				}
-
 				// Update status when activeFilter, mode, selection or readOnly changes.
-				this._.listeners.push( editor.on( 'activeFilterChange', updateState, this ) );
-				this._.listeners.push( editor.on( 'mode', updateState, this ) );
-				this._.listeners.push( editor.on( 'selectionChange', updateState, this ) );
+				this._.listeners.push( editor.on( 'activeFilterChange', this.updateState, this ) );
+				this._.listeners.push( editor.on( 'mode', this.updateState, this ) );
+				this._.listeners.push( editor.on( 'selectionChange', this.updateState, this ) );
 				// If this combo is sensitive to readOnly state, update it accordingly.
-				!this.readOnly && this._.listeners.push( editor.on( 'readOnly', updateState, this ) );
+				!this.readOnly && this._.listeners.push( editor.on( 'readOnly', this.updateState, this ) );
 
 				var keyDownFn = CKEDITOR.tools.addFunction( function( ev, element ) {
 					ev = new CKEDITOR.dom.event( ev );

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -109,7 +109,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Updates state of the combo.
 			 *
-			 * @since 4.11.2
+			 * @since 4.11.3
 			 * @param {CKEDITOR.editor} editor The editor instance, which owns this rich combo.
 			 */
 			updateState: function( editor ) {

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -1,5 +1,5 @@
-/* bender-tags: balloontoolbar */
-/* bender-ckeditor-plugins: balloontoolbar, richcombo, toolbar, button, stylescombo */
+/* bender-tags: balloontoolbar, 1268 */
+/* bender-ckeditor-plugins: balloontoolbar, toolbar, stylescombo */
 
 
 ( function() {

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -8,12 +8,11 @@
 	bender.editor = {};
 
 	var tests = {
-		init: function() {
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 || bender.tools.env.mobile ) {
-				bender.ignore();
-			}
-		},
 		'test stylescombo state': function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 || bender.tools.env.mobile ) {
+				assert.ignore();
+			}
+
 			var editor = this.editor,
 				panel,
 				comboButton;

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -33,7 +33,7 @@
 
 			// On Edge and IE the button element has 'onmouseup' instead of 'onclick' so calling `$.click()` will not work there.
 			if ( CKEDITOR.env.ie || CKEDITOR.env.edge ) {
-				CKEDITOR.tools.callFunction( 4, comboButton.$ );
+				comboButton.$.onmouseup();
 			} else {
 				comboButton.$.click();
 			}

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -5,13 +5,14 @@
 ( function() {
 	'use strict';
 
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
-		bender.ignore();
-	}
-
 	bender.editor = {};
 
 	var tests = {
+		init: function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 || bender.tools.env.mobile ) {
+				bender.ignore();
+			}
+		},
 		'test stylescombo state': function() {
 			var editor = this.editor,
 				panel,
@@ -27,11 +28,15 @@
 			} );
 			panel.attach( editor.editable() );
 			comboButton = panel._view.parts.content.findOne( '.cke_combo_button' );
-
 			assert.isNotNull( panel._view.parts.content.findOne( '.cke_combo_off' ) );
 			assert.isTrue( panel._items.Styles.getState() === 2 );
 
-			comboButton.$.click();
+			// On Edge and IE the button element has 'onmouseup' instead of 'onclick' so calling `$.click()` will not work there.
+			if ( CKEDITOR.env.ie || CKEDITOR.env.edge ) {
+				CKEDITOR.tools.callFunction( 4, comboButton.$ );
+			} else {
+				comboButton.$.click();
+			}
 			assert.isNotNull( panel._view.parts.content.findOne( '.cke_combo_on' ) );
 			assert.isTrue( panel._items.Styles.getState() === 1 );
 		}

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -1,0 +1,41 @@
+/* bender-tags: balloontoolbar */
+/* bender-ckeditor-plugins: balloontoolbar, richcombo, toolbar, button, stylescombo */
+
+
+( function() {
+	'use strict';
+
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
+	bender.editor = {};
+
+	var tests = {
+		'test stylescombo state': function() {
+			var editor = this.editor,
+				panel,
+				comboButton;
+			this.editorBot.setHtmlWithSelection( '<div><p>[Test]</p></div>' );
+			panel = new CKEDITOR.ui.balloonToolbar( this.editor, {
+				width: 'auto',
+				height: 40
+			} );
+
+			panel.addItems( {
+				Styles: editor.ui.create( 'Styles' )
+			} );
+			panel.attach( editor.editable() );
+			comboButton = panel._view.parts.content.findOne( '.cke_combo_button' );
+
+			assert.isNotNull( panel._view.parts.content.findOne( '.cke_combo_off' ) );
+			assert.isTrue( panel._items.Styles.getState() === 2 );
+
+			comboButton.$.click();
+			assert.isNotNull( panel._view.parts.content.findOne( '.cke_combo_on' ) );
+			assert.isTrue( panel._items.Styles.getState() === 1 );
+		}
+	};
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -14,13 +14,13 @@
 			}
 
 			var editor = this.editor,
-				balloonToolbar,
+				balloonToolbar = new CKEDITOR.ui.balloonToolbar( this.editor, {
+						width: 'auto',
+						height: 40
+					} ),
 				comboButton;
+
 			this.editorBot.setHtmlWithSelection( '<div><p>[Test]</p></div>' );
-			balloonToolbar = new CKEDITOR.ui.balloonToolbar( this.editor, {
-				width: 'auto',
-				height: 40
-			} );
 
 			balloonToolbar.addItems( {
 				Styles: editor.ui.create( 'Styles' )

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -27,7 +27,6 @@
 			} );
 			balloonToolbar.attach( editor.editable() );
 			comboButton = balloonToolbar._view.parts.content.findOne( '.cke_combo_button' );
-			assert.isNotNull( balloonToolbar._view.parts.content.findOne( '.cke_combo_off' ) );
 			assert.isTrue( balloonToolbar._items.Styles.getState() === 2 );
 
 			// On Edge and IE the button element has 'onmouseup' instead of 'onclick' so calling `$.click()` will not work there.
@@ -36,7 +35,6 @@
 			} else {
 				comboButton.$.click();
 			}
-			assert.isNotNull( balloonToolbar._view.parts.content.findOne( '.cke_combo_on' ) );
 			assert.isTrue( balloonToolbar._items.Styles.getState() === 1 );
 		}
 	};

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -30,11 +30,8 @@
 			assert.isTrue( balloonToolbar._items.Styles.getState() === 2 );
 
 			// On Edge and IE the button element has 'onmouseup' instead of 'onclick' so calling `$.click()` will not work there.
-			if ( CKEDITOR.env.ie || CKEDITOR.env.edge ) {
-				comboButton.$.onmouseup();
-			} else {
-				comboButton.$.click();
-			}
+			comboButton.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
+
 			assert.isTrue( balloonToolbar._items.Styles.getState() === 1 );
 		}
 	};

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -27,12 +27,12 @@
 			} );
 			balloonToolbar.attach( editor.editable() );
 			comboButton = balloonToolbar._view.parts.content.findOne( '.cke_combo_button' );
-			assert.isTrue( balloonToolbar._items.Styles.getState() === 2 );
+			assert.areSame( CKEDITOR.TRISTATE_OFF, balloonToolbar._items.Styles.getState(), 'State at the beginning' );
 
 			// On Edge and IE the button element has 'onmouseup' instead of 'onclick' so calling `$.click()` will not work there.
 			comboButton.$[ CKEDITOR.env.ie ? 'onmouseup' : 'onclick' ]();
 
-			assert.isTrue( balloonToolbar._items.Styles.getState() === 1 );
+			assert.areSame( CKEDITOR.TRISTATE_ON, balloonToolbar._items.Styles.getState(), 'State after opening' );
 		}
 	};
 

--- a/tests/plugins/balloontoolbar/combostate.js
+++ b/tests/plugins/balloontoolbar/combostate.js
@@ -14,21 +14,21 @@
 			}
 
 			var editor = this.editor,
-				panel,
+				balloonToolbar,
 				comboButton;
 			this.editorBot.setHtmlWithSelection( '<div><p>[Test]</p></div>' );
-			panel = new CKEDITOR.ui.balloonToolbar( this.editor, {
+			balloonToolbar = new CKEDITOR.ui.balloonToolbar( this.editor, {
 				width: 'auto',
 				height: 40
 			} );
 
-			panel.addItems( {
+			balloonToolbar.addItems( {
 				Styles: editor.ui.create( 'Styles' )
 			} );
-			panel.attach( editor.editable() );
-			comboButton = panel._view.parts.content.findOne( '.cke_combo_button' );
-			assert.isNotNull( panel._view.parts.content.findOne( '.cke_combo_off' ) );
-			assert.isTrue( panel._items.Styles.getState() === 2 );
+			balloonToolbar.attach( editor.editable() );
+			comboButton = balloonToolbar._view.parts.content.findOne( '.cke_combo_button' );
+			assert.isNotNull( balloonToolbar._view.parts.content.findOne( '.cke_combo_off' ) );
+			assert.isTrue( balloonToolbar._items.Styles.getState() === 2 );
 
 			// On Edge and IE the button element has 'onmouseup' instead of 'onclick' so calling `$.click()` will not work there.
 			if ( CKEDITOR.env.ie || CKEDITOR.env.edge ) {
@@ -36,8 +36,8 @@
 			} else {
 				comboButton.$.click();
 			}
-			assert.isNotNull( panel._view.parts.content.findOne( '.cke_combo_on' ) );
-			assert.isTrue( panel._items.Styles.getState() === 1 );
+			assert.isNotNull( balloonToolbar._view.parts.content.findOne( '.cke_combo_on' ) );
+			assert.isTrue( balloonToolbar._items.Styles.getState() === 1 );
 		}
 	};
 

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.html
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.html
@@ -1,0 +1,41 @@
+<textarea id="editor1" cols="10" rows="10">
+	<p>Some text</p>
+	<p><strong>Click on me</strong></p>
+</textarea>
+
+<script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+		bender.ignore();
+	}
+
+	function instanceReadyListener( evt ) {
+		var strong = this.editable().findOne( 'strong' ),
+			panel = new CKEDITOR.ui.balloonToolbar( this, {
+				width: 'auto',
+				height: 40
+			} );
+
+		strong.on( 'click', function() {
+			panel.addItems( {
+				bold: new CKEDITOR.ui.button( {
+					label: 'test',
+					command: 'bold'
+				} ),
+				language: evt.editor.ui.create( 'Language' ),
+				Styles: evt.editor.ui.create( 'Styles' )
+			} );
+			panel.attach( this );
+		} );
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'balloonpanel,language,stylescombo',
+		height: 300,
+		width: 600,
+		on: {
+			instanceReady: instanceReadyListener
+		}
+	} );
+
+</script>

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.html
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.html
@@ -18,11 +18,11 @@
 
 		strong.on( 'click', function() {
 			panel.addItems( {
-				bold: new CKEDITOR.ui.button( {
-					label: 'test',
-					command: 'bold'
-				} ),
-				language: evt.editor.ui.create( 'Language' ),
+				// bold: new CKEDITOR.ui.button( {
+				// 	label: 'test',
+				// 	command: 'bold'
+				// } ),
+				// language: evt.editor.ui.create( 'Language' ),
 				Styles: evt.editor.ui.create( 'Styles' )
 			} );
 			panel.attach( this );
@@ -30,7 +30,7 @@
 	}
 
 	CKEDITOR.replace( 'editor1', {
-		extraPlugins: 'balloonpanel,language,stylescombo',
+		// extraPlugins: 'balloonpanel,language,stylescombo',
 		height: 300,
 		width: 600,
 		on: {

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.html
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.html
@@ -1,8 +1,11 @@
-<textarea id="editor1" cols="10" rows="10">
+<textarea id="classic" cols="10" rows="10">
 	<p>Some text</p>
 	<p><strong>Click on me</strong></p>
 </textarea>
-
+<div id="inline" contenteditable="true">
+	<p>Some text</p>
+	<p><strong>Click on me</strong></p>
+</div>
 <script>
 	// Currently balloon toolbar is not integrated with old IE browsers.
 	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 || bender.tools.env.mobile ) {
@@ -24,12 +27,16 @@
 		} );
 	}
 
-	CKEDITOR.replace( 'editor1', {
-		height: 300,
-		width: 600,
+	CKEDITOR.replace( 'classic', {
 		on: {
 			instanceReady: instanceReadyListener
 		}
 	} );
 
+	CKEDITOR.inline( 'inline', {
+		on: {
+			instanceReady: instanceReadyListener
+		},
+		extraPlugins: 'floatingspace'
+	} );
 </script>

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.html
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.html
@@ -5,7 +5,7 @@
 
 <script>
 	// Currently balloon toolbar is not integrated with old IE browsers.
-	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 || bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 
@@ -18,11 +18,6 @@
 
 		strong.on( 'click', function() {
 			panel.addItems( {
-				// bold: new CKEDITOR.ui.button( {
-				// 	label: 'test',
-				// 	command: 'bold'
-				// } ),
-				// language: evt.editor.ui.create( 'Language' ),
 				Styles: evt.editor.ui.create( 'Styles' )
 			} );
 			panel.attach( this );
@@ -30,7 +25,6 @@
 	}
 
 	CKEDITOR.replace( 'editor1', {
-		// extraPlugins: 'balloonpanel,language,stylescombo',
 		height: 300,
 		width: 600,
 		on: {

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.html
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.html
@@ -19,10 +19,11 @@
 				height: 40
 			} );
 
-		strong.on( 'click', function() {
-			panel.addItems( {
-				Styles: evt.editor.ui.create( 'Styles' )
-			} );
+		panel.addItems( {
+			Styles: evt.editor.ui.create( 'Styles' )
+		} );
+
+		strong.once( 'click', function() {
 			panel.attach( this );
 		} );
 	}

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -9,4 +9,4 @@
 
 ## Expected
 
-Styles dropdown has hover css effect.
+Styles dropdown has hover effect.

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.11.0, bug, 1268, balloontoolbar
+@bender-tags: 4.11.2, bug, 1268, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,stylescombo
 
 ## For each editor

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -1,0 +1,9 @@
+@bender-ui: collapsed
+@bender-tags: 4.9.0, bug, 1268, balloontoolbar
+@bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,notification,floatingspace,balloontoolbar,sourcearea,list,link
+
+1. Click on strong text two times.
+1. Hover Styles dropdown.
+
+## Expected
+Styles has hover css effect.

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.10.2, bug, 1268, balloontoolbar
+@bender-tags: 4.11.0, bug, 1268, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,stylescombo
 
 ## For each editor

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -1,9 +1,9 @@
 @bender-ui: collapsed
-@bender-tags: 4.9.0, bug, 1268, balloontoolbar
-@bender-ckeditor-plugins: wysiwygarea,toolbar,undo,basicstyles,notification,floatingspace,balloontoolbar,sourcearea,list,link
+@bender-tags: 4.9.1, bug, 1268, balloontoolbar
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,stylescombo
 
-1. Click on strong text two times.
+1. Click on bold text two times.
 1. Hover Styles dropdown.
 
 ## Expected
-Styles has hover css effect.
+Styles dropdown has hover css effect.

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -2,8 +2,11 @@
 @bender-tags: 4.10.2, bug, 1268, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,stylescombo
 
+## For each editor
+
 1. Click on bold text two times.
 1. Hover Styles dropdown.
 
 ## Expected
+
 Styles dropdown has hover css effect.

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.9.1, bug, 1268, balloontoolbar
+@bender-tags: 4.10.2, bug, 1268, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,stylescombo
 
 1. Click on bold text two times.

--- a/tests/plugins/balloontoolbar/manual/dropdownhover.md
+++ b/tests/plugins/balloontoolbar/manual/dropdownhover.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.11.2, bug, 1268, balloontoolbar
+@bender-tags: 4.11.3, bug, 1268, balloontoolbar
 @bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,balloontoolbar,sourcearea,stylescombo
 
 ## For each editor

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -83,7 +83,7 @@ function testUpdateState( options ) {
 
 		if ( options.mode && options.mode !== editor.mode ) {
 			originalMode = editor.mode;
-			editor.mode = options.mode;
+			editor.setMode( options.mode );
 		}
 
 		if ( options.readOnly || originalMode ) {
@@ -102,7 +102,7 @@ function testUpdateState( options ) {
 		spy.restore();
 
 		if ( originalMode ) {
-			editor.mode = originalMode;
+			editor.setMode( originalMode );
 		}
 
 		assert.areEqual( expected[ 0 ], spy.callCount );

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -56,5 +56,56 @@ bender.test( {
 
 		assert.areEqual( 0, combo._.listeners.length, 'Listeners array is empty.' );
 		assert.isTrue( listenersRemoved, 'All listeners are removed.' );
-	}
+	},
+
+	// (#1268)
+	'test updatestate': testUpdateState(),
+
+	// (#1268)
+	'test updatestate read only editor': testUpdateState( { readOnly: true } ),
+
+	// (#1268)
+	'test updatestate source mode': testUpdateState( { mode: 'source' } ),
+
+	// (#1268)
+	'test updatestate combo on': testUpdateState( { comboOn: true } )
 } );
+
+function testUpdateState( options ) {
+	return function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo' ),
+			spy = sinon.spy( combo, 'setState' ),
+			expected = [ 1, CKEDITOR.TRISTATE_OFF ],
+			originalMode;
+
+		options = options || {};
+
+		if ( options.mode && options.mode !== editor.mode ) {
+			originalMode = editor.mode;
+			editor.mode = options.mode;
+		}
+
+		if ( options.readOnly || originalMode ) {
+			editor.setReadOnly( true );
+			expected[ 1 ] = CKEDITOR.TRISTATE_DISABLED;
+		}
+
+		if ( options.comboOn ) {
+			combo.setState( CKEDITOR.TRISTATE_ON );
+			spy.reset();
+			expected = [ 0, CKEDITOR.TRISTATE_ON ];
+		}
+
+		combo.updateState( editor );
+
+		spy.restore();
+
+		if ( originalMode ) {
+			editor.mode = originalMode;
+		}
+
+		assert.areEqual( expected[ 0 ], spy.callCount );
+		assert.areEqual( expected[ 1 ], combo.getState() );
+	};
+}

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: richcombo,toolbar */
+/* bender-ckeditor-plugins: richcombo,toolbar,sourcearea */
 
 var customCls = 'my_combo';
 bender.editor = {

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -76,7 +76,7 @@ function testUpdateState( options ) {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo' ),
 			spy = sinon.spy( combo, 'setState' ),
-			expected = [ 1, CKEDITOR.TRISTATE_OFF ],
+			expected = { callCount: 1, state: CKEDITOR.TRISTATE_OFF },
 			originalMode;
 
 		options = options || {};
@@ -88,13 +88,13 @@ function testUpdateState( options ) {
 
 		if ( options.readOnly || originalMode ) {
 			editor.setReadOnly( true );
-			expected[ 1 ] = CKEDITOR.TRISTATE_DISABLED;
+			expected.state = CKEDITOR.TRISTATE_DISABLED;
 		}
 
 		if ( options.comboOn ) {
 			combo.setState( CKEDITOR.TRISTATE_ON );
 			spy.reset();
-			expected = [ 0, CKEDITOR.TRISTATE_ON ];
+			expected = { callCount: 0, state: CKEDITOR.TRISTATE_ON };
 		}
 
 		combo.updateState( editor );
@@ -105,7 +105,7 @@ function testUpdateState( options ) {
 			editor.setMode( originalMode );
 		}
 
-		assert.areEqual( expected[ 0 ], spy.callCount );
-		assert.areEqual( expected[ 1 ], combo.getState() );
+		assert.areEqual( expected.callCount, spy.callCount );
+		assert.areEqual( expected.state, combo.getState() );
 	};
 }


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

Existing test already cover this case.

## What changes did you make?

I've presented new private method `CKEDITOR.ui.balloonToolbarView.prototype._updateStatus` which updates status of element and used in on each `richCombo` elements in balloon toolbar.

Closes #1268 