### PR TITLE
Easy Image includes backend service error message (if available) on upload failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,7 +56,7 @@ New Features:
 
 New Features:
 
-* [#1763](https://github.com/ckeditor/ckeditor-dev/issues/1763): Easy Image includes backend service error message (if available) on upload failure.
+* [#1763](https://github.com/ckeditor/ckeditor-dev/issues/1763): [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin includes backend service error message (if available) on upload failure.
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
 * [#706](https://github.com/ckeditor/ckeditor-dev/issues/706): Added different cursor style when selecting cells for [Table Selection](https://ckeditor.com/cke4/addon/tableselection) plugin.
 * [#651](https://github.com/ckeditor/ckeditor-dev/issues/651): Text pasted using [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) preservers indentation in paragraphs.
 * [#1176](https://github.com/ckeditor/ckeditor-dev/pull/1176): The [Balloon Panel](https://ckeditor.com/cke4/addon/balloonpanel) can be attached to selection instead of element.
+* [#1763](https://github.com/ckeditor/ckeditor-dev/issues/1763): [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin includes backend service error message (if available) on upload failure.
 
 API Changes:
 
@@ -53,10 +54,6 @@ New Features:
 * [#1703](https://github.com/ckeditor/ckeditor-dev/issues/1703): Introduced the [Mentions](https://ckeditor.com/cke4/addon/mentions) plugin providing smart completion feature for custom text matches based on user input starting with a chosen marker character.
 * [#1746](https://github.com/ckeditor/ckeditor-dev/issues/1703): Introduced the [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin providing completion feature for emoji ideograms.
 * [#1761](https://github.com/ckeditor/ckeditor-dev/issues/1761): The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin now supports email links.
-
-New Features:
-
-* [#1763](https://github.com/ckeditor/ckeditor-dev/issues/1763): [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin includes backend service error message (if available) on upload failure.
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,10 @@ New Features:
 * [#1746](https://github.com/ckeditor/ckeditor-dev/issues/1703): Introduced the [Emoji](https://ckeditor.com/cke4/addon/emoji) plugin providing completion feature for emoji ideograms.
 * [#1761](https://github.com/ckeditor/ckeditor-dev/issues/1761): The [Auto Link](https://ckeditor.com/cke4/addon/autolink) plugin now supports email links.
 
+New Features:
+
+* [#1763](https://github.com/ckeditor/ckeditor-dev/issues/1763): Easy Image includes backend service error message (if available) on upload failure.
+
 Fixed Issues:
 
 * [#1458](https://github.com/ckeditor/ckeditor-dev/issues/1458): [Edge] Fixed: After blurring the editor it takes 2 clicks to focus a widget.

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -343,6 +343,7 @@
 
 					this.on( 'uploadFailed', function( evt ) {
 						var response = evt.data.loader.responseData.response;
+						// Add response message if available (#1763).
 						alert( response && response.message || this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
 					} );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -341,8 +341,9 @@
 						} );
 					} );
 
-					this.on( 'uploadFailed', function() {
-						alert( this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
+					this.on( 'uploadFailed', function( evt ) {
+						var response = evt.data.loader.responseData.response;
+						alert( response && response.message || this.editor.lang.easyimage.uploadFailed ); // jshint ignore:line
 					} );
 
 					this._loadDefaultStyle();

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -108,6 +108,10 @@
 						data[ i ] = response[ i ];
 					}
 
+					if ( !response.uploaded ) {
+						evt.cancel();
+					}
+
 				} catch ( err ) {
 					// Response parsing error.
 					data.message = fileLoader.lang.filetools.responseError;
@@ -620,7 +624,7 @@
 
 				loader.uploaded = loader.uploadTotal;
 
-				var responseData = fireAndCopyFileUploadResponse();
+				var responseData = handleFileUploadResponse();
 
 				if ( xhr.status < 200 || xhr.status > 299 ) {
 					loader.message = loader.lang.filetools[ 'httpError' + xhr.status ];
@@ -637,7 +641,7 @@
 				}
 			};
 
-			function fireAndCopyFileUploadResponse() {
+			function handleFileUploadResponse() {
 				var data = {
 						fileLoader: loader
 					},

--- a/plugins/filetools/plugin.js
+++ b/plugins/filetools/plugin.js
@@ -624,7 +624,7 @@
 
 				loader.uploaded = loader.uploadTotal;
 
-				var responseData = handleFileUploadResponse();
+				var success = handleFileUploadResponse();
 
 				if ( xhr.status < 200 || xhr.status > 299 ) {
 					loader.message = loader.lang.filetools[ 'httpError' + xhr.status ];
@@ -632,12 +632,10 @@
 						loader.message = loader.lang.filetools.httpError.replace( '%1', xhr.status );
 					}
 					loader.changeStatus( 'error' );
+				} else if ( success === false ) {
+					loader.changeStatus( 'error' );
 				} else {
-					if ( responseData.uploaded ) {
-						loader.changeStatus( 'uploaded' );
-					} else {
-						loader.changeStatus( 'error' );
-					}
+					loader.changeStatus( 'uploaded' );
 				}
 			};
 
@@ -646,7 +644,7 @@
 						fileLoader: loader
 					},
 					valuesToCopy = [ 'message', 'fileName', 'url' ],
-					responseData = loader.editor.fire( 'fileUploadResponse', data );
+					success = loader.editor.fire( 'fileUploadResponse', data );
 
 				for ( var i = 0; i < valuesToCopy.length; i++ ) {
 					var key = valuesToCopy[ i ];
@@ -659,7 +657,7 @@
 				// But without reference to the loader itself.
 				delete loader.responseData.fileLoader;
 
-				return responseData;
+				return success;
 			}
 
 			function onError() {

--- a/tests/plugins/easyimage/manual/errormessage.html
+++ b/tests/plugins/easyimage/manual/errormessage.html
@@ -3,7 +3,6 @@
 <div id="editor1">
 </div>
 
-<script src="_helpers/tools.js"></script>
 <script>
 	if ( easyImageTools.isUnsupportedEnvironment() ) {
 		bender.ignore();

--- a/tests/plugins/easyimage/manual/errormessage.html
+++ b/tests/plugins/easyimage/manual/errormessage.html
@@ -9,10 +9,15 @@
 		bender.ignore();
 	}
 
-	easyImageTools.getToken( function( token ) {
-		CKEDITOR.replace( 'editor1', {
-				cloudServices_url: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
-				cloudServices_token: token + 'invalid' // Pass invalid token to fire uploadFailed event.
-			} );
+	var editor = CKEDITOR.replace( 'editor1', {
+		cloudServices_uploadUrl: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
+		cloudServices_tokenUrl: easyImageTools.CLOUD_SERVICES_TOKEN_URL,
+		on: {
+			instanceReady: function() {
+				editor.once( 'fileUploadRequest', function( evt ) {
+					evt.data.fileLoader.xhr.setRequestHeader( 'Authorization', 'invalid token' );
+				} );
+			}
+		}
 	} );
 </script>

--- a/tests/plugins/easyimage/manual/errormessage.html
+++ b/tests/plugins/easyimage/manual/errormessage.html
@@ -1,0 +1,18 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<div id="editor1">
+</div>
+
+<script src="_helpers/tools.js"></script>
+<script>
+	if ( easyImageTools.isUnsupportedEnvironment() ) {
+		bender.ignore();
+	}
+
+	easyImageTools.getToken( function( token ) {
+		CKEDITOR.replace( 'editor1', {
+				cloudServices_url: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
+				cloudServices_token: token + 'invalid' // Pass invalid token to fire uploadFailed event.
+			} );
+	} );
+</script>

--- a/tests/plugins/easyimage/manual/errormessage.md
+++ b/tests/plugins/easyimage/manual/errormessage.md
@@ -8,8 +8,8 @@
 
 ## Expected
 
-Alert shows up `Invalid token` message.
+Alert shows up with `Invalid token` message.
 
 ## Unexpected
 
-Alert shows up `Your image could not be uploaded due to a network error.` message.
+No alert showed up or it had a different message.

--- a/tests/plugins/easyimage/manual/errormessage.md
+++ b/tests/plugins/easyimage/manual/errormessage.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.10.0, feature, 1763
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, easyimage
+@bender-include: ../_helpers/tools.js
+
+1. Drag an image into editor.
+2. Wait until image is uploaded.
+
+## Expected
+
+Alert shows up `Invalid token` message.
+
+## Unexpected
+
+Alert shows up `Your image could not be uploaded due to a network error.` message.

--- a/tests/plugins/easyimage/manual/errormessage.md
+++ b/tests/plugins/easyimage/manual/errormessage.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, feature, 1763
+@bender-tags: 4.11.0, feature, 1763
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, easyimage
 @bender-include: ../_helpers/tools.js

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -275,7 +275,7 @@
 						easyImageDef.loaderType = originalLoader;
 
 						assert.areSame( 1, window.alert.callCount, 'Alert call count' );
-						sinon.assert.alwaysCalledWith( window.alert, 'Input buffer contains unsupported image format.' );
+						assert.isTrue( window.alert.alwaysCalledWith( 'Input buffer contains unsupported image format.' ) );
 
 						// Widget should be removed.
 						assert.areSame( 0, widgets.length, 'Widgets count' );

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -283,6 +283,7 @@
 				} );
 			},
 
+			// (#1763)
 			'test handling failed uploads with default alert message': function() {
 				var easyImageDef = this.editor.widgets.registered.easyimage,
 					originalLoader = easyImageDef.loaderType;

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -24,6 +24,7 @@
 	}
 
 	var assertPasteFiles = imageBaseFeaturesTools.assertPasteFiles,
+		failCloudServicesResponse,
 		tests = {
 			init: function() {
 				// We need to ignore entire test suit to prevent of fireing init, which breaks test suit on IE8-IE10.
@@ -43,11 +44,6 @@
 						1890: '%BASE_PATH%/_assets/logo.png?w=1890',
 						2048: '%BASE_PATH%/_assets/logo.png?w=2048',
 						'default': '%BASE_PATH%/_assets/logo.png'
-					},
-					failCloudServicesResponse = {
-						statusCode: 400,
-						error: 'Bad Request',
-						message: 'Input buffer contains unsupported image format'
 					};
 
 				// Array of listeners to be cleared after each TC.
@@ -126,6 +122,12 @@
 			},
 
 			setUp: function() {
+				failCloudServicesResponse = {
+					statusCode: 400,
+					error: 'Bad Request',
+					message: 'Input buffer contains unsupported image format.'
+				};
+
 				this.sandbox.stub( window, 'alert' );
 
 				this.editorBot.setHtmlWithSelection( '<p>^</p>' );
@@ -263,6 +265,29 @@
 			'test handling failed uploads': function() {
 				var easyImageDef = this.editor.widgets.registered.easyimage,
 					originalLoader = easyImageDef.loaderType;
+
+				easyImageDef.loaderType = AsyncFailFileLoader;
+
+				assertPasteFiles( this.editor, {
+					files: [ bender.tools.getTestPngFile() ],
+					fullLoad: true,
+					callback: function( widgets ) {
+						easyImageDef.loaderType = originalLoader;
+
+						assert.areSame( 1, window.alert.callCount, 'Alert call count' );
+						sinon.assert.alwaysCalledWith( window.alert, 'Input buffer contains unsupported image format.' );
+
+						// Widget should be removed.
+						assert.areSame( 0, widgets.length, 'Widgets count' );
+					}
+				} );
+			},
+
+			'test handling failed uploads with default alert message': function() {
+				var easyImageDef = this.editor.widgets.registered.easyimage,
+					originalLoader = easyImageDef.loaderType;
+
+				failCloudServicesResponse = null;
 
 				easyImageDef.loaderType = AsyncFailFileLoader;
 

--- a/tests/plugins/filetools/fileloader.js
+++ b/tests/plugins/filetools/fileloader.js
@@ -395,6 +395,7 @@
 			wait();
 		},
 
+		// (#1763)
 		'test upload with error fires fileUploadResponse': function() {
 			var responseText = 'Unauthorized';
 			editorMock.lang = { filetools: { 'httpError401': responseText } };


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Changed `filetools` to include information about error response data on `fileUploadResponse` event. Updated `easyimage` to use backend service error message if available.

Closes #1763.