### PR TITLE
Fix for wrong deletion of mixed text and table content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Fixed Issues:
 * [#1776](https://github.com/ckeditor/ckeditor-dev/issues/1776): [Image Base](https://ckeditor.com/cke4/addon/imagebase) empty caption placeholder is not hidden when blurred.
 * [#1592](https://github.com/ckeditor/ckeditor-dev/issues/1592): [Image Base](https://ckeditor.com/cke4/addon/imagebase) caption is not visible after paste.
 * [#620](https://github.com/ckeditor/ckeditor-dev/issues/620): Fixed: [`forcePasteAsPlainText`](https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText) will be respected when internal and cross-editor pasting happens.
+* [#541](https://github.com/ckeditor/ckeditor-dev/issues/1592): Selection containing text and tables, will now properly support <kbd>Backspace</kbd> and <kbd>Delete</kbd> keys.
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -2525,8 +2525,7 @@
 
 	function mergeBlocksNonCollapsedSelection( editor, range, startPath ) {
 		var startBlock = startPath.block,
-			endPath = range.endPath(),
-			endBlock = endPath.block;
+			endBlock = range.endPath().block;
 
 		// Selection must be anchored in two different blocks.
 		if ( !startBlock || !endBlock || startBlock.equals( endBlock ) )
@@ -2539,36 +2538,8 @@
 		if ( ( bogus = startBlock.getBogus() ) )
 			bogus.remove();
 
-		// Changing end container to element from text node (https://dev.ckeditor.com/ticket/12503).
-		range.enlarge( CKEDITOR.ENLARGE_INLINE );
-
-		// Delete range contents. Do NOT merge. Merging is weird.
-		range.deleteContents();
-
-		// If something has left of the block to be merged, clean it up.
-		// It may happen when merging with list items.
-		if ( endBlock.getParent() ) {
-			// Move children to the first block.
-			endBlock.moveChildren( startBlock, false );
-
-			// ...and merge them if that's possible.
-			startPath.lastElement.mergeSiblings();
-
-			// If expanded selection, things are always merged like with BACKSPACE.
-			pruneEmptyDisjointAncestors( startBlock, endBlock, true );
-		}
-
-		// Make sure the result selection is collapsed.
-		range = editor.getSelection().getRanges()[ 0 ];
-		range.collapse( 1 );
-
-		// Optimizing range containers from text nodes to elements (https://dev.ckeditor.com/ticket/12503).
-		range.optimize();
-		if ( range.startContainer.getHtml() === '' ) {
-			range.startContainer.appendBogus();
-		}
-
-		range.select();
+		// Remove selected content. Handle cases when list, tables, etc. are partially selected (#541).
+		editor.extractSelectedHtml();
 
 		return true;
 	}

--- a/core/editable.js
+++ b/core/editable.js
@@ -2525,18 +2525,25 @@
 
 	function mergeBlocksNonCollapsedSelection( editor, range, startPath ) {
 		var startBlock = startPath.block,
-			endBlock = range.endPath().block;
+			endPath = range.endPath(),
+			endBlock = endPath.block;
 
-		// Selection must be anchored in two different blocks.
-		if ( !startBlock || !endBlock || startBlock.equals( endBlock ) )
+		var selectionInTwoDifferentBlocks = !startBlock || !endBlock || startBlock.equals( endBlock );
+		var hasBoundariesInTable = range.startContainer.getAscendant( 'table', true ) || range.endContainer.getAscendant( 'table', true );
+
+		// Selection must be anchored in two different blocks
+		// Boundary block is not in table (block elements are empty there).
+		if ( selectionInTwoDifferentBlocks && !hasBoundariesInTable ) {
 			return false;
+		}
 
 		editor.fire( 'saveSnapshot' );
 
 		// Remove bogus to avoid duplicated boguses.
 		var bogus;
-		if ( ( bogus = startBlock.getBogus() ) )
+		if ( ( bogus = startBlock && startBlock.getBogus() ) )
 			bogus.remove();
+
 
 		// Remove selected content. Handle cases when list, tables, etc. are partially selected (#541).
 		editor.extractSelectedHtml();

--- a/core/editable.js
+++ b/core/editable.js
@@ -2528,22 +2528,22 @@
 			endPath = range.endPath(),
 			endBlock = endPath.block;
 
-		var selectionInTwoDifferentBlocks = !startBlock || !endBlock || startBlock.equals( endBlock );
+		var selectionInSameBlock = !startBlock || !endBlock || startBlock.equals( endBlock );
 		var hasBoundariesInTable = range.startContainer.getAscendant( 'table', true ) || range.endContainer.getAscendant( 'table', true );
 
 		// Selection must be anchored in two different blocks
 		// Boundary block is not in table (block elements are empty there).
-		if ( selectionInTwoDifferentBlocks && !hasBoundariesInTable ) {
+		if ( selectionInSameBlock && !hasBoundariesInTable ) {
 			return false;
 		}
 
 		editor.fire( 'saveSnapshot' );
 
 		// Remove bogus to avoid duplicated boguses.
-		var bogus;
-		if ( ( bogus = startBlock && startBlock.getBogus() ) )
+		var bogus = startBlock && startBlock.getBogus();
+		if ( bogus ) {
 			bogus.remove();
-
+		}
 
 		// Remove selected content. Handle cases when list, tables, etc. are partially selected (#541).
 		editor.extractSelectedHtml();

--- a/core/editable.js
+++ b/core/editable.js
@@ -1204,8 +1204,15 @@
 								return;
 						}
 
+						// We need to obtain new range for creating bookmarks, as previously obtained might be modified while merging.
+						range = editor.getSelection().getRanges()[ 0 ];
+
+						// Storing selection in bookmark is temporary fix until #1956 will be merged.
+						var bm = range.createBookmark2();
 						// Scroll to the new position of the caret (https://dev.ckeditor.com/ticket/11960).
 						editor.getSelection().scrollIntoView();
+						sel.selectBookmarks( [ bm ] );
+
 						editor.fire( 'saveSnapshot' );
 
 						return false;
@@ -2545,9 +2552,9 @@
 			bogus.remove();
 		}
 
-		// Remove selected content. Handle cases when list, tables, etc. are partially selected (#541).
-		editor.extractSelectedHtml();
-
+		// Remove selected content. It appears work better than native handling "backspace"/"delete" button.
+		editor.document.$.execCommand( 'delete' );
+		editor.focus();
 		return true;
 	}
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -2553,8 +2553,12 @@
 		}
 
 		// Remove selected content. It appears work better than native handling "backspace"/"delete" button.
-		editor.document.$.execCommand( 'delete' );
-		editor.focus();
+		if ( hasBoundariesInTable ) {
+			editor.document.$.execCommand( 'delete' );
+		} else {
+			editor.extractSelectedHtml();
+		}
+
 		return true;
 	}
 

--- a/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
@@ -104,11 +104,11 @@
 
 		// Tables #541
 		// jscs:disable maximumLineLength
-		'test backspace and delete, tables no action #1':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td></tr></tbody></table><p>y</p>' ),
-		'test backspace and delete, tables no action #2':	bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td><td>@</td></tr></tbody></table><p>y</p>' ),
-		'test backspace and delete, tables no action #3':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>', '<table><tbody><tr><td>x^</td></tr></tbody></table><table><tbody><tr><td>y</td></tr></tbody></table>' ),
-		'test backspace and delete, tables no action #4':	bd( '<p>x[x</p><table><tbody><tr><td>aa</td><td>b]b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>', '<p>x^</p><table><tbody><tr><td>@</td><td>b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>' ),
-		'test backspace and delete, tables no action #5':	bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>', '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^</td><td>@</td></tr></tbody></table><p>z</p>' ),
+		'test backspace and delete, tables #1':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables #2':	bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td><td>@</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables #3':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>', '<table><tbody><tr><td>x^</td></tr></tbody></table><table><tbody><tr><td>y</td></tr></tbody></table>' ),
+		'test backspace and delete, tables #4':	bd( '<p>x[x</p><table><tbody><tr><td>aa</td><td>b]b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>', '<p>x^</p><table><tbody><tr><td>@</td><td>b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>' ),
+		'test backspace and delete, tables #5':	bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>', '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^</td><td>@</td></tr></tbody></table><p>z</p>' ),
 		'test backspace and delete, tables + paragraphs #1':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^</p></td></tr></tbody></table><p>y</p>' ),
 		'test backspace and delete, tables + paragraphs #2':	bd( '<table><tbody><tr><td><p>x[x</p></td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^</p></td><td>@</td></tr></tbody></table><p>y</p>' ),
 		'test backspace and delete, tables + paragraphs #3':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><table><tbody><tr><td><p>y]y</p></td></tr></tbody></table>' , '<table><tbody><tr><td><p>x^</p></td></tr></tbody></table><table><tbody><tr><td><p>y</p></td></tr></tbody></table>' ),

--- a/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
@@ -80,8 +80,8 @@
 		'test backspace and delete #13':				bd( '<ul><li>xx<ul><li>n[n</li><li>mm</li></ul></li></ul><p>y]y</p>',					'<ul><li>xx<ul><li>n^y</li></ul></li></ul>' ),
 		'test backspace and delete #14':				bd( '<ul><li>xx<ul><li>n[n</li><li>mm</li></ul></li><li>ww</li></ul><p>y]y</p>',		'<ul><li>xx<ul><li>n^y</li></ul></li></ul>' ),
 
-		'test backspace and delete #15':				bd( '<div>x<p>x[x</p></div><div><p>y]y</p>y</div>',										'<div>x<p>x^y</p></div><div>y</div>' ),
-		'test backspace and delete #16':				bd( '<div>x<p>x[x</p></div><div><div><div><p>y]y</p>y</div></div></div>',				'<div>x<p>x^y</p></div><div><div><div>y</div></div></div>' ),
+		'test backspace and delete #15':				bd( '<div>x<p>x[x</p></div><div><p>y]y</p>y</div>',										'<div>x<p>x^y</p>y</div>' ),
+		'test backspace and delete #16':				bd( '<div>x<p>x[x</p></div><div><div><div><p>y]y</p>y</div></div></div>',				'<div>x<p>x^y</p><div><div>y</div></div></div>' ),
 		'test backspace and delete #17':				bd( '<div><div>x<div><p>x[x</p></div></div></div><div>y<p>y]y</p></div>',				'<div><div>x<div><p>x^y</p></div></div></div>' ),
 
 		// Merge inline elements after keystroke.

--- a/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
@@ -98,11 +98,19 @@
 		'test backspace and delete, bogus #5':			bd( '<h1>{Foo</h1><p>bar</p><p><small>baz}</small></p>', '<h1>^@!</h1>' ),
 
 		// Merge inline elements after keystroke.
-		'test backspace and delete, no action #1':		bdf( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>' ),
-		'test backspace and delete, no action #2':		bdf( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>' ),
-		'test backspace and delete, no action #3':		bdf( '<span>xx[x</span><p>y]yy</p>' ),
-		'test backspace and delete, no action #4':		bdf( '<p>xx[x</p><span>y]yy</span>' ),
-		'test backspace and delete, no action #5':		bdf( '<p>x[xy]y</p>' ),
-		'test backspace and delete, no action #6':		bdf( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>' )
+		'test backspace and delete, no action #1':		bdf( '<span>xx[x</span><p>y]yy</p>' ),
+		'test backspace and delete, no action #2':		bdf( '<p>xx[x</p><span>y]yy</span>' ),
+		'test backspace and delete, no action #3':		bdf( '<p>x[xy]y</p>' ),
+
+		// Tables #541
+		'test backspace and delete, tables #1':		bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables #2':		bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td><td>@</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables #3':		bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>',
+														'<table><tbody><tr><td>x^</td></tr></tbody></table><table><tbody><tr><td>y</td></tr></tbody></table>' ),
+		'test backspace and delete, tables #4':		bd( '<p>x[x</p><table><tbody><tr><td>aa</td><td>b]b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>',
+														'<p>x^</p><table><tbody><tr><td>@</td><td>b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>' ),
+		'test backspace and delete, tables #5':		bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>',
+														'<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^</td><td>@</td></tr></tbody></table><p>z</p>' )
+
 	} );
 } )( quirksTools.bd, quirksTools.bdf, quirksTools.b, quirksTools.df );

--- a/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
@@ -103,14 +103,18 @@
 		'test backspace and delete, no action #3':		bdf( '<p>x[xy]y</p>' ),
 
 		// Tables #541
-		'test backspace and delete, tables #1':		bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td></tr></tbody></table><p>y</p>' ),
-		'test backspace and delete, tables #2':		bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td><td>@</td></tr></tbody></table><p>y</p>' ),
-		'test backspace and delete, tables #3':		bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>',
-														'<table><tbody><tr><td>x^</td></tr></tbody></table><table><tbody><tr><td>y</td></tr></tbody></table>' ),
-		'test backspace and delete, tables #4':		bd( '<p>x[x</p><table><tbody><tr><td>aa</td><td>b]b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>',
-														'<p>x^</p><table><tbody><tr><td>@</td><td>b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>' ),
-		'test backspace and delete, tables #5':		bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>',
-														'<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^</td><td>@</td></tr></tbody></table><p>z</p>' )
+		// jscs:disable maximumLineLength
+		'test backspace and delete, tables no action #1':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables no action #2':	bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td><td>@</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables no action #3':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>', '<table><tbody><tr><td>x^</td></tr></tbody></table><table><tbody><tr><td>y</td></tr></tbody></table>' ),
+		'test backspace and delete, tables no action #4':	bd( '<p>x[x</p><table><tbody><tr><td>aa</td><td>b]b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>', '<p>x^</p><table><tbody><tr><td>@</td><td>b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>' ),
+		'test backspace and delete, tables no action #5':	bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>', '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^</td><td>@</td></tr></tbody></table><p>z</p>' ),
+		'test backspace and delete, tables + paragraphs #1':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^</p></td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables + paragraphs #2':	bd( '<table><tbody><tr><td><p>x[x</p></td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^</p></td><td>@</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables + paragraphs #3':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><table><tbody><tr><td><p>y]y</p></td></tr></tbody></table>' , '<table><tbody><tr><td><p>x^</p></td></tr></tbody></table><table><tbody><tr><td><p>y</p></td></tr></tbody></table>' ),
+		'test backspace and delete, tables + paragraphs #4':	bd( '<p>x[x</p><table><tbody><tr><td><p>aa</p></td><td><p>b]b</p></td></tr><tr><td><p>cc</p></td><td><p>dd</p></td></tr></tbody></table><p>zz</p>' , '<p>x^</p><table><tbody><tr><td>@</td><td><p>b</p></td></tr><tr><td><p>cc</p></td><td><p>dd</p></td></tr></tbody></table><p>zz</p>' ),
+		'test backspace and delete, tables + paragraphs #5':	bd( '<p>xx</p><table><tbody><tr><td><p>aa</p></td><td><p>bb</p></td></tr><tr><td><p>c[c</p></td><td><p>dd</p></td></tr></tbody></table><p>z]z</p>' , '<p>xx</p><table><tbody><tr><td><p>aa</p></td><td><p>bb</p></td></tr><tr><td><p>c^</p></td><td>@</td></tr></tbody></table><p>z</p>' )
+		// jscs:enable maximumLineLength
 
 	} );
 } )( quirksTools.bd, quirksTools.bdf, quirksTools.b, quirksTools.df );

--- a/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
+++ b/tests/core/editable/keystrokes/delbackspacequirks/expanded.js
@@ -104,16 +104,16 @@
 
 		// Tables #541
 		// jscs:disable maximumLineLength
-		'test backspace and delete, tables #1':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td></tr></tbody></table><p>y</p>' ),
-		'test backspace and delete, tables #2':	bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^</td><td>@</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables #1':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^y</td></tr></tbody></table>' ),
+		'test backspace and delete, tables #2':	bd( '<table><tbody><tr><td>x[x</td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td>x^y</td><td>@</td></tr></tbody></table>' ),
 		'test backspace and delete, tables #3':	bd( '<table><tbody><tr><td>x[x</td></tr></tbody></table><table><tbody><tr><td>y]y</td></tr></tbody></table>', '<table><tbody><tr><td>x^</td></tr></tbody></table><table><tbody><tr><td>y</td></tr></tbody></table>' ),
 		'test backspace and delete, tables #4':	bd( '<p>x[x</p><table><tbody><tr><td>aa</td><td>b]b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>', '<p>x^</p><table><tbody><tr><td>@</td><td>b</td></tr><tr><td>cc</td><td>dd</td></tr></tbody></table><p>zz</p>' ),
-		'test backspace and delete, tables #5':	bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>', '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^</td><td>@</td></tr></tbody></table><p>z</p>' ),
-		'test backspace and delete, tables + paragraphs #1':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^</p></td></tr></tbody></table><p>y</p>' ),
-		'test backspace and delete, tables + paragraphs #2':	bd( '<table><tbody><tr><td><p>x[x</p></td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^</p></td><td>@</td></tr></tbody></table><p>y</p>' ),
+		'test backspace and delete, tables #5':	bd( '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c[c</td><td>dd</td></tr></tbody></table><p>z]z</p>', '<p>xx</p><table><tbody><tr><td>aa</td><td>bb</td></tr><tr><td>c^z</td><td>@</td></tr></tbody></table>' ),
+		'test backspace and delete, tables + paragraphs #1':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^y</p></td></tr></tbody></table>' ),
+		'test backspace and delete, tables + paragraphs #2':	bd( '<table><tbody><tr><td><p>x[x</p></td><td>zz</td></tr></tbody></table><p>y]y</p>', '<table><tbody><tr><td><p>x^y</p></td><td>@</td></tr></tbody></table>' ),
 		'test backspace and delete, tables + paragraphs #3':	bd( '<table><tbody><tr><td><p>x[x</p></td></tr></tbody></table><table><tbody><tr><td><p>y]y</p></td></tr></tbody></table>' , '<table><tbody><tr><td><p>x^</p></td></tr></tbody></table><table><tbody><tr><td><p>y</p></td></tr></tbody></table>' ),
 		'test backspace and delete, tables + paragraphs #4':	bd( '<p>x[x</p><table><tbody><tr><td><p>aa</p></td><td><p>b]b</p></td></tr><tr><td><p>cc</p></td><td><p>dd</p></td></tr></tbody></table><p>zz</p>' , '<p>x^</p><table><tbody><tr><td>@</td><td><p>b</p></td></tr><tr><td><p>cc</p></td><td><p>dd</p></td></tr></tbody></table><p>zz</p>' ),
-		'test backspace and delete, tables + paragraphs #5':	bd( '<p>xx</p><table><tbody><tr><td><p>aa</p></td><td><p>bb</p></td></tr><tr><td><p>c[c</p></td><td><p>dd</p></td></tr></tbody></table><p>z]z</p>' , '<p>xx</p><table><tbody><tr><td><p>aa</p></td><td><p>bb</p></td></tr><tr><td><p>c^</p></td><td>@</td></tr></tbody></table><p>z</p>' )
+		'test backspace and delete, tables + paragraphs #5':	bd( '<p>xx</p><table><tbody><tr><td><p>aa</p></td><td><p>bb</p></td></tr><tr><td><p>c[c</p></td><td><p>dd</p></td></tr></tbody></table><p>z]z</p>' , '<p>xx</p><table><tbody><tr><td><p>aa</p></td><td><p>bb</p></td></tr><tr><td><p>c^z</p></td><td>@</td></tr></tbody></table>' )
 		// jscs:enable maximumLineLength
 
 	} );

--- a/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.html
+++ b/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.html
@@ -1,0 +1,91 @@
+<textarea id="classic">
+	<p>Table without paragraphs.</p>
+	<p>Fo&rarr;o</p>
+	<table border="1">
+		<tbody>
+			<tr>
+				<td>AA</td>
+				<td>B&larr;B</td>
+				<td>CC</td>
+			</tr>
+			<tr>
+				<td>DD</td>
+				<td>E&rarr;E</td>
+				<td>FF</td>
+			</tr>
+		</tbody>
+	</table>
+	<p>Ba&larr;r</p>
+	<p>&nbsp;</p>
+	<p>Table with paragraphs.</p>
+	<p>Fo&rarr;o</p>
+	<table border="1">
+		<tbody>
+			<tr>
+				<td><p>A&larr;A</p></td>
+				<td><p>BB</p></td>
+				<td><p>CC</p></td>
+			</tr>
+			<tr>
+				<td><p>DD</p></td>
+				<td><p>EE</p></td>
+				<td><p>F&rarr;F</p></td>
+			</tr>
+		</tbody>
+	</table>
+	<p>Ba&larr;r</p>
+</textarea>
+
+<div contenteditable="true" id="divarea">
+	<p>Table without paragraphs.</p>
+	<p>Fo&rarr;o</p>
+	<table border="1">
+		<tbody>
+			<tr>
+				<td>AA</td>
+				<td>B&larr;B</td>
+				<td>CC</td>
+			</tr>
+			<tr>
+				<td>DD</td>
+				<td>E&rarr;E</td>
+				<td>FF</td>
+			</tr>
+		</tbody>
+	</table>
+	<p>Ba&larr;r</p>
+	<p>&nbsp;</p>
+	<p>Table with paragraphs.</p>
+	<p>Fo&rarr;o</p>
+	<table border="1">
+		<tbody>
+			<tr>
+				<td><p>A&larr;A</p></td>
+				<td><p>BB</p></td>
+				<td><p>CC</p></td>
+			</tr>
+			<tr>
+				<td><p>DD</p></td>
+				<td><p>EE</p></td>
+				<td><p>F&rarr;F</p></td>
+			</tr>
+		</tbody>
+	</table>
+	<p>Ba&larr;r</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.webkit ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic', {
+		height: 600,
+		removePlugins: 'tableselection'
+	} );
+	CKEDITOR.replace( 'divarea', {
+		height: 600,
+		extraPlugins: 'divarea',
+		removePlugins: 'tableselection'
+	} );
+</script>

--- a/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.html
+++ b/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.html
@@ -22,14 +22,14 @@
 	<table border="1">
 		<tbody>
 			<tr>
-				<td><p>A&larr;A</p></td>
-				<td><p>BB</p></td>
+				<td><p>AA</p></td>
+				<td><p>B&larr;B</p></td>
 				<td><p>CC</p></td>
 			</tr>
 			<tr>
 				<td><p>DD</p></td>
-				<td><p>EE</p></td>
-				<td><p>F&rarr;F</p></td>
+				<td><p>E&rarr;E</p></td>
+				<td><p>FF</p></td>
 			</tr>
 		</tbody>
 	</table>
@@ -60,14 +60,14 @@
 	<table border="1">
 		<tbody>
 			<tr>
-				<td><p>A&larr;A</p></td>
-				<td><p>BB</p></td>
+				<td><p>AA</p></td>
+				<td><p>B&larr;B</p></td>
 				<td><p>CC</p></td>
 			</tr>
 			<tr>
 				<td><p>DD</p></td>
-				<td><p>EE</p></td>
-				<td><p>F&rarr;F</p></td>
+				<td><p>E&rarr;E</p></td>
+				<td><p>FF</p></td>
 			</tr>
 		</tbody>
 	</table>

--- a/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.md
+++ b/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.10.0, bug, #541
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, table, tabletools, sourcearea, resize, undo, clipboard
+
+----
+
+**Repeat steps for both editors and both tables inside each of them.**
+
+1. Select content between first pair of arrows. It has to start/end outside of a table and has to end/start inside of a table.
+2. Press <kbd>Backspace</kbd> or <kbd>Delete</kbd>
+3. Now select content between second pair of arrows and repeat step 2.
+
+**Expected:** Selected text will be nicely removed.
+
+**Unexpected:**
+	* Table cells are removed
+	* Content from paragraph is moved inside a table
+	* Content from table is moved outside

--- a/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.md
+++ b/tests/core/editable/keystrokes/delbackspacequirks/manual/tables.md
@@ -10,9 +10,9 @@
 2. Press <kbd>Backspace</kbd> or <kbd>Delete</kbd>
 3. Now select content between second pair of arrows and repeat step 2.
 
-**Expected:** Selected text will be nicely removed.
+**Expected:**
+	* Selected text will be removed.
+	* Text from paragraph might be merged with table content. This behaviour has to be coherent with using regular keys over selection.
 
 **Unexpected:**
 	* Table cells are removed
-	* Content from paragraph is moved inside a table
-	* Content from table is moved outside

--- a/tests/core/editable/keystrokes/keystrokes.js
+++ b/tests/core/editable/keystrokes/keystrokes.js
@@ -97,10 +97,10 @@ bender.test( {
 		'<table><tbody><tr><td><p><b><i>[foo]</i></b></p></td></tr></tbody></table>' ,
 		'^', 'table b2' );
 
-		// Adverse tests.
+		// Since #541 webkit browsers will process this markup other remain it untouched to be processed natively by the browser.
 		this.assertKeystroke( DEL, 0,
 		'<table><tbody><tr><td>[foo]bar</td></tr></tbody></table>' ,
-		'(not handled)', 'table r1' );
+		CKEDITOR.env.webkit ? '<table><tbody><tr><td>^bar</td></tr></tbody></table>' : '(not handled)', 'table r1' );
 
 		// Make sure that the modifiers are ignored.
 		// https://dev.ckeditor.com/ticket/11861#comment:13
@@ -170,12 +170,12 @@ bender.test( {
 	},
 
 	// https://dev.ckeditor.com/ticket/13096
-    'test deleting text without selection with DEL key': function() {
+	'test deleting text without selection with DEL key': function() {
 		var editor = this.editor,
 			bot = this.editorBot;
 		editor.focus();
 
-		bot.setHtmlWithSelection('<p>^Foo</p>');
+		bot.setHtmlWithSelection( '<p>^Foo</p>' );
 		editor.getSelection().removeAllRanges();
 		editor.fire( 'key', {
 			domEvent: {
@@ -192,7 +192,7 @@ bender.test( {
 			bot = this.editorBot;
 
 		editor.focus();
-		bot.setHtmlWithSelection('<p>^Foo</p>');
+		bot.setHtmlWithSelection( '<p>^Foo</p>' );
 		editor.getSelection().removeAllRanges();
 		editor.fire( 'key', {
 			domEvent: {


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?
* use `editor.extractSelectedHtml` instead of current logic to remove content from the editor after pressing <kbd>Backspace</kbd> or <kbd>Delete</kbd>
* correct bunch of test
* Unfortunately this solution has 2 minor things:
    * nested tables are still wrongly processed what is caused by this issue: #1880
    * identical elements might be merged #1881 (because of that test `#15` and `#16` are changed)

Close #541 