### PR TITLE
Allow non-draggable widgets to capture mouse clicks

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2625,6 +2625,10 @@
 
 				// Widget was clicked, but not editable nested in it.
 				if ( widget ) {
+                     // Ignore mousedown if the widget is not draggable.
+                     if ( !widget.draggable ) {
+                        return;
+                    }
 					// Ignore mousedown on drag and drop handler if the widget is inline.
 					// Block widgets are handled by Lineutils.
 					if ( widget.inline && target.type == CKEDITOR.NODE_ELEMENT && target.hasAttribute( 'data-cke-widget-drag-handler' ) ) {


### PR DESCRIPTION
Currently, mouse clicks are eaten by the generic widget handler with seemingly no mechanism for preserving them. This breaks the use of `<select>` tags inside widgets.

I have no idea how to write a test case for this though.