### PR TITLE
Updated changeListType behavior to be more simple & consistent

### DIFF
--- a/tests/plugins/list/list.html
+++ b/tests/plugins/list/list.html
@@ -48,18 +48,35 @@
 <dl>
 	<dt>text1</dt>
 	<dd>
-		<ul>
-			<li>text2</li>
-		</ul>
 		<ol>
 			<li>text2</li>
+			<li>text2</li>
+			<li>text2</li>
+			<li>text2</li>
+			<li>text2</li>
+			<li>text2</li>
 		</ol>
-		<ul>
-			<li>text2</li>
-			<li>text2</li>
-			<li>text2</li>
-			<li>text2</li>
-		</ul>
 	</dd>
 </dl>
+</textarea>
+<textarea id='switch_list_inside'>
+<ul>
+	<li>foo
+		<ul>
+			<li>bar^</li>
+			<li>bar2</li>
+		</ul>
+	</li>
+	<li>foo2</li>
+</ul>
+=>
+<ul>
+	<li>foo
+		<ol>
+			<li>bar</li>
+			<li>bar2</li>
+		</ol>
+	</li>
+	<li>foo2</li>
+</ul>
 </textarea>

--- a/tests/plugins/list/list.js
+++ b/tests/plugins/list/list.js
@@ -162,7 +162,17 @@ bender.test( {
 		}
 		bot.setHtmlWithSelection( '[<ul style="font-size:16px;"><li>foo<ul style="font-size:22px;"><li>bar</li></ul></li></ul>]' );
 		bot.execCommand( 'numberedlist' );
-		assert.areSame( '<ol style="font-size:16px;"><li>foo<ol style="font-size:22px;"><li>bar</li></ol></li></ol>', bot.getData( true ) );
+		assert.areSame( '<ol style="font-size:16px;"><li>foo<ul style="font-size:22px;"><li>bar</li></ul></li></ol>', bot.getData( true ) );
+	},
+
+	'test change sublist type but not parent list type': function() {
+		var bot = this.editorBots.editor2;
+		bender.tools.testInputOut( 'switch_list_inside', function( source, expected ) {
+			bot.setHtmlWithSelection( source );
+			bot.execCommand( 'numberedlist' );
+			assert.areSame( bender.tools.compatHtml( expected ), bot.getData( false, true ) );
+
+		} );
 	},
 
 	'test create list with merge below (with direction)': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

This pull request solves issue #1234 - makes changing of a list type more consistent.

## Does your PR contain necessary tests?

This PR does not have any tests.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What changes did you make?

`changeListType` method's behavior was unconsistent for the users. New behavior is more aligned with classic editors like MS Word, Google document, Tiny MCE. New behavior can be seen on my screen-cap video [here](https://anonfile.com/a027G1ddbb/new-chaneListType-behavior.mov).

Anyway, I never wrote new behavior for CKEditor, so if I missed anything, I apologize and I will fix it promptly.

As they say: best code is deleted code...
