### PR TITLE
Failing test ignore on IE8: /tests/plugins/widget/manual/outline

### DIFF
--- a/tests/plugins/widget/manual/outline.html
+++ b/tests/plugins/widget/manual/outline.html
@@ -28,7 +28,7 @@
 <script>
 	// Ignore on mobiles due to hovering.
 	// Inline editor with widget crashes on IE8 (#1821).
-	if ( bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
+	if ( bender.tools.env.mobile || CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/widget/manual/outline.html
+++ b/tests/plugins/widget/manual/outline.html
@@ -27,7 +27,8 @@
 
 <script>
 	// Ignore on mobiles due to hovering.
-	if ( bender.tools.env.mobile ) {
+	// Inline editor with widget crashes on IE8 (#1821).
+	if ( bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
 		bender.ignore();
 	}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

I've ignored widget manual test on IE8. This test fails due to problem with widget inside inline editor on IE8.

Closes #1641 
