### PR TITLE
Fixed failing test tests/plugins/widget/nestededitables on IE

### DIFF
--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -979,13 +979,15 @@
 				CKEDITOR.document.getById( 'some_input' ).focus();
 
 				editor.once( 'blur', function() {
-					resume();
-					assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
-					assert.isFalse( !!widget.focusedEditable, 'editable is not focused' );
+					resume( function() {
+							assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
+							assert.isFalse( !!widget.focusedEditable, 'editable is not focused' );
 
-					editor.focus();
-					assert.isTrue( editor.focusManager.hasFocus, 'editor has focus again' );
-					assert.areSame( eFoo, widget.focusedEditable, 'editable is focused again' );
+							editor.focus();
+							assert.isTrue( editor.focusManager.hasFocus, 'editor has focus again' );
+							assert.areSame( eFoo, widget.focusedEditable, 'editable is focused again' );
+						}
+					);
 				} );
 
 				CKEDITOR.document.getById( 'some_input' ).focus();
@@ -1107,14 +1109,16 @@
 				CKEDITOR.document.getById( 'some_input' ).focus();
 
 				editor.once( 'blur', function() {
-					resume();
-					assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
+					resume( function() {
+							assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
 
-					selectionChanged = 0;
+							selectionChanged = 0;
 
-					eFoo.focus();
+							eFoo.focus();
 
-					assert.isTrue( !!selectionChanged, 'selectionChange fired second time on next focus' );
+							assert.isTrue( !!selectionChanged, 'selectionChange fired second time on next focus' );
+						}
+					);
 				} );
 
 				CKEDITOR.document.getById( 'some_input' ).focus();

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -978,14 +978,19 @@
 
 				CKEDITOR.document.getById( 'some_input' ).focus();
 
-				wait( function() {
+				editor.once( 'blur', function() {
+					resume();
 					assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
 					assert.isFalse( !!widget.focusedEditable, 'editable is not focused' );
 
 					editor.focus();
 					assert.isTrue( editor.focusManager.hasFocus, 'editor has focus again' );
 					assert.areSame( eFoo, widget.focusedEditable, 'editable is focused again' );
-				}, 210 );
+				} );
+
+				CKEDITOR.document.getById( 'some_input' ).focus();
+
+				wait();
 			} );
 		},
 
@@ -1101,7 +1106,8 @@
 
 				CKEDITOR.document.getById( 'some_input' ).focus();
 
-				wait( function() {
+				editor.once( 'blur', function() {
+					resume();
 					assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
 
 					selectionChanged = 0;
@@ -1109,7 +1115,11 @@
 					eFoo.focus();
 
 					assert.isTrue( !!selectionChanged, 'selectionChange fired second time on next focus' );
-				}, 210 );
+				} );
+
+				CKEDITOR.document.getById( 'some_input' ).focus();
+
+				wait();
 			} );
 		},
 

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1011,7 +1011,19 @@
 				var widget = getWidgetById( editor, 'w1' ),
 					eFoo = widget.editables.foo;
 
-				wait( function() {
+				// If editor still has focus assert on blur, else assert right away.
+				if ( editor.focusManager.hasFocus ) {
+					editor.once( 'blur', function() {
+						resume( function() {
+							assertEditorFocus();
+						} );
+					} );
+					wait();
+				} else {
+					assertEditorFocus();
+				}
+
+				function assertEditorFocus() {
 					assert.isFalse( editor.focusManager.hasFocus, 'editor lost focus' );
 					assert.isFalse( !!widget.focusedEditable, 'editable is not focused' );
 
@@ -1024,7 +1036,7 @@
 
 					assert.areSame( eFoo, widget.focusedEditable, 'editable is focused' );
 					assert.isTrue( editor.focusManager.hasFocus, 'editor has focus' );
-				}, 210 );
+				}
 			} );
 		},
 

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1049,16 +1049,14 @@
 				}
 			} );
 
-			wait( function() {
-				this.editorBot.setData( '<p id="x">X</p><div data-widget="testdestroy1" id="w1"><p id="foo">B</p></div>', function() {
-					var widget = getWidgetById( editor, 'w1' );
+			this.editorBot.setData( '<p id="x">X</p><div data-widget="testdestroy1" id="w1"><p id="foo">B</p></div>', function() {
+				var widget = getWidgetById( editor, 'w1' );
 
-					// Destroy in offline mode.
-					editor.widgets.destroy( widget, true );
+				// Destroy in offline mode.
+				editor.widgets.destroy( widget, true );
 
-					assert.isFalse( !!editor.widgets.widgetHoldingFocusedEditable, 'widgets repo does not point to nested editable' );
-				} );
-			}, 210 );
+				assert.isFalse( !!editor.widgets.widgetHoldingFocusedEditable, 'widgets repo does not point to nested editable' );
+			} );
 		},
 
 		'test focused editable is resetted on setData': function() {


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix to failing test

## What changes did you make?

Assertions were fired with 210ms delay after focusing element. As blur happens with 200ms delay everything should be ok, but IE11 sometimes lags and fires our blur event later. I don't want to increase timeout, so I've moved assertions to `once( 'blur', ... )` listener. If listener isn't fired test still fails, because resume() isn't called.

Closes #2143