### PR TITLE
Fixed issue with textwatcher throttle invalid selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Fixed Issues:
 API Changes:
 
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
+* [#2373](https://github.com/ckeditor/ckeditor-dev/issues/2373): Fixed: [Text Watcher](https://ckeditor.com/cke4/addon/textwatcher) throttling calls [`check`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_textWatcher.html#method-check) method with invalid selection.
 
 ## CKEditor 4.10.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Fixed Issues:
 API Changes:
 
 * [#1451](https://github.com/ckeditor/ckeditor-dev/issues/1451): Fixed: Context menu is incorrectly positioned when opened with `Shift-F10`.
-* [#2373](https://github.com/ckeditor/ckeditor-dev/issues/2373): Fixed: [Text Watcher](https://ckeditor.com/cke4/addon/textwatcher) throttling calls [`check`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_textWatcher.html#method-check) method with invalid selection.
+* [#2373](https://github.com/ckeditor/ckeditor-dev/issues/2373): Fixed: [Text Watcher](https://ckeditor.com/cke4/addon/textwatcher) throttling calls of [`check`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_textWatcher.html#method-check) method with invalid selection.
 
 ## CKEditor 4.10.1
 

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -153,7 +153,7 @@
 		 *
 		 * @private
 		 */
-		this._buffer = CKEDITOR.tools.throttle( this.throttle, testTextMatch, this );
+		this._buffer = CKEDITOR.tools.throttle( this.throttle, this.check, this );
 
 		/**
 		 * Event fired when the text is no longer matching.
@@ -169,21 +169,6 @@
 		 *
 		 * @event unmatched
 		 */
-
-		function testTextMatch( selectionRange ) {
-			var matched = this.callback( selectionRange );
-
-			if ( matched ) {
-				if ( matched.text == this.lastMatched ) {
-					return;
-				}
-
-				this.lastMatched = matched.text;
-				this.fire( 'matched', matched );
-			} else if ( this.lastMatched ) {
-				this.unmatch();
-			}
-		}
 	}
 
 	TextWatcher.prototype = {
@@ -211,13 +196,7 @@
 			function onContentDom() {
 				var editable = editor.editable();
 
-				this._listeners.push( editable.attachListener( editable, 'keyup', check, this ) );
-			}
-
-			// CKEditor's event system has a limitation that one function (in this case this.check)
-			// cannot be used as listener for the same event more than once. Hence, wrapper function.
-			function check( evt ) {
-				this.check( evt );
+				this._listeners.push( editable.attachListener( editable, 'keyup', this._buffer.input, this ) );
 			}
 
 			function unmatch() {
@@ -253,7 +232,18 @@
 				return;
 			}
 
-			this._buffer.input( selectionRange );
+			var matched = this.callback( selectionRange );
+
+			if ( matched ) {
+				if ( matched.text == this.lastMatched ) {
+					return;
+				}
+
+				this.lastMatched = matched.text;
+				this.fire( 'matched', matched );
+			} else if ( this.lastMatched ) {
+				this.unmatch();
+			}
 		},
 
 		/**

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -172,14 +172,8 @@
 
 		function testTextMatch() {
 			// There are cases where the selection needs to be refreshed after debounce. (#2373)
-			var selectionRange = this._getRange( this.editor );
-
-			if ( !selectionRange ) {
-				this.unmatch();
-				return;
-			}
-
-			var matched = this.callback( selectionRange );
+			var selectionRange = this._getRange( this.editor ),
+				matched = selectionRange && this.callback( selectionRange );
 
 			if ( matched ) {
 				if ( matched.text == this.lastMatched ) {

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -170,9 +170,9 @@
 		 * @event unmatched
 		 */
 
-		function testTextMatch( selectionRange ) {
+		function testTextMatch() {
 			// There are cases where the selection needs to be refreshed after debounce. (#2373)
-			selectionRange = this._getRange( this.editor );
+			var selectionRange = this._getRange( this.editor );
 
 			if ( !selectionRange ) {
 				return;
@@ -250,10 +250,8 @@
 				return;
 			}
 
-			var selectionRange = this._getRange( this.editor );
-
-			if ( selectionRange ) {
-				this._buffer.input( selectionRange );
+			if ( this._getRange( this.editor ) ) {
+				this._buffer.input();
 			}
 		},
 

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -175,6 +175,7 @@
 			var selectionRange = this._getRange( this.editor );
 
 			if ( !selectionRange ) {
+				this.unmatch();
 				return;
 			}
 

--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -250,17 +250,11 @@
 				return;
 			}
 
-			var sel = this.editor.getSelection();
-			if ( !sel ) {
-				return;
-			}
+			var selectionRange = this._getRange( this.editor );
 
-			var selectionRange = sel.getRanges()[ 0 ];
-			if ( !selectionRange ) {
-				return;
+			if ( selectionRange ) {
+				this._buffer.input( selectionRange );
 			}
-
-			this._buffer.input( selectionRange );
 		},
 
 		/**

--- a/tests/plugins/textwatcher/manual/throttlesync.html
+++ b/tests/plugins/textwatcher/manual/throttlesync.html
@@ -9,12 +9,7 @@
 
 <span>Status:</span>
 <span id="status" class="ok">OK!</span>
-<div id="editor">
-	Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
-	tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-	vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-	no sea takimata sanctus est Lorem ipsum dolor sit amet.
-</div>
+<div id="editor"></div>
 
 <script>
 	var statusEl = document.getElementById( 'status' ),

--- a/tests/plugins/textwatcher/manual/throttlesync.html
+++ b/tests/plugins/textwatcher/manual/throttlesync.html
@@ -1,0 +1,34 @@
+<style>
+.ok {
+	color: green;
+}
+.error {
+	color: red;
+}
+</style>
+
+<span>Status:</span>
+<span id="status" class="ok">OK!</span>
+<div id="editor">
+	Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+	tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+	vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+	no sea takimata sanctus est Lorem ipsum dolor sit amet.
+</div>
+
+<script>
+	var statusEl = document.getElementById( 'status' ),
+		editor = CKEDITOR.replace( 'editor', {
+		on: {
+			instanceReady: function() {
+				new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
+					var isSelCorrect = editor.getSelection().getRanges()[0].startContainer.equals( selectionRange.startContainer );
+					if ( !isSelCorrect ) {
+						statusEl.innerText = 'Selection is out of sync!';
+						statusEl.className = 'error';
+					}
+				}, 1000 ).attach();
+			}
+		}
+	} )
+</script>

--- a/tests/plugins/textwatcher/manual/throttlesync.html
+++ b/tests/plugins/textwatcher/manual/throttlesync.html
@@ -17,7 +17,7 @@
 		on: {
 			instanceReady: function() {
 				new CKEDITOR.plugins.textWatcher( editor, function( selectionRange ) {
-					var isSelCorrect = editor.getSelection().getRanges()[0].startContainer.equals( selectionRange.startContainer );
+					var isSelCorrect = editor.getSelection().getRanges()[ 0 ].startContainer.equals( selectionRange.startContainer );
 					if ( !isSelCorrect ) {
 						statusEl.innerText = 'Selection is out of sync!';
 						statusEl.className = 'error';

--- a/tests/plugins/textwatcher/manual/throttlesync.html
+++ b/tests/plugins/textwatcher/manual/throttlesync.html
@@ -12,6 +12,11 @@
 <div id="editor"></div>
 
 <script>
+
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	var statusEl = document.getElementById( 'status' ),
 		editor = CKEDITOR.replace( 'editor', {
 		on: {

--- a/tests/plugins/textwatcher/manual/throttlesync.md
+++ b/tests/plugins/textwatcher/manual/throttlesync.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.10.2, bug, 2373
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, textwatcher
+
+1. Put cursor at the end of the editor's content.
+1. Start deleting characters using `backspace` key.
+
+
+## Expected
+
+Status: `OK!`.
+
+## Unexpected
+
+Status: `Selection is out of sync!`.

--- a/tests/plugins/textwatcher/manual/throttlesync.md
+++ b/tests/plugins/textwatcher/manual/throttlesync.md
@@ -2,9 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, textwatcher
 
-1. Put cursor at the end of the editor's content.
-1. Start deleting characters using `backspace` key.
-
+1. Focus the editor.
+1. Start pressing `backspace` key multiple times.
 
 ## Expected
 

--- a/tests/plugins/textwatcher/textwatcher.js
+++ b/tests/plugins/textwatcher/textwatcher.js
@@ -240,6 +240,37 @@
 			}, 100 );
 
 			wait();
+		},
+
+		// (#2373)
+		'test throttle synchronization': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				editable = editor.editable(),
+				isSelCorrect;
+
+			attachTextWatcher( editor, function( selectionRange ) {
+				var range = editor.getSelection().getRanges()[ 0 ];
+				isSelCorrect = range.startContainer.equals( selectionRange.startContainer );
+				return {
+					text: 'test'
+				};
+			}, 100 );
+
+			bot.setHtmlWithSelection( '<b>[xxx]</b><i>yyy</i>' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			bot.setHtmlWithSelection( '<b>xxx</b><i>[yyy]</i>' );
+
+			setTimeout( function() {
+				resume( function() {
+					assert.isTrue( isSelCorrect );
+				} );
+			}, 100 );
+
+			wait();
 		}
 
 	} );

--- a/tests/plugins/textwatcher/textwatcher.js
+++ b/tests/plugins/textwatcher/textwatcher.js
@@ -246,10 +246,14 @@
 		'test throttle synchronization': function() {
 			var editor = this.editor,
 				bot = this.editorBot,
-				isSelCorrect,
 				textWatcher = attachTextWatcher( editor, function( selectionRange ) {
-					var range = editor.getSelection().getRanges()[ 0 ];
-					isSelCorrect = range.startContainer.equals( selectionRange.startContainer );
+					if ( editor.getSelection().getSelectedText() === 'yyy' ) {
+						resume( function() {
+							var range = editor.getSelection().getRanges()[ 0 ];
+							assert.isTrue( range.startContainer.equals( selectionRange.startContainer ) );
+						} );
+					}
+
 					return {
 						text: 'test'
 					};
@@ -261,12 +265,6 @@
 			textWatcher.check( {} );
 
 			bot.setHtmlWithSelection( '<b>xxx</b><i>[yyy]</i>' );
-
-			setTimeout( function() {
-				resume( function() {
-					assert.isTrue( isSelCorrect );
-				} );
-			}, 100 );
 
 			wait();
 		},


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Throttling textwatcher#check function sometimes results with out of sync selection. I moved selection getter into a throttled function.

Closes #2373
