### PR TITLE
Fixed: Typing text on iOS scrolls editable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ API Changes:
 * [#1582](https://github.com/ckeditor/ckeditor-dev/issues/1582): The [`CKEDITOR.editor.addCommand`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_editor.html#method-addCommand) can accept [`CKEDITOR.command`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_command.html) instance as parameter.
 * [#1712](https://github.com/ckeditor/ckeditor-dev/issues/1712): [`extraPlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-extraPlugins), [`removePlugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removePlugins) and [`plugins`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-plugins) configuration options allow whitespace.
 
+Fixed Issues:
+
+* [#498](https://github.com/ckeditor/ckeditor-dev/issues/498): Typing scrolls editor content on iOS.
+
 ## CKEditor 4.9.1
 
 Fixed Issues:

--- a/core/editable.js
+++ b/core/editable.js
@@ -1216,12 +1216,12 @@
 				if ( !this.isInline() && CKEDITOR.env.iOS && CKEDITOR.env.safari ) {
 					var touchListenerStatus, scrollListenerStatus;
 
-					this.on( 'textInput', scrollToRangesOnScroll, this, null, 10000 );
+					this.on( 'input', scrollToRangesOnScroll, this, null, 10000 );
 					this.on( 'keydown', scrollToRangesOnScroll, this, null, 10000 );
 				}
 
 				function scrollToRangesOnScroll() {
-					var contentsWrapper = CKEDITOR.document.findOne( '#' + CKEDITOR.instances.editor.id + '_contents' );
+					var contentsWrapper = CKEDITOR.document.findOne( '#' + editor.id + '_contents' );
 
 					function scrollListener() {
 						this.editor.getSelection().getRanges()[ 0 ].scrollIntoView();

--- a/core/editable.js
+++ b/core/editable.js
@@ -1211,6 +1211,38 @@
 						return false;
 					}, this, null, 100 ); // Later is better – do not override existing listeners.
 				}
+
+				// Scroll to current ranges due to bug on iOS #498
+				if ( !this.isInline() && CKEDITOR.env.iOS && CKEDITOR.env.safari ) {
+					var touchListenerStatus, scrollListenerStatus;
+
+					this.on( 'textInput', scrollToRangesOnScroll, this, null, 10000 );
+					this.on( 'keydown', scrollToRangesOnScroll, this, null, 10000 );
+				}
+
+				function scrollToRangesOnScroll() {
+					var contentsWrapper = CKEDITOR.document.findOne( '#' + CKEDITOR.instances.editor.id + '_contents' );
+
+					function scrollListener() {
+						this.editor.getSelection().getRanges()[ 0 ].scrollIntoView();
+					}
+
+					// Don't register same listener many times.
+					if ( !scrollListenerStatus ) {
+						contentsWrapper.on( 'scroll', scrollListener, this );
+						scrollListenerStatus = true;
+					}
+
+					if ( !touchListenerStatus ) {
+						// Restore scrolling on editable, when user touches it.
+						this.once( 'touchstart', function() {
+							scrollListenerStatus = false;
+							contentsWrapper.removeListener( 'scroll', scrollListener );
+							touchListenerStatus = false;
+						} );
+						touchListenerStatus = true;
+					}
+				}
 			}
 		},
 

--- a/tests/core/editable/manual/scrolloninput.html
+++ b/tests/core/editable/manual/scrolloninput.html
@@ -1,0 +1,50 @@
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+<p>Line above editor</p>
+
+<textarea id="editor" contenteditable="true">
+	<p>Paragraph 01</p><p>Paragraph 02</p><p>Paragraph 03</p><p>Paragraph 04</p><p>Paragraph 05</p><p>Paragraph 06</p><p>Paragraph 07</p><p>Paragraph 08</p><p>Paragraph 09</p><p>Paragraph 10</p><p>Paragraph 11</p><p>Paragraph 12</p><p>Paragraph 13</p><p>Paragraph 14</p><p>Paragraph 15</p><p>Paragraph 16</p><p>Paragraph 17</p><p>Paragraph 18</p><p>Paragraph 19</p><p>Paragraph 20</p>
+</textarea>
+
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+<p>Line below editor</p>
+
+<script>
+	if ( !CKEDITOR.env.iOS && !CKEDITOR.env.safari ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/editable/manual/scrolloninput.md
+++ b/tests/core/editable/manual/scrolloninput.md
@@ -1,0 +1,20 @@
+@bender-tags: 4.10.0, bug, 498
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea
+
+## Test scenario
+
+For each editor:
+1. Scroll page down until editable is on top of view.
+1. Put focus caret in first line of editable content.
+1. Start typing with on screen keyboard using letter keys and auto-complete.
+
+## Expected result
+
+Editable is scrolled in a way caret is visible and user can see what is typing.
+
+## Unexpected
+
+Editable is scrolled down and caret is not visible and typed letters are not visible.
+
+Note: Flickering occurs when typing.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## What changes did you make?
I'm calling `scrollIntoView` on current selection ranges on iOS. Doing that on `keydown` and on `textInput`. Reason to use two listeners is because iOS screen keyboard doesn't fire `keydown` event when using autocomplete. And using backspace or new line doesn't call `textInput`.

One problem with this solution is that editor is scrolled right after scroll invoked by browsers native methods. Hence there is visible flickering.

Closes #498