### PR TITLE
Integrate caption with basicstyles plugin

### DIFF
--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -604,7 +604,7 @@
 			 * @param {CKEDITOR.dom.element} sender The element that this function should be called on.
 			 * @param {Boolean} [isFocused] Indicates if current widget should be treated as a focused one.
 			 * If this parameter is omitted, its value is determined by checking
-			 * {@link CKEDITOR.plugins.widget.repository#focused} value. This parameter was added in 4.9.1.
+			 * {@link CKEDITOR.plugins.widget.repository#focused} value. This parameter was added in 4.10.
 			 */
 			_refreshCaption: function( sender, isFocused ) {
 				var caption = this.parts.caption,

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -565,7 +565,7 @@
 
 					// In Firefox and Edge applying styles inside caption results
 					// in firing this listener without focused widget.
-					// However it could be obtained from element, on which the event took place.
+					// However it could be obtained from element, on which the event took place (#1646).
 					if ( editor.focusManager.hasFocus && sender && !focused ) {
 						focused = editor.widgets.getByElement( sender );
 					}
@@ -604,7 +604,7 @@
 			 * @param {CKEDITOR.dom.element} sender The element that this function should be called on.
 			 * @param {Boolean} [isFocused] Indicates if current widget should be treated as a focused one.
 			 * If this parameter is omitted, its value is determined by checking
-			 * {@link CKEDITOR.plugins.widget.repository#focused} value.
+			 * {@link CKEDITOR.plugins.widget.repository#focused} value. This parameter was added in 4.9.1.
 			 */
 			_refreshCaption: function( sender, isFocused ) {
 				var caption = this.parts.caption,

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -601,17 +601,14 @@
 			 * @private
 			 * @member CKEDITOR.plugins.imagebase.featuresDefinitions.caption
 			 * @param {CKEDITOR.dom.element} sender The element that this function should be called on.
-			 * @param {Boolean} [isFocused] Indicates if current widget should be treated as a focused one.
-			 * If this parameter is omitted, its value is determined by checking
+			 * @param {Boolean} [forceFocus] Indicates if current widget should be treated as a focused one.
+			 * If this parameter is omitted or set to false, the focused widget is determined by checking
 			 * {@link CKEDITOR.plugins.widget.repository#focused} value. This parameter was added in 4.10.
 			 */
-			_refreshCaption: function( sender, isFocused ) {
+			_refreshCaption: function( sender, forceFocus ) {
 				var caption = this.parts.caption,
-					editable = this.editables.caption;
-
-				if ( typeof isFocused !== 'boolean' ) {
-					isFocused = getFocusedWidget( this.editor ) === this;
-				}
+					editable = this.editables.caption,
+					isFocused = forceFocus || ( getFocusedWidget( this.editor ) === this );
 
 				function isInCaption( element ) {
 					return element.equals( caption ) || caption.contains( element );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -570,7 +570,6 @@
 						focused = editor.widgets.getByElement( sender );
 					}
 
-
 					CKEDITOR.tools.array.forEach( widgets, function( widget ) {
 						widget._refreshCaption( sender, widget === focused );
 					} );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -599,10 +599,14 @@
 					caption = this.parts.caption,
 					editable = this.editables.caption;
 
+				function isInCaption( element ) {
+					return element.equals( caption ) || caption.contains( element );
+				}
+
 				if ( isFocused ) {
-					if ( !editable.getData() && !sender.equals( caption ) ) {
+					if ( !editable.getData() && !isInCaption( sender ) ) {
 						addPlaceholder( this );
-					} else if ( !sender || ( sender.equals( caption ) && sender.data( 'cke-caption-placeholder' ) ) ) {
+					} else if ( !sender || ( isInCaption( sender ) && caption.data( 'cke-caption-placeholder' ) ) ) {
 						removePlaceholder( this );
 					}
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -554,7 +554,8 @@
 				function listener( evt ) {
 					var path = evt.name === 'blur' ? editor.elementPath() : evt.data.path,
 						sender = path ? path.lastElement : null,
-						widgets = getWidgetsWithFeature( editor.widgets.instances, 'caption' );
+						widgets = getWidgetsWithFeature( editor.widgets.instances, 'caption' ),
+						focused = getFocusedWidget( editor );
 
 					if ( !editor.filter.check( 'figcaption' ) ) {
 						return CKEDITOR.tools.array.forEach( listeners, function( listener ) {
@@ -562,8 +563,16 @@
 						} );
 					}
 
+					// In Firefox and Edge applying styles inside caption results
+					// in firing this listener without focused widget.
+					// However it could be obtained from element, on which the event took place.
+					if ( editor.focusManager.hasFocus && sender && !focused ) {
+						focused = editor.widgets.getByElement( sender );
+					}
+
+
 					CKEDITOR.tools.array.forEach( widgets, function( widget ) {
-						widget._refreshCaption( sender );
+						widget._refreshCaption( sender, widget === focused );
 					} );
 				}
 
@@ -593,11 +602,17 @@
 			 * @private
 			 * @member CKEDITOR.plugins.imagebase.featuresDefinitions.caption
 			 * @param {CKEDITOR.dom.element} sender The element that this function should be called on.
+			 * @param {Boolean} [isFocused] Indicates if current widget should be treated as a focused one.
+			 * If this parameter is omitted, its value is determined by checking
+			 * {@link CKEDITOR.plugins.widget.repository#focused} value.
 			 */
-			_refreshCaption: function( sender ) {
-				var isFocused = getFocusedWidget( this.editor ) === this,
-					caption = this.parts.caption,
+			_refreshCaption: function( sender, isFocused ) {
+				var caption = this.parts.caption,
 					editable = this.editables.caption;
+
+				if ( typeof isFocused !== 'boolean' ) {
+					isFocused = getFocusedWidget( this.editor ) === this;
+				}
 
 				function isInCaption( element ) {
 					return element.equals( caption ) || caption.contains( element );

--- a/tests/plugins/imagebase/features/caption.js
+++ b/tests/plugins/imagebase/features/caption.js
@@ -443,7 +443,6 @@
 			}
 		} ),
 
-
 		// (#1776)
 		'test empty caption placeholder is hidden when blurred': function( editor, bot ) {
 			addTestWidget( editor );
@@ -468,7 +467,7 @@
 			} );
 		},
 
-		// #tp3384
+		// #1646
 		'test caption placeholder integration with basicstyles': createToggleTest( {
 			fixture: 'toggleOneEmpty',
 			initial: false,
@@ -476,8 +475,17 @@
 			blur: false,
 
 			customFocus: function( widget ) {
+				var range = widget.editor.createRange(),
+					caption = widget.parts.caption;
+
 				widget.focus();
-				widget.parts.caption.focus();
+				caption.focus();
+
+				// In Safari and IE11 focus is not enough to move selection.
+				range.setStart( caption.getChild( 0 ), 0 );
+				range.collapse();
+				range.select();
+
 				widget.editor.execCommand( 'bold' );
 			},
 

--- a/tests/plugins/imagebase/features/caption.js
+++ b/tests/plugins/imagebase/features/caption.js
@@ -1,7 +1,7 @@
 /* bender-tags: editor,widget */
-/* bender-ckeditor-plugins: imagebase,toolbar,easyimage */
-/* bender-include: ../../widget/_helpers/tools.js */
-/* global widgetTestsTools */
+/* bender-ckeditor-plugins: imagebase,basicstyles,toolbar,easyimage */
+/* bender-include: ../../widget/_helpers/tools.js, %BASE_PATH%/plugins/easyimage/_helpers/tools.js */
+/* global widgetTestsTools, easyImageTools */
 
 ( function() {
 	'use strict';
@@ -443,6 +443,7 @@
 			}
 		} ),
 
+
 		// (#1776)
 		'test empty caption placeholder is hidden when blurred': function( editor, bot ) {
 			addTestWidget( editor );
@@ -465,7 +466,25 @@
 					blurHost: emptyCaptionWidget
 				} );
 			} );
-		}
+		},
+
+		// #tp3384
+		'test caption placeholder integration with basicstyles': createToggleTest( {
+			fixture: 'toggleOneEmpty',
+			initial: false,
+			focus: true,
+			blur: false,
+
+			customFocus: function( widget ) {
+				widget.focus();
+				widget.parts.caption.focus();
+				widget.editor.execCommand( 'bold' );
+			},
+
+			onFocus: function( widget ) {
+				assertPlaceholder( widget, false );
+			}
+		} )
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );

--- a/tests/plugins/imagebase/features/caption.js
+++ b/tests/plugins/imagebase/features/caption.js
@@ -467,7 +467,7 @@
 			} );
 		},
 
-		// #1646
+		// (#1646)
 		'test caption placeholder integration with basicstyles': createToggleTest( {
 			fixture: 'toggleOneEmpty',
 			initial: false,

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.html
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.html
@@ -1,0 +1,51 @@
+<head>
+	<link rel="stylesheet" href="/apps/ckeditor/contents.css">
+</head>
+<body>
+	<h1>Classic editor</h1>
+
+	<div id="classic">
+		<p>Widget without caption:</p>
+		<figure>
+			<img src="../../../image2/_assets/foo.png" alt="foo">
+		</figure>
+
+		<p>Widget with caption:</p>
+		<figure>
+			<img src="../../../image2/_assets/foo.png" alt="foo">
+			<figcaption>Test caption</figcaption>
+		</figure>
+	</div>
+
+	<h1>Divarea</h1>
+
+	<div id="divarea">
+		<p>Widget without caption:</p>
+		<figure>
+			<img src="../../../image2/_assets/foo.png" alt="foo">
+		</figure>
+
+		<p>Widget with caption:</p>
+		<figure>
+			<img src="../../../image2/_assets/foo.png" alt="foo">
+			<figcaption>Test caption</figcaption>
+		</figure>
+	</div>
+
+	<script>
+		var cfg = {
+			on: {
+				pluginsLoaded: function( evt ) {
+					var editor = evt.editor,
+						imageBase = CKEDITOR.plugins.imagebase;
+
+					imageBase.addImageWidget( editor, 'testWidget', imageBase.addFeature( editor, 'caption', {} ) );
+				}
+			},
+			height: 500
+		};
+
+		CKEDITOR.replace( 'classic', cfg );
+		CKEDITOR.replace( 'divarea', CKEDITOR.tools.object.merge( cfg, { extraPlugins: 'divarea' } ) );
+	</script>
+</body>

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.html
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.html
@@ -33,6 +33,10 @@
 	</div>
 
 	<script>
+		if ( easyImageTools.isUnsupportedEnvironment() ) {
+			bender.ignore();
+		}
+
 		var cfg = {
 			on: {
 				pluginsLoaded: function( evt ) {

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.html
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.html
@@ -33,9 +33,7 @@
 	</div>
 
 	<script>
-		if ( easyImageTools.isUnsupportedEnvironment() ) {
-			bender.ignore();
-		}
+		bender.tools.ignoreUnsupportedEnvironment( 'easyimage' );
 
 		var cfg = {
 			on: {

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.md
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.md
@@ -1,0 +1,24 @@
+@bender-tags: 4.9.0, feature, 932, tp3384
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, toolbar, imagebase, link, htmlwriter, elementspath, basicstyles
+
+# Integration of caption and basicstyles
+
+1. Focus widget.
+2. Put cursor inside the caption. If caption contains text, delete it.
+3. Apply "Bold".
+
+## Expected
+
+* Bold is applied.
+* There is no visible placeholder.
+* Firefox/Edge: Selection remains inside the caption.
+
+## Unexpected
+
+* Placeholder shows up.
+* Firefox/Edge: Selection is lost.
+
+---
+
+Repeat for all editors.

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.md
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.9.1, feature, 932, tp3384, 1646
+@bender-tags: 4.10.0, feature, 932, tp3384, 1646
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, imagebase, basicstyles
 @bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.md
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.md
@@ -1,6 +1,7 @@
 @bender-tags: 4.9.1, feature, 932, tp3384, 1646
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, imagebase, basicstyles
+@bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js
 
 # Integration of caption and basicstyles
 

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.md
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.md
@@ -1,6 +1,6 @@
-@bender-tags: 4.9.0, feature, 932, tp3384
+@bender-tags: 4.9.1, feature, 932, tp3384, 1646
 @bender-ui: collapsed
-@bender-ckeditor-plugins: sourcearea, wysiwygarea, toolbar, imagebase, link, htmlwriter, elementspath, basicstyles
+@bender-ckeditor-plugins: wysiwygarea, toolbar, imagebase, basicstyles
 
 # Integration of caption and basicstyles
 
@@ -12,7 +12,7 @@
 
 * Bold is applied.
 * There is no visible placeholder.
-* Firefox/Edge: Selection remains inside the caption.
+* Selection remains inside the caption.
 
 ## Unexpected
 

--- a/tests/plugins/imagebase/features/manual/captionbasicstyles.md
+++ b/tests/plugins/imagebase/features/manual/captionbasicstyles.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, feature, 932, tp3384, 1646
+@bender-tags: 4.13.1, bug, 1646
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, imagebase, basicstyles
 @bender-include: %BASE_PATH%/plugins/easyimage/_helpers/tools.js


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've broaden check for caption (now it's check if an element is a caption or is inside a caption). I've also introduced mechanism to force treating widget as a focused one (via the second parameter to the `_refreshCaption` private method).

Closes #1646.