### PR TITLE
Ability to configure split button in config.toolbar property

### DIFF
--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -140,8 +140,8 @@
 				 * @since 4.11.0
 				 * @constructor
 				 * @param {Object} definition The Split Button definition
-				 * @param {Object[]} definition.items An array of Split Button dropdown items
-				 * @param {Object} [definition.face] Item which will be Split Button face
+				 * @param {Object[]/String[]} definition.items An array of Split Button dropdown items
+				 * @param {Object/String} [definition.face] Item which will be Split Button face
 				 * @param {String} [definition.default] Item which will be Split Button face when there is no face defined and none of items is currently active
 				 */
 				$: function( definition ) {

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -44,6 +44,10 @@
 			if ( typeof item === 'string' ) {
 				item = CKEDITOR.tools.clone( editor.ui.items[ item ] );
 
+				// It is possible to define CKEDITOR.ui.button instance without `icon` property defined.
+				// In such case icon name will fallback to `name` or `command`. However CKEDITOR.ui.menu doesn't have such logic for its items.
+				// We need to reverse this fallback to pass an icon name to the menu item.
+				// See comment (https://github.com/ckeditor/ckeditor-dev/pull/2094#discussion_r196684673).
 				if ( !item.icon ) {
 					item.icon = item.name || item.command;
 				}

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -120,7 +120,7 @@
 				previousButton = properties.buttons[ item.id ];
 				defaultButton = properties.buttons[ item.id ];
 			} else {
-				if ( definition[ 'default' ] === item.name ) {
+				if ( definition[ 'default' ] && definition[ 'default' ].toLowerCase() === item.name ) {
 					defaultButton && defaultButton.hide();
 					defaultButton = properties.buttons[ item.id ];
 				} else {

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -27,7 +27,7 @@
 		if ( face ) {
 			// Split Button can be defined with simpler definition via strings, needed by #2091
 			if ( typeof face === 'string' ) {
-				face = editor.ui.items[ face ];
+				face = CKEDITOR.tools.clone( editor.ui.items[ face ] );
 
 				if ( !face.icon ) {
 					face.icon = face.name || face.command;
@@ -46,7 +46,7 @@
 
 			// Split Button can be defined with simpler definition via strings, needed by #2091
 			if ( typeof item === 'string' ) {
-				item = editor.ui.items[ item ];
+				item = CKEDITOR.tools.clone( editor.ui.items[ item ] );
 
 				if ( !item.icon ) {
 					item.icon = item.name || item.command;

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -111,10 +111,13 @@
 
 			editor.addFeature( properties.buttons[ item.id ] );
 
-			// If no default button was defined then first button will act as default.
-			if ( !defaultButton && !definition[ 'default' ] ) {
+			// Store first item as default. It will be overwritten by actual default if it exists and has correct value.
+			if ( !defaultButton ) {
 				defaultButton = properties.buttons[ item.id ];
 			} else if ( definition[ 'default' ] && definition[ 'default' ].toLowerCase() === item.name ) {
+				if ( defaultButton ) {
+					defaultButton.hide();
+				}
 				defaultButton = properties.buttons[ item.id ];
 			} else {
 				properties.buttons[ item.id ].hide();

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -25,7 +25,7 @@
 			defaultButton;
 
 		if ( face ) {
-			// Split Button can be defined with simpler definition via strings, needed by #2091
+			// Split Button can be defined with simpler definition via strings, needed by (#2091).
 			if ( typeof face === 'string' ) {
 				face = CKEDITOR.tools.clone( editor.ui.items[ face ] );
 
@@ -44,7 +44,7 @@
 		for ( i in allItems ) {
 			item = allItems[ i ];
 
-			// Split Button can be defined with simpler definition via strings, needed by #2091
+			// Split Button can be defined with simpler definition via strings, needed by (#2091).
 			if ( typeof item === 'string' ) {
 				item = CKEDITOR.tools.clone( editor.ui.items[ item ] );
 

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -28,10 +28,6 @@
 			// Split Button can be defined with simpler definition via strings, needed by (#2091).
 			if ( typeof face === 'string' ) {
 				face = CKEDITOR.tools.clone( editor.ui.items[ face ] );
-
-				if ( !face.icon ) {
-					face.icon = face.name || face.command;
-				}
 			}
 			face.click = face.click || face.onClick ||  function() {
 				editor.execCommand( face.command, face.commandData );
@@ -117,15 +113,11 @@
 
 			// If no default button was defined then first button will act as default.
 			if ( !defaultButton && !definition[ 'default' ] ) {
-				previousButton = properties.buttons[ item.id ];
+				defaultButton = properties.buttons[ item.id ];
+			} else if ( definition[ 'default' ] && definition[ 'default' ].toLowerCase() === item.name ) {
 				defaultButton = properties.buttons[ item.id ];
 			} else {
-				if ( definition[ 'default' ] && definition[ 'default' ].toLowerCase() === item.name ) {
-					defaultButton && defaultButton.hide();
-					defaultButton = properties.buttons[ item.id ];
-				} else {
-					properties.buttons[ item.id ].hide();
-				}
+				properties.buttons[ item.id ].hide();
 			}
 		}
 		return properties;

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -21,10 +21,19 @@
 			face = definition.face,
 			i,
 			item,
+			itemName,
 			previousButton,
 			defaultButton;
 
 		if ( face ) {
+			// Split Button can be defined with simpler definition via strings, needed by #2091
+			if ( typeof face === 'string' ) {
+				face = editor.ui.items[ face ];
+
+				if ( !face.icon ) {
+					face.icon = face.name || face.command;
+				}
+			}
 			face.click = face.click || face.onClick ||  function() {
 				editor.execCommand( face.command, face.commandData );
 			};
@@ -34,7 +43,21 @@
 		}
 
 		for ( i in allItems ) {
-			item = allItems[ i ];
+			itemName = item = allItems[ i ];
+
+			// Split Button can be defined with simpler definition via strings, needed by #2091
+			if ( typeof item === 'string' ) {
+				item = editor.ui.items[ item ];
+
+				if ( !item.icon ) {
+					item.icon = item.name || item.command;
+				}
+
+				if ( definition[ 'default' ] === itemName ) {
+					item[ 'default' ] = true;
+				}
+				allItems[ i ] = item;
+			}
 
 			if ( !item.group ) {
 				item.group = definition.label + '_default';

--- a/plugins/splitbutton/plugin.js
+++ b/plugins/splitbutton/plugin.js
@@ -21,7 +21,6 @@
 			face = definition.face,
 			i,
 			item,
-			itemName,
 			previousButton,
 			defaultButton;
 
@@ -43,7 +42,7 @@
 		}
 
 		for ( i in allItems ) {
-			itemName = item = allItems[ i ];
+			item = allItems[ i ];
 
 			// Split Button can be defined with simpler definition via strings, needed by #2091
 			if ( typeof item === 'string' ) {
@@ -53,11 +52,10 @@
 					item.icon = item.name || item.command;
 				}
 
-				if ( definition[ 'default' ] === itemName ) {
-					item[ 'default' ] = true;
-				}
 				allItems[ i ] = item;
 			}
+
+			item.name = item.name || item.command;
 
 			if ( !item.group ) {
 				item.group = definition.label + '_default';
@@ -117,12 +115,12 @@
 
 			editor.addFeature( properties.buttons[ item.id ] );
 
-			// First button as default. It might be overwritten by actual default button.
-			if ( !defaultButton && !item[ 'default' ] ) {
+			// If no default button was defined then first button will act as default.
+			if ( !defaultButton && !definition[ 'default' ] ) {
 				previousButton = properties.buttons[ item.id ];
 				defaultButton = properties.buttons[ item.id ];
 			} else {
-				if ( item[ 'default' ] ) {
+				if ( definition[ 'default' ] === item.name ) {
 					defaultButton && defaultButton.hide();
 					defaultButton = properties.buttons[ item.id ];
 				} else {

--- a/plugins/splitbutton/samples/sampleplugins/justifysplit.js
+++ b/plugins/splitbutton/samples/sampleplugins/justifysplit.js
@@ -9,11 +9,11 @@ CKEDITOR.plugins.add( 'justifysplit', {
 
 		editor.ui.add( 'JustifySplit', CKEDITOR.UI_SPLITBUTTON, {
 			label: 'Text Align',
+			'default': 'justifyleft',
 			items: [ {
 				label: 'Left',
 				command: 'justifyleft',
-				icon: 'justifyleft',
-				'default': true
+				icon: 'justifyleft'
 			}, {
 				label: 'Center',
 				command: 'justifycenter',

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -535,11 +535,9 @@
 
 					// Ignore items that are configured to be removed.
 					if ( !removeButtons || CKEDITOR.tools.indexOf( removeButtons, name ) == -1 ) {
-						// Option to define Split Button or other UI elements in `config.toolbar` #2091
-						if ( item.type ) {
-							if ( item.type in editor.ui._.handlers ) {
-								editor.ui.add( name, item.type, item );
-							}
+						// Option to define UI element in `config.toolbar` (#2091).
+						if ( item.type && item.type in editor.ui._.handlers ) {
+							editor.ui.add( name, item.type, item );
 						}
 						item = editor.ui.create( name );
 

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -724,8 +724,8 @@ CKEDITOR.config.toolbarLocation = 'top';
  *		// Load toolbar_Name where Name = Basic.
  *		config.toolbar = 'Basic';
  *
- *	*Since 4.11.0* item can be a {@link CKEDITOR.ui.item}.
- *	Such item will be passed as an argument to {@CKEDITOR.ui.add}.
+ *	**Since 4.11.0:** item can be a {@link CKEDITOR.ui.toolbarItem}.
+ *	Such item will be passed as an argument to {@link CKEDITOR.ui#add}.
  *
  * @cfg {Array/String} [toolbar=null]
  * @member CKEDITOR.config
@@ -832,10 +832,20 @@ CKEDITOR.config.toolbarLocation = 'top';
  *
  * This virtual class illustrates the properties that developers have to use to define and create new UI element.
  *
- * *Note* other properties vary depending on item type which is defined.
+ * **Note:** other properties vary depending on item type which is defined.
  *
- * @class CKEDITOR.toolbar.item
- * @property {String} name UI element name
- * @property {String} type UI item type, added by {@link CKEDITOR.ui.addHandler}
+ * @class CKEDITOR.ui.toolbarItem
  * @abstract
+ */
+
+/**
+ * UI element name.
+ *
+ * @property {String} name
+ */
+
+/**
+ * UI item type, added by {@link CKEDITOR.ui.addHandler}.
+ *
+ * @property {String} type
  */

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -724,6 +724,9 @@ CKEDITOR.config.toolbarLocation = 'top';
  *		// Load toolbar_Name where Name = Basic.
  *		config.toolbar = 'Basic';
  *
+ *	*Since 4.11.0* item can be a {@link CKEDITOR.ui.item}.
+ *	Such item will be passed as an argument to {@CKEDITOR.ui.add}.
+ *
  * @cfg {Array/String} [toolbar=null]
  * @member CKEDITOR.config
  */
@@ -822,4 +825,17 @@ CKEDITOR.config.toolbarLocation = 'top';
  * @readonly
  * @property {Object} toolbar
  * @member CKEDITOR.editor
+ */
+
+/**
+ * Abstract class describing the UI element defined in {@link CKEDITOR.config.toolbar}.
+ *
+ * This virtual class illustrates the properties that developers have to use to define and create new UI element.
+ *
+ * *Note* other properties vary depending on item type which is defined.
+ *
+ * @class CKEDITOR.toolbar.item
+ * @property {String} name UI element name
+ * @property {String} type UI item type, added by {@link CKEDITOR.ui.addHandler}
+ * @abstract
  */

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -535,6 +535,12 @@
 
 					// Ignore items that are configured to be removed.
 					if ( !removeButtons || CKEDITOR.tools.indexOf( removeButtons, name ) == -1 ) {
+						// Option to define Split Button or other UI elements in `config.toolbar` #2091
+						if ( item.type ) {
+							if ( item.type in editor.ui._.handlers ) {
+								editor.ui.add( name, item.type, item );
+							}
+						}
 						item = editor.ui.create( name );
 
 						if ( !item )

--- a/tests/plugins/button/button.js
+++ b/tests/plugins/button/button.js
@@ -29,9 +29,6 @@ bender.editor = {
 					label: 'button without icon',
 					icon: false
 				} );
-				ed.ui.addButton( 'hidden_btn', {
-					label: 'hidden button'
-				} );
 			}
 		}
 	}
@@ -70,6 +67,7 @@ bender.test( {
 			btnEl = CKEDITOR.document.getById( btn._.id );
 		assert.isNull( btnEl.findOne( '.cke_button_icon' ) );
 	},
+
 	'test hiding button from toolbar': function() {
 		var btn = this.editor.ui.get( 'custom_btn' ),
 			btnEl = CKEDITOR.document.getById( btn._.id );

--- a/tests/plugins/button/button.js
+++ b/tests/plugins/button/button.js
@@ -29,6 +29,9 @@ bender.editor = {
 					label: 'button without icon',
 					icon: false
 				} );
+				ed.ui.addButton( 'hidden_btn', {
+					label: 'hidden button'
+				} );
 			}
 		}
 	}
@@ -68,6 +71,7 @@ bender.test( {
 		assert.isNull( btnEl.findOne( '.cke_button_icon' ) );
 	},
 
+	// (#2091)
 	'test hiding button from toolbar': function() {
 		var btn = this.editor.ui.get( 'custom_btn' ),
 			btnEl = CKEDITOR.document.getById( btn._.id );

--- a/tests/plugins/splitbutton/integration/manual/balloontoolbar.html
+++ b/tests/plugins/splitbutton/integration/manual/balloontoolbar.html
@@ -17,11 +17,11 @@
 			var lang = editor.lang.basicstyles;
 			editor.ui.add( 'teststylesplit', CKEDITOR.UI_SPLITBUTTON, {
 				label: 'Basic Styles',
+				'default': 'bold',
 				items: [ {
 					label: lang.bold,
 					command: 'bold',
-					icon: 'bold',
-					'default': true
+					icon: 'bold'
 				}, {
 					label: lang.italic,
 					command: 'italic',

--- a/tests/plugins/splitbutton/manual/skins/moono-lisa.html
+++ b/tests/plugins/splitbutton/manual/skins/moono-lisa.html
@@ -9,11 +9,11 @@
 			var lang = editor.lang.basicstyles;
 			editor.ui.add( 'teststylesplit', CKEDITOR.UI_SPLITBUTTON, {
 				label: 'Basic Styles',
+				'default': 'bold',
 				items: [ {
 					label: lang.bold,
 					command: 'bold',
-					icon: 'bold',
-					'default': true
+					icon: 'bold'
 				}, {
 					label: lang.italic,
 					command: 'italic',

--- a/tests/plugins/splitbutton/manual/skins/moono.html
+++ b/tests/plugins/splitbutton/manual/skins/moono.html
@@ -9,11 +9,11 @@
 			var lang = editor.lang.basicstyles;
 			editor.ui.add( 'teststylesplit', CKEDITOR.UI_SPLITBUTTON, {
 				label: 'Basic Styles',
+				'default': 'bold',
 				items: [ {
 					label: lang.bold,
 					command: 'bold',
-					icon: 'bold',
-					'default': true
+					icon: 'bold'
 				}, {
 					label: lang.italic,
 					command: 'italic',

--- a/tests/plugins/splitbutton/manual/skins/splitbutton.html
+++ b/tests/plugins/splitbutton/manual/skins/splitbutton.html
@@ -9,11 +9,11 @@
 			var lang = editor.lang.basicstyles;
 			editor.ui.add( 'teststylesplit', CKEDITOR.UI_SPLITBUTTON, {
 				label: 'Basic Styles',
+				default: 'bold',
 				items: [ {
 					label: lang.bold,
 					command: 'bold',
-					icon: 'bold',
-					'default': true
+					icon: 'bold'
 				}, {
 					label: lang.italic,
 					command: 'italic',

--- a/tests/plugins/splitbutton/manual/splitbutton.html
+++ b/tests/plugins/splitbutton/manual/splitbutton.html
@@ -9,11 +9,11 @@
 			var lang = editor.lang.basicstyles;
 			editor.ui.add( 'teststylesplit', CKEDITOR.UI_SPLITBUTTON, {
 				label: 'Basic Styles',
+				'default': 'bold',
 				items: [ {
 					label: lang.bold,
 					command: 'bold',
-					icon: 'bold',
-					'default': true
+					icon: 'bold'
 				}, {
 					label: lang.italic,
 					command: 'italic',

--- a/tests/plugins/splitbutton/manual/toolbar.html
+++ b/tests/plugins/splitbutton/manual/toolbar.html
@@ -12,7 +12,7 @@
 			name: 'BasicStylesSplitButton',
 			label: 'Basic styles',
 			face: 'Bold',
-			items: [ 'Bold' , 'Italic', 'Underline' ],
+			items: [ 'Bold' , 'Italic', 'Underline' ]
 		} ], [ {
 			type: 'splitbutton',
 			name: 'JustifySplitButton',

--- a/tests/plugins/splitbutton/manual/toolbar.html
+++ b/tests/plugins/splitbutton/manual/toolbar.html
@@ -1,0 +1,25 @@
+<textarea id="editor">
+	<p>Text</p>
+	<p style="text-align: center;"><strong>Text</strong></p>
+	<p style="text-align: right;"><em>Text</em></p>
+	<p style="text-align: justify;"><u>Text</u></p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		toolbar: [ [ {
+			type: 'splitbutton',
+			name: 'BasicStylesSplitButton',
+			label: 'Basic styles',
+			face: 'Bold',
+			items: [ 'Bold' , 'Italic', 'Underline' ],
+		} ], [ {
+			type: 'splitbutton',
+			name: 'JustifySplitButton',
+			label: 'Justify',
+			items: [ 'JustifyLeft' , 'JustifyCenter', 'JustifyRight', 'JustifyBlock' ],
+			'default': 'JustifyRight'
+			} ]
+		]
+	} );
+</script>

--- a/tests/plugins/splitbutton/manual/toolbar.md
+++ b/tests/plugins/splitbutton/manual/toolbar.md
@@ -1,0 +1,11 @@
+@bender-ui: collapsed
+@bender-tags: feature, 4.10.0, 1679
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, splitbutton, basicstyles, justify
+
+# Creating Split Button with `config.toolbar`
+
+## Things to test:
+
+- Check if Split Buttons and menu items are rendered properly with icons and labels.
+- First Split Button have a static face, which means main button should look and work the same all the time.
+- Second Split Button have a dynamic face, which means main button should match current active command.

--- a/tests/plugins/splitbutton/manual/toolbar.md
+++ b/tests/plugins/splitbutton/manual/toolbar.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: feature, 4.10.0, 1679
+@bender-tags: feature, 4.11.0, 1679
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, splitbutton, basicstyles, justify
 
 # Creating Split Button with `config.toolbar`

--- a/tests/plugins/splitbutton/splitbutton.js
+++ b/tests/plugins/splitbutton/splitbutton.js
@@ -31,6 +31,11 @@
 							'default': 'bold'
 						} );
 
+						editor.ui.add( 'wrongdefault', CKEDITOR.UI_SPLITBUTTON, {
+							items: items,
+							'default': 'foo'
+						} );
+
 						editor.ui.add( 'staticface', CKEDITOR.UI_SPLITBUTTON, {
 							face: {
 								command: 'bold',
@@ -67,6 +72,12 @@
 					toolbar: [ [ {
 						type: 'splitbutton',
 						name: 'teststylesplit',
+						'default': 'bold',
+						items: items
+					}, {
+						type: 'splitbutton',
+						name: 'wrongdefault',
+						'default': 'foo',
 						items: items
 					}, {
 						type: 'splitbutton',
@@ -119,6 +130,14 @@
 				key = key.substring( 0, key.length - 1 );
 				assert.isTrue( key in items );
 			}
+		},
+		'test split button with wrong default item value': function( editor ) {
+			var splitButton = editor.ui.get( 'wrongdefault' ),
+				button = splitButton.buttons.bold0,
+				element = CKEDITOR.document.findOne( '#' + button._.id );
+
+			// Bold as first item should become default item and be visible.
+			assert.isFalse( element.getStyle( 'display' ) === 'none' );
 		},
 		'test state of split button buttons': function( editor ) {
 			var splitButton = editor.ui.get( 'teststylesplit' ),

--- a/tests/plugins/splitbutton/splitbutton.js
+++ b/tests/plugins/splitbutton/splitbutton.js
@@ -15,8 +15,7 @@
 							},
 							items = [ {
 								command: 'bold',
-								icon: 'bold',
-								'default': true
+								icon: 'bold'
 							}, {
 								command: 'italic',
 								icon: 'italic'
@@ -32,7 +31,8 @@
 							} ];
 
 						editor.ui.add( 'teststylesplit', CKEDITOR.UI_SPLITBUTTON, {
-							items: items
+							items: items,
+							'default': 'bold'
 						} );
 
 						editor.ui.add( 'staticface', CKEDITOR.UI_SPLITBUTTON, {


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_contributing_code-section-tests),
[how to set the testing environment](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests) and
[how to create tests](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_tests-section-creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

This feature is rather straight forward. I've selected base as `t/1679` so GH displays real diff for this branch.

Closes #2091 