### PR TITLE
Fix for drop in Edge not working correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,8 +29,9 @@ Fixed Issues:
 * [#898](https://github.com/ckeditor/ckeditor-dev/issues/898): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) long alt text protrudes into editor when image is selected.
 * [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 * [#1682](https://github.com/ckeditor/ckeditor-dev/issues/1682) Fixed: Hovering [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) panel changes its size causing flickering.
-* [#1832](https://github.com/ckeditor/ckeditor-dev/issues/1832): Fixed: Drop doesn't always work in Edge.
-* [#1943](https://github.com/ckeditor/ckeditor-dev/issues/1943): Fixed: Dragged text disappears when dropped on Edge.
+* [#1832](https://github.com/ckeditor/ckeditor-dev/issues/1832): [Edge] Fixed: Drop doesn't always work.
+* [#1943](https://github.com/ckeditor/ckeditor-dev/issues/1943): [Edge] Fixed: Dragged text disappears when dropped.
+* [#2303](https://github.com/ckeditor/ckeditor-dev/issues/2303): [Edge] Fixed: Pasting with [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin present throws error.
 
 API Changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ Fixed Issues:
 * [#898](https://github.com/ckeditor/ckeditor-dev/issues/898): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) long alt text protrudes into editor when image is selected.
 * [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 * [#1682](https://github.com/ckeditor/ckeditor-dev/issues/1682) Fixed: Hovering [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) panel changes its size causing flickering.
+* [#1832](https://github.com/ckeditor/ckeditor-dev/issues/1832): Fixed: Drop doesn't always work in Edge.
+* [#1943](https://github.com/ckeditor/ckeditor-dev/issues/1943): Fixed: Dragged text disappears when dropped on Edge.
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -316,6 +316,11 @@
 				// Make the final range selection.
 				range.select();
 
+				// Edge sometimes loses focus on editable on text drag and drop, even when editor is still focused.
+				if ( CKEDITOR.env.edge && !this.hasFocus ) {
+					this.focus();
+				}
+
 				afterInsert( this );
 
 				this.editor.fire( 'afterInsertHtml', {} );

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1604,6 +1604,8 @@
 					element = range.startContainer;
 				}
 
+				// When dropping to the end of editable, when last element is read only (e.g. widget)Edge returns widget element as drop range container.
+				// To solve this we need to move range outside of widget element. This also allows to drop in between widgets (#1832).
 				while ( element && element.isReadOnly() ) {
 					element = element.getParent();
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1471,14 +1471,8 @@
 			// we drop image it will overwrite document.
 
 			editable.attachListener( dropTarget, 'dragover', function( evt ) {
-				// Edge requires this handler to have `preventDefault()` regardless of the situation.
-				if ( CKEDITOR.env.edge ) {
-					evt.data.preventDefault();
-					return;
-				}
 
 				var target = evt.data.getTarget();
-
 				// Prevent reloading page when dragging image on empty document (https://dev.ckeditor.com/ticket/12619).
 				if ( target && target.is && target.is( 'html' ) ) {
 					evt.data.preventDefault();
@@ -1490,7 +1484,7 @@
 				// if we prevent it the cursor will not we shown, so we prevent
 				// dragover only on IE, on versions which support file API and only
 				// if the event contains files.
-				if ( CKEDITOR.env.ie &&
+				if ( CKEDITOR.env.ie && !CKEDITOR.env.edge &&
 					CKEDITOR.plugins.clipboard.isFileApiSupported &&
 					evt.data.$.dataTransfer.types.contains( 'Files' ) ) {
 					evt.data.preventDefault();

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1604,7 +1604,7 @@
 					element = range.startContainer;
 				}
 
-				// When dropping to the end of editable, when last element is read only (e.g. widget)Edge returns widget element as drop range container.
+				// When dropping to the end of editable, when last element is read only (e.g. widget) Edge returns widget element as drop range container.
 				// To solve this we need to move range outside of widget element. This also allows to drop in between widgets (#1832).
 				while ( element && element.isReadOnly() ) {
 					element = element.getParent();

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1614,6 +1614,7 @@
 						break;
 					}
 				}
+
 				if ( editor.fire( evt.name, eventData ) === false ) {
 					evt.data.preventDefault();
 				}
@@ -2929,6 +2930,11 @@
 				nativeDataTransfer = this._dataTransfer.$;
 
 			try {
+				// We need to clear data of existing type before storing it or else clipboard will get broken on Edge (#1943).
+				if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 17 && nativeDataTransfer.getData( type ) ) {
+					nativeDataTransfer.clearData( type );
+				}
+
 				nativeDataTransfer.setData( type, data );
 
 				if ( isFallbackDataType ) {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1591,15 +1591,29 @@
 				var eventData = {
 						$: evt.data.$,
 						target: evt.data.getTarget()
-					};
+					},
+					element,
+					range,
+					offset;
 
 				if ( dragRange ) {
 					eventData.dragRange = dragRange;
 				}
 				if ( dropRange ) {
-					eventData.dropRange = dropRange;
+					eventData.dropRange = range = dropRange;
 				}
 
+				while ( range.checkReadOnly() ) {
+					element = range.startContainer.getParent();
+					offset = range.startContainer.getIndex() + 1;
+
+					range.setStart( element, offset );
+					range.setEnd( element, offset );
+
+					if ( element instanceof CKEDITOR.editable ) {
+						break;
+					}
+				}
 				if ( editor.fire( evt.name, eventData ) === false ) {
 					evt.data.preventDefault();
 				}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2935,7 +2935,13 @@
 					nativeDataTransfer.clearData( type );
 				}
 
-				nativeDataTransfer.setData( type, data );
+				// Edge crashes when we try to store empty string as data.
+				// As it doesn't make any sense to set empty data, lets not do it on any browser.
+				// https://github.com/ckeditor/ckeditor-dev/pull/1850#issuecomment-404463434
+				// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18336754/
+				if ( data ) {
+					nativeDataTransfer.setData( type, data );
+				}
 
 				if ( isFallbackDataType ) {
 					// If fallback type used, the native data is different so we overwrite `nativeHtmlCache` here.

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1603,7 +1603,7 @@
 					eventData.dropRange = range = dropRange;
 				}
 
-				while ( range.checkReadOnly() ) {
+				while ( range && range.checkReadOnly() ) {
 					element = range.startContainer.getParent();
 					offset = range.startContainer.getIndex() + 1;
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1601,18 +1601,19 @@
 				}
 				if ( dropRange ) {
 					eventData.dropRange = range = dropRange;
+					element = range.startContainer;
 				}
 
-				while ( range && range.checkReadOnly() ) {
-					element = range.startContainer.getParent();
-					offset = range.startContainer.getIndex() + 1;
+				while ( element && element.isReadOnly() ) {
+					element = element.getParent();
+					offset = element.getIndex() + 1;
+
+					if ( !element || element instanceof CKEDITOR.editable  ) {
+						break;
+					}
 
 					range.setStart( element, offset );
 					range.setEnd( element, offset );
-
-					if ( element instanceof CKEDITOR.editable ) {
-						break;
-					}
 				}
 
 				if ( editor.fire( evt.name, eventData ) === false ) {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1606,11 +1606,12 @@
 
 				while ( element && element.isReadOnly() ) {
 					element = element.getParent();
-					offset = element.getIndex() + 1;
 
 					if ( !element || element instanceof CKEDITOR.editable  ) {
 						break;
 					}
+
+					offset = element.getIndex() + 1;
 
 					range.setStart( element, offset );
 					range.setEnd( element, offset );

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1193,5 +1193,33 @@ bender.test( {
 		assert.areSame( '', dt1._stripHtml( '' ), 'Empty html' );
 		assert.isUndefined( dt1._stripHtml( undefined ), 'Undefined' );
 		assert.isNull( dt1._stripHtml( null ), 'Null' );
+	},
+
+	// (#1832)
+	'test setData with empty string doesn\'t call nativeDataTransfer.setData': function() {
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+			assert.ignore();
+		}
+
+		var mockedDataTransfer = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( mockedDataTransfer ),
+			spy = sinon.spy( mockedDataTransfer, 'setData' ),
+			args;
+
+		dataTransfer._.fallbackDataTransfer.isRequired = function() {
+			return true;
+		};
+
+		CKEDITOR.tools.array.forEach( [ 'text/plain', 'text/html', 'custom' ], function( type ) {
+			dataTransfer.setData( type, '' );
+			dataTransfer.setData( type, 'foo' );
+		} );
+
+		args = CKEDITOR.tools.array.map( spy.args, function( item ) {
+			return item[ 1 ];
+		} );
+
+		assert.areSame( spy.callCount, 3, 'Method setData should be called 3 times.' );
+		assert.areSame( args.indexOf( '' ), -1, 'Empty string shouldn\'t be passed as an argument to setData.' );
 	}
 } );

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1203,22 +1203,14 @@ bender.test( {
 
 		var mockedDataTransfer = bender.tools.mockNativeDataTransfer(),
 			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( mockedDataTransfer ),
-			spy = sinon.spy( mockedDataTransfer, 'setData' ),
-			args;
+			spy = sinon.spy( mockedDataTransfer, 'setData' );
 
 		dataTransfer._.fallbackDataTransfer.isRequired = function() {
 			return true;
 		};
 
-		CKEDITOR.tools.array.forEach( [ 'text/plain', 'text/html', 'custom' ], function( type ) {
-			dataTransfer.setData( type, '' );
-			dataTransfer.setData( type, 'foo' );
-		} );
+		dataTransfer.setData( 'text/html', '' );
 
-		args = CKEDITOR.tools.array.map( spy.args, function( item ) {
-			return item[ 1 ];
-		} );
-		assert.isTrue( spy.callCount >= 3, 'Method setData should be called at least 3 times.' );
-		assert.areSame( args.indexOf( '' ), -1, 'Empty string shouldn\'t be passed as an argument to setData.' );
+		assert.areSame( 0, spy.callCount, 'Method setData shouldn\'t be called.' );
 	}
 } );

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1218,8 +1218,7 @@ bender.test( {
 		args = CKEDITOR.tools.array.map( spy.args, function( item ) {
 			return item[ 1 ];
 		} );
-
-		assert.areSame( spy.callCount, 3, 'Method setData should be called 3 times.' );
+		assert.isTrue( spy.callCount >= 3, 'Method setData should be called at least 3 times.' );
 		assert.areSame( args.indexOf( '' ), -1, 'Empty string shouldn\'t be passed as an argument to setData.' );
 	}
 } );

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -1189,7 +1189,10 @@ var testsForMultipleEditor = {
 				bot = this.editorBots[ editor.name ],
 				spy = sinon.spy(),
 				data = {
-					preventDefault: spy
+					preventDefault: spy,
+					getTarget: function() {
+						return null;
+					}
 				};
 
 			bot.setHtmlWithSelection( '<p>Test area.</p>' );

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -1,4 +1,4 @@
-/* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453 */
+/* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453, 1832 */
 /* bender-ckeditor-plugins: toolbar,clipboard,undo */
 /* bender-include: _helpers/pasting.js */
 
@@ -1179,6 +1179,7 @@ var testsForMultipleEditor = {
 			assert.areEqual( 'none', data.$.dataTransfer.dropEffect, 'dropEffect reset to \'none\'' );
 		},
 
+		// #1832 https://github.com/ckeditor/ckeditor-dev/issues/1832
 		'test dragOver Edge': function() {
 			if ( !CKEDITOR.env.edge ) {
 				assert.ignore();
@@ -1195,7 +1196,7 @@ var testsForMultipleEditor = {
 
 			editor.editable().fire( 'dragover', data );
 
-			assert.isTrue( spy.called, 'preventDefault called.' );
+			assert.isFalse( spy.called, 'preventDefault not called.' );
 		}
 	};
 

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -1,4 +1,4 @@
-/* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453, 1832, 1943 */
+/* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453, 1832 */
 /* bender-ckeditor-plugins: toolbar,clipboard,undo */
 /* bender-include: _helpers/pasting.js */
 
@@ -1181,7 +1181,7 @@ var testsForMultipleEditor = {
 			assert.areEqual( 'none', data.$.dataTransfer.dropEffect, 'dropEffect reset to \'none\'' );
 		},
 
-		// (#1832) and (#1943).
+		// (#1832)
 		'test dragOver Edge': function() {
 			if ( !CKEDITOR.env.edge ) {
 				assert.ignore();

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -1,4 +1,4 @@
-/* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453, 1832 */
+/* bender-tags: clipboard, 13468, 13015, 13140, 12806, 13011, 13453, 1832, 1943 */
 /* bender-ckeditor-plugins: toolbar,clipboard,undo */
 /* bender-include: _helpers/pasting.js */
 
@@ -1180,6 +1180,7 @@ var testsForMultipleEditor = {
 		},
 
 		// #1832 https://github.com/ckeditor/ckeditor-dev/issues/1832
+		// #1943 https://github.com/ckeditor/ckeditor-dev/issues/1943
 		'test dragOver Edge': function() {
 			if ( !CKEDITOR.env.edge ) {
 				assert.ignore();

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -675,7 +675,9 @@ var testsForMultipleEditor = {
 			editor.once( 'drop', listener, null, null, -1 );
 
 			// dropRange must be not null.
-			evt.testRange = {};
+			evt.testRange = { checkReadOnly: function() {
+					return false;
+				} };
 
 			dropTarget.fire( 'drop', evt );
 

--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -1179,8 +1179,7 @@ var testsForMultipleEditor = {
 			assert.areEqual( 'none', data.$.dataTransfer.dropEffect, 'dropEffect reset to \'none\'' );
 		},
 
-		// #1832 https://github.com/ckeditor/ckeditor-dev/issues/1832
-		// #1943 https://github.com/ckeditor/ckeditor-dev/issues/1943
+		// (#1832) and (#1943).
 		'test dragOver Edge': function() {
 			if ( !CKEDITOR.env.edge ) {
 				assert.ignore();

--- a/tests/plugins/clipboard/manual/draganddropdata.html
+++ b/tests/plugins/clipboard/manual/draganddropdata.html
@@ -85,7 +85,8 @@
 
 			CKEDITOR.plugins.clipboard.initDragDataTransfer( evt );
 
-			var dataTransfer = evt.data.dataTransfer;
+			var dataTransfer = evt.data.dataTransfer,
+				id = dataTransfer.getData( 'cke/id' );
 
 			dataTransfer.setData( 'contact', CONTACTS[ target.data( 'contact' ) ] );
 
@@ -93,6 +94,12 @@
 
 			if ( dataTransfer.$.setDragImage ) {
 				dataTransfer.$.setDragImage( target.findOne( 'img' ).$, 0, 0 );
+			}
+
+			// This is temporary, should be removed once Edge fully accepts custom mine types in dataTransfer.
+			// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11780845/
+			if ( CKEDITOR.env.ie && id ) {
+				dataTransfer.setData( 'cke/id', id );
 			}
 		} );
 	} );

--- a/tests/plugins/clipboard/manual/draganddropdata.html
+++ b/tests/plugins/clipboard/manual/draganddropdata.html
@@ -97,7 +97,7 @@
 			}
 
 			// This is temporary, should be removed once Edge fully accepts custom mine types in dataTransfer.
-			// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11780845/
+			// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18993248/
 			if ( CKEDITOR.env.ie && id ) {
 				dataTransfer.setData( 'cke/id', id );
 			}

--- a/tests/plugins/clipboard/manual/draganddropdata.md
+++ b/tests/plugins/clipboard/manual/draganddropdata.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.7.0, trac16777, dataTransfer, 4.10.0, 1832
+@bender-tags: bug, 4.7.0, trac16777, dataTransfer, 4.10.1, 1832
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, sourcearea, elementspath, clipboard, image2, uploadimage, uploadwidget
 @bender-include: ../../../plugins/uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/clipboard/manual/draganddropdata.md
+++ b/tests/plugins/clipboard/manual/draganddropdata.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.7.0, trac16777, dataTransfer
+@bender-tags: bug, 4.7.0, trac16777, dataTransfer, 4.10.0, 1832
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, sourcearea, elementspath, clipboard, image2, uploadimage, uploadwidget
 @bender-include: ../../../plugins/uploadwidget/manual/_helpers/xhr.js
@@ -10,8 +10,13 @@
 
 ## Expected result
 
-Both operations possible, no errors.
+Both operations possible, no errors. During drag there should be visible caret in editable. After drop widget should appear in last caret position.
 
 ## Unexpected
 
-Impossible to drop either contacts, or image, or both.
+- Impossible to drop either contacts, or image, or both.
+- There is no caret during drag.
+
+#### Note:
+
+Dragging elements into editor will paste them into current collapsed selection. If selection is inside Widget element nothing will happen because it is `readonly` element.

--- a/tests/plugins/clipboard/manual/draganddropdata.md
+++ b/tests/plugins/clipboard/manual/draganddropdata.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.7.0, trac16777, dataTransfer, 4.10.1, 1832
+@bender-tags: bug, 4.7.0, trac16777, dataTransfer, 4.11.2, 1832
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, sourcearea, elementspath, clipboard, image2, uploadimage, uploadwidget
 @bender-include: ../../../plugins/uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/clipboard/manual/draganddropedge.html
+++ b/tests/plugins/clipboard/manual/draganddropedge.html
@@ -6,7 +6,7 @@ Ut eleifend, eros in scelerisque auctor, purus eros semper ligula, non scelerisq
 </textarea>
 
 <script>
-	if ( CKEDITOR.env.edge ) {
+	if ( !CKEDITOR.env.edge ) {
 		bender.ignore();
 	}
 	CKEDITOR.replace( 'editor1' );

--- a/tests/plugins/clipboard/manual/draganddropedge.html
+++ b/tests/plugins/clipboard/manual/draganddropedge.html
@@ -1,0 +1,13 @@
+<textarea name="editor1" id="editor1" cols="30" rows="10">
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut velit massa, suscipit in egestas vitae, pulvinar id velit. Maecenas congue neque enim, sit amet sodales nisi lacinia in. Aliquam vitae quam blandit, viverra purus eget, bibendum arcu. Sed convallis hendrerit porttitor. Nulla eget orci et nisi viverra tristique. Fusce posuere efficitur ornare. Nullam venenatis id nulla et blandit. Mauris ornare magna id orci porttitor egestas. Duis sit amet ante in tortor lobortis euismod at eu sapien. Sed in sapien nec mi sollicitudin rutrum.
+
+Ut eleifend, eros in scelerisque auctor, purus eros semper ligula, non scelerisque odio nunc at lectus. Donec non faucibus nisl, ut pulvinar libero. Vivamus quis arcu vulputate, eleifend massa et, venenatis nisi. Fusce elementum massa orci, ut scelerisque massa euismod in. Vestibulum mollis ullamcorper consequat. Mauris non libero ut massa laoreet semper sit amet sodales orci. Ut id sollicitudin massa. Donec pretium congue velit, in fringilla lacus porta vitae. Aenean tempus tincidunt libero, et facilisis dui lacinia et. Phasellus porttitor at justo ac fringilla. Nam consequat rhoncus dignissim.
+</p>
+</textarea>
+
+<script>
+	if ( CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -2,10 +2,10 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, clipboard
 
-# Test steps
+# Drag and drop
 
 1. Select some part of text.
-2. Drag and drop it into another place inside editor.
+1. Drag and drop it into another place inside editor.
 
 ## Expected result
 
@@ -14,3 +14,16 @@ Selected text appears in place where it was dropped.
 ## Unexpected
 
 Selected text disappears.
+
+# Pasting
+
+1. Copy some text.
+1. Paste it into editor.
+
+## Expected result
+
+Text is pasted into editor.
+
+## Unexpeted
+
+Text is not pasted and clipboard is empty.

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.0, 1943
+@bender-tags: 4.10.1, 1943
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, clipboard
 

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.10.0, 1943
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, clipboard
+
+# Test steps
+
+1. Select some part of text.
+2. Drag and drop it into another place inside editor.
+
+## Expected result
+
+Selected text appears in place where it was dropped.
+
+## Unexpected
+
+Selected text disappears.

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -24,6 +24,6 @@ Selected text disappears.
 
 Text is pasted into editor.
 
-## Unexpeted
+## Unexpected
 
 Text is not pasted and clipboard is empty.

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.1, 1943
+@bender-tags: 4.10.2, 1943, 2303
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, clipboard
 

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -27,3 +27,8 @@ Text is pasted into editor.
 ## Unexpected
 
 Text is not pasted and clipboard is empty.
+
+
+## Note
+
+There is known bug, when caret disappears after drop.

--- a/tests/plugins/clipboard/manual/draganddropedge.md
+++ b/tests/plugins/clipboard/manual/draganddropedge.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.10.2, 1943, 2303
+@bender-tags: 4.11.2, 1943, 2303
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, clipboard
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

I've just slightly updated existing tests.

## What changes did you make?

There were `preventDefault()` for Edge on `dragover` which prevented caret from editor. This piece of code was introduced in 16777. According to description it was only related to dnd sample, so removing this part of code shouldn't break anything else.

https://dev.ckeditor.com/ticket/16777
https://github.com/ckeditor/ckeditor-dev/commit/8bd9090a7e6dc95b812f49c182f837177cfdbc55

According to description it was only changed to make dnd sample work on Edge, so removing this shouldn't break anything else. However this fix created new bug.

Selection in Edge works different than in other browsers, so even with that fix it wont work 100% as expected. E.g.  When caret is in empty paragraph `window.getSelection().getRangeAt(0).startContainer` can still point to widget.


Closes #1832
Closes #1943
Closes #2303