### PR TITLE
Fix refresh problem of balloontolbar in Edge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Fixed Issues:
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 * [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen.
 * [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
+* [#1580](https://github.com/ckeditor/ckeditor-dev/issues/1580): Fixed: wrongly refreshed [Easy Image](https://ckeditor.com/cke4/addon/easyimage) icons in Edge browser.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Fixed Issues:
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 * [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen.
 * [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
-* [#1580](https://github.com/ckeditor/ckeditor-dev/issues/1580): Fixed: wrongly refreshed buttons in [balloon toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) for [Easy Image](https://ckeditor.com/cke4/addon/easyimage) in Edge browser.
+* [#1580](https://github.com/ckeditor/ckeditor-dev/issues/1580): Fixed: wrongly refreshed buttons in [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) for [Easy Image](https://ckeditor.com/cke4/addon/easyimage) in Edge browser.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Fixed Issues:
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 * [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happen.
 * [#1467](https://github.com/ckeditor/ckeditor-dev/issues/1467): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) resizing coursor appearing in middle of merged cell.
-* [#1580](https://github.com/ckeditor/ckeditor-dev/issues/1580): Fixed: wrongly refreshed [Easy Image](https://ckeditor.com/cke4/addon/easyimage) icons in Edge browser.
+* [#1580](https://github.com/ckeditor/ckeditor-dev/issues/1580): Fixed: wrongly refreshed buttons in [balloon toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) for [Easy Image](https://ckeditor.com/cke4/addon/easyimage) in Edge browser.
 
 API Changes:
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -131,8 +131,21 @@
 			editor.on( 'afterCommandExec', function( evt ) {
 				if ( getStyleNameFromCommand( evt.data.name, styles ) ) {
 					editor.forceNextSelectionCheck();
-					editor.selectionChange( true );
+					runSelectionChange();
 				}
+
+				function runSelectionChange() {
+					// In div-type editors Edge removes selection from hidden element when balloon toolbar is clicked.
+					// That's why we preserve this selection after command's execution (#1580).
+					if ( CKEDITOR.env.edge && editor.editable().isInline() ) {
+						var range = editor.getSelection().getRanges()[ 0 ];
+						editor.selectionChange( true );
+						range.select();
+					} else {
+						editor.selectionChange( true );
+					}
+				}
+
 			} );
 
 			editor.on( 'beforeCommandExec', function( evt ) {

--- a/tests/plugins/easyimage/commands.js
+++ b/tests/plugins/easyimage/commands.js
@@ -165,7 +165,7 @@
 
 			// #1580
 			'test edge refresh button state': function( editor, bot ) {
-				if ( !CKEDITOR.env.edge || !editor.editable().isInline() ) {
+				if ( !CKEDITOR.env.edge ) {
 					assert.ignore();
 				}
 				bot.setData( widgetHtml, function() {

--- a/tests/plugins/easyimage/commands.js
+++ b/tests/plugins/easyimage/commands.js
@@ -161,6 +161,45 @@
 					widget.focus();
 					wait();
 				} );
+			},
+
+			// #1580
+			'test edge refresh button state': function( editor, bot ) {
+				if ( !CKEDITOR.env.edge || !editor.editable().isInline() ) {
+					assert.ignore();
+				}
+				bot.setData( widgetHtml, function() {
+					var widget = editor.widgets.getByElement( editor.editable().findOne( 'figure' ) ),
+						toolbar = editor.balloonToolbars._contexts[ 0 ].toolbar;
+
+					toolbar._view.once( 'show', function() {
+						easyImageTools.assertCommandsState( editor, {
+							easyimageFull: CKEDITOR.TRISTATE_ON,
+							easyimageSide: CKEDITOR.TRISTATE_OFF,
+							easyimageAlt: CKEDITOR.TRISTATE_OFF
+						} );
+
+						editor.once( 'afterCommandExec', function() {
+							resume( function() {
+								easyImageTools.assertCommandsState( editor, {
+									easyimageFull: CKEDITOR.TRISTATE_OFF,
+									easyimageSide: CKEDITOR.TRISTATE_ON,
+									easyimageAlt: CKEDITOR.TRISTATE_OFF
+								} );
+							} );
+						}, null, null, 1000 );
+
+						// Edge resets document selection when balloontoolbar is clicked. That's how we can simulate it.
+						editor.once( 'afterCommandExec', function() {
+							editor.window.$.getSelection().removeAllRanges();
+						}, null, null, 1 );
+
+						editor.execCommand( 'easyimageSide' );
+					} );
+
+					widget.focus();
+					wait();
+				} );
 			}
 		};
 

--- a/tests/plugins/easyimage/commands.js
+++ b/tests/plugins/easyimage/commands.js
@@ -165,7 +165,7 @@
 
 			// #1580
 			'test edge refresh button state': function( editor, bot ) {
-				if ( !CKEDITOR.env.edge ) {
+				if ( !CKEDITOR.env.edge || !editor.editable().isInline() ) {
 					assert.ignore();
 				}
 				bot.setData( widgetHtml, function() {

--- a/tests/plugins/easyimage/manual/buttonupdateedge.html
+++ b/tests/plugins/easyimage/manual/buttonupdateedge.html
@@ -27,6 +27,9 @@
 
 <script>
 ( function() {
+	if ( !CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'editor1' );
 	CKEDITOR.replace( 'editor2', {
 		extraPlugins: 'divarea'

--- a/tests/plugins/easyimage/manual/buttonupdateedge.html
+++ b/tests/plugins/easyimage/manual/buttonupdateedge.html
@@ -1,0 +1,38 @@
+<h2>Classic editor:</h2>
+<textarea id="editor1" cols="10" rows="10">
+	<h1>Apollo 11</h1>
+	<figure class="image easyimage">
+		<img alt="Saturn V carrying Apollo 11" src="%BASE_PATH%/_assets/logo.png">
+	</figure>
+	<p>Armstrong spent about <s>three and a half</s> two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission, <a href="http://en.wikipedia.org/wiki/Michael_Collins_(astronaut)">Michael Collins</a>, piloted the <a href="http://en.wikipedia.org/wiki/Apollo_Command/Service_Module">command</a> spacecraft alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
+</textarea>
+
+<h2>Divarea editor:</h2>
+<textarea id="editor2" cols="10" rows="10">
+	<h1>Apollo 11</h1>
+	<figure class="image easyimage">
+		<img alt="Saturn V carrying Apollo 11" src="%BASE_PATH%/_assets/logo.png">
+	</figure>
+	<p>Armstrong spent about <s>three and a half</s> two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission, <a href="http://en.wikipedia.org/wiki/Michael_Collins_(astronaut)">Michael Collins</a>, piloted the <a href="http://en.wikipedia.org/wiki/Apollo_Command/Service_Module">command</a> spacecraft alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
+</textarea>
+
+<h2>Inline editor:</h2>
+<div id="editor3" contenteditable="true">
+	<h1>Apollo 11</h1>
+	<figure class="image easyimage">
+		<img alt="Saturn V carrying Apollo 11" src="%BASE_PATH%/_assets/logo.png">
+	</figure>
+	<p>Armstrong spent about <s>three and a half</s> two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission, <a href="http://en.wikipedia.org/wiki/Michael_Collins_(astronaut)">Michael Collins</a>, piloted the <a href="http://en.wikipedia.org/wiki/Apollo_Command/Service_Module">command</a> spacecraft alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
+</div>
+
+<script>
+( function() {
+	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea'
+	} );
+	CKEDITOR.inline( 'editor3', {
+		extraPlugins: 'floatingspace'
+	} );
+} )();
+</script>

--- a/tests/plugins/easyimage/manual/buttonupdateedge.md
+++ b/tests/plugins/easyimage/manual/buttonupdateedge.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.10.0, bug, 1580
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, easyimage, divarea
+
+----
+
+1. Click on image
+2. Change alignment of an image
+
+**Expected:** Balloontoolbar has refreshed buttons' state and it's positioned below image.
+
+**Unexpected:** Balloontoolbar remain in origin position, buttons are not refreshed.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

- Edge clears out selection of hidden element in when balloontoolbar is clicked. Now i such situation happen we will try to restore selection in hidden element instead of immediately clearing it out.

close #1580 