### PR TITLE
Added possibility to customize dialog field default values

### DIFF
--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1610,7 +1610,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 *
 		 * @since 4.11.0
 		 * @private
-		 *
 		 * @param {String} tabId
 		 * @param {CKEDITOR.ui.dialog.uiElement} element
 		 */
@@ -1636,10 +1635,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 *
 		 * @since 4.11.0
 		 * @private
-		 *
 		 * @param {String} tabId
 		 * @param {String} elementName
-		 *
 		 * @returns {String} [defaultValue]
 		 */
 		_getFieldConfigDefaultValue: function( tabId, elementName ) {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -715,7 +715,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	}
 
 	function getFieldConfig( editor, dialogId, tabId, fieldName ) {
-		var defaultValues = editor.config.dialog_defaultValues || CKEDITOR.config.dialog_defaultValues;
+		var defaultValues = editor.config.dialog_defaultValues;
 
 		if ( !defaultValues ) {
 			return null;

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -313,7 +313,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			dialog: this
 		}, editor ).definition;
 
-		// Overwrite definition with default config values (#2277).
+		// (#2277)
 		setConfigDefaultValues( this );
 
 		// Cache tabs that should be removed.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3634,7 +3634,7 @@ CKEDITOR.plugins.add( 'dialog', {
  * ```
  *
  * @since 4.11.0
- * @cfg {Object} [dialog_defaultValues]
+ * @cfg {Object.<String, String>} [dialog_defaultValues]
  * @member CKEDITOR.config
  */
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3634,7 +3634,7 @@ CKEDITOR.plugins.add( 'dialog', {
  * ```
  *
  * @since 4.11.0
- * @cfg {String} [dialog_defaultValues]
+ * @cfg {Object} [dialog_defaultValues]
  * @member CKEDITOR.config
  */
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -313,40 +313,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			dialog: this
 		}, editor ).definition;
 
-		var me = this,
-			contents = this.definition.contents;
-
-		// Overwrite definition with default values (#2277).
-		for ( var key in contents ) {
-			var contentObj = contents[ key ];
-			CKEDITOR.tools.array.forEach( contentObj.elements, function( element ) {
-				setDefaultValues( me, contentObj.id, element );
-			} );
-		}
-
-		function setDefaultValues( dialog, tabId, element ) {
-			var dialogId = dialog._.name;
-			if ( element.type === 'vbox' || element.type === 'hbox' ) {
-				return CKEDITOR.tools.array.forEach( element.children, function( child ) {
-					setDefaultValues( dialog, tabId, child );
-				} );
-			}
-
-			var defaultValue = getFieldConfig( dialog._.editor, dialogId, tabId, element.id );
-			if ( defaultValue ) {
-				element[ 'default' ] = defaultValue;
-			}
-		}
-
-		function getFieldConfig( editor, dialogId, tabId, fieldName ) {
-			var defaultValues = editor.config.dialog_defaultValues || CKEDITOR.config.dialog_defaultValues;
-
-			if ( !defaultValues ) {
-				return null;
-			}
-
-			return defaultValues[ [ dialogId, tabId, fieldName ].join( '.' ) ];
-		}
+		// Overwrite definition with default config values (#2277).
+		setConfigDefaultValues( this );
 
 		// Cache tabs that should be removed.
 		if ( !( 'removeDialogTabs' in editor._ ) && editor.config.removeDialogTabs ) {
@@ -401,6 +369,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					evt.data.hide = false;
 			} );
 		}
+
+		var me = this;
 
 		// Iterates over all items inside all content in the dialog, calling a
 		// function for each of them.
@@ -719,6 +689,40 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 * @property {Number} [state=CKEDITOR.DIALOG_STATE_IDLE]
 		 */
 	};
+
+	function setConfigDefaultValues( dialog ) {
+		var contents = dialog.definition.contents;
+		for ( var key in contents ) {
+			var contentObj = contents[ key ];
+			CKEDITOR.tools.array.forEach( contentObj.elements, function( element ) {
+				setElementDefaultValues( this, contentObj.id, element );
+			}, dialog );
+		}
+	}
+
+	function setElementDefaultValues( dialog, tabId, element ) {
+		var dialogId = dialog._.name;
+		if ( element.children ) {
+			return CKEDITOR.tools.array.forEach( element.children, function( child ) {
+				setElementDefaultValues( dialog, tabId, child );
+			} );
+		}
+
+		var defaultValue = getFieldConfig( dialog._.editor, dialogId, tabId, element.id );
+		if ( defaultValue ) {
+			element[ 'default' ] = defaultValue;
+		}
+	}
+
+	function getFieldConfig( editor, dialogId, tabId, fieldName ) {
+		var defaultValues = editor.config.dialog_defaultValues || CKEDITOR.config.dialog_defaultValues;
+
+		if ( !defaultValues ) {
+			return null;
+		}
+
+		return defaultValues[ [ dialogId, tabId, fieldName ].join( '.' ) ];
+	}
 
 	// Focusable interface. Use it via dialog.addFocusable.
 	function Focusable( dialog, element, index ) {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -340,6 +340,11 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 		function getFieldConfig( editor, dialogId, tabId, fieldName ) {
 			var defaultValues = editor.config.dialog_defaultValues || CKEDITOR.config.dialog_defaultValues;
+
+			if ( !defaultValues ) {
+				return null;
+			}
+
 			return defaultValues[ [ dialogId, tabId, fieldName ].join( '.' ) ];
 		}
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1589,7 +1589,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			return CKEDITOR.dialog.EDITING_MODE;
 		},
 
-		/*
+		/**
 		 * Overwrites dialog field default values with {@link CKEDITOR.config.dialog_defaultValues}.
 		 *
 		 * @since 4.13.0

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -986,8 +986,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 				this.fire( 'show', {} );
 
-				// Configure default values right after `show` event so they won't be modified by plugin (#2277).
-
 				this._.editor.fire( 'dialogShow', this );
 
 				if ( !this._.parentDialog )
@@ -3608,6 +3606,31 @@ CKEDITOR.plugins.add( 'dialog', {
  *
  * @since 4.3.0
  * @cfg {Boolean} [dialog_noConfirmCancel=false]
+ * @member CKEDITOR.config
+ */
+
+/**
+ * Allows to customize default dialog field values.
+ *
+ * Each field is represented by a flat object separated by `.` into three values used to
+ * identify it. E.g. `link.info.protocol` stands for:
+ *
+ * * `link` - dialog window name for which we want to customize dialog field value.
+ * * `info` - dialog window tab name in which the field is located.
+ * * `protocol` - the given field ID we want to customize.
+ *
+ * To make it easier for you to track field paths you may want to use
+ * [Developer Tools](https://ckeditor.com/cke4/addon/devtools) plugin.
+ *
+ * ```javascript
+ *  config.dialog_defaultValues = {
+ *    'link.info.protocol': 'https://',
+ *    'table.info.txtWidth': '100%'
+ *  }
+ * ```
+ *
+ * @since 4.11.0
+ * @cfg {String} [dialog_defaultValues]
  * @member CKEDITOR.config
  */
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1622,7 +1622,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			}
 
 			var defaultValue = this._getFieldCofigDefaultValue( tabId, element.id );
-			if ( defaultValue ) {
+			if ( defaultValue !== null ) {
 				element[ 'default' ] = defaultValue;
 			}
 		},
@@ -1632,7 +1632,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 * Gets field config value from {@link CKEDITOR.config.dialog_defaultValues}
 		 * for the given tab and element name.
 		 *
-		 * The value is fetched only for the current dialog name.
+		 * The value is retrieved only for the current dialog definition.
 		 *
 		 * @since 4.11.0
 		 * @private
@@ -1649,7 +1649,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				return null;
 			}
 
-			return defaultValues[ [ this._.name, tabId, elementName ].join( '.' ) ];
+			var value = defaultValues[ [ this._.name, tabId, elementName ].join( '.' ) ];
+
+			return value !== undefined ? value : null;
 		}
 	};
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -314,7 +314,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}, editor ).definition;
 
 		// (#2277)
-		this._setConfigDefaultValues();
+		this.setConfigDefaultValues();
 
 		// Cache tabs that should be removed.
 		if ( !( 'removeDialogTabs' in editor._ ) && editor.config.removeDialogTabs ) {
@@ -1592,15 +1592,15 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		/*
 		 * Overwrites dialog field default values with {@link CKEDITOR.config.dialog_defaultValues}.
 		 *
-		 * @since 4.11.0
+		 * @since 4.13.0
 		 * @private
 		 */
-		_setConfigDefaultValues: function() {
+		setConfigDefaultValues: function() {
 			var contents = this.definition.contents;
 			for ( var key in contents ) {
 				var contentObj = contents[ key ];
 				CKEDITOR.tools.array.forEach( contentObj.elements, function( element ) {
-					this._setFieldConfigDefaultValue( contentObj.id, element );
+					this.setFieldConfigDefaultValue( contentObj.id, element );
 				}, this );
 			}
 		},
@@ -1611,19 +1611,19 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 *
 		 * Field default value is left unchanged if configuration value doesn't exist.
 		 *
-		 * @since 4.11.0
+		 * @since 4.13.0
 		 * @private
 		 * @param {String} tabId
 		 * @param {CKEDITOR.ui.dialog.uiElement} element
 		 */
-		_setFieldConfigDefaultValue: function( tabId, element ) {
+		setFieldConfigDefaultValue: function( tabId, element ) {
 			if ( element.children ) {
 				return CKEDITOR.tools.array.forEach( element.children, function( child ) {
-					this._setFieldConfigDefaultValue( tabId, child );
+					this.setFieldConfigDefaultValue( tabId, child );
 				}, this );
 			}
 
-			var defaultValue = this._getFieldConfigDefaultValue( tabId, element.id );
+			var defaultValue = this.getFieldConfigDefaultValue( tabId, element.id );
 			if ( defaultValue !== null ) {
 				element[ 'default' ] = defaultValue;
 			}
@@ -1636,13 +1636,13 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 *
 		 * The value is retrieved only for the current dialog definition.
 		 *
-		 * @since 4.11.0
+		 * @since 4.13.0
 		 * @private
 		 * @param {String} tabId
 		 * @param {String} elementName
 		 * @returns {String} [defaultValue]
 		 */
-		_getFieldConfigDefaultValue: function( tabId, elementName ) {
+		getFieldConfigDefaultValue: function( tabId, elementName ) {
 			var defaultValues = this._.editor.config.dialog_defaultValues;
 
 			if ( !defaultValues ) {
@@ -3667,7 +3667,7 @@ CKEDITOR.plugins.add( 'dialog', {
  *  }
  * ```
  *
- * @since 4.11.0
+ * @since 4.13.0
  * @cfg {Object.<String, String>} [dialog_defaultValues]
  * @member CKEDITOR.config
  */

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -865,8 +865,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 */
 		show: function() {
 			// Insert the dialog's element to the root document.
-			var element = this._.element;
-			var definition = this.definition;
+			var element = this._.element,
+				definition = this.definition,
+				editor = this.getParentEditor();
 
 			if ( !( element.getParent() && element.getParent().equals( CKEDITOR.document.getBody() ) ) ) {
 				element.appendTo( CKEDITOR.document.getBody() );
@@ -880,8 +881,10 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				this._.contentSize && this._.contentSize.height || definition.height || definition.minHeight
 			);
 
-			// Reset all inputs back to their default value.
-			this.reset();
+			// (#2277)
+			if ( this.getMode( editor ) === CKEDITOR.dialog.CREATION_MODE ) {
+				this.reset();
+			}
 
 			// Selects the first tab if no tab is already selected.
 			if ( this._.currentTabId === null ) {
@@ -897,12 +900,12 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			if ( CKEDITOR.dialog._.currentTop === null ) {
 				CKEDITOR.dialog._.currentTop = this;
 				this._.parentDialog = null;
-				showCover( this._.editor );
+				showCover( editor );
 
 			} else {
 				this._.parentDialog = CKEDITOR.dialog._.currentTop;
 				var parentElement = this._.parentDialog.getElement().getFirst();
-				parentElement.$.style.zIndex -= Math.floor( this._.editor.config.baseFloatZIndex / 2 );
+				parentElement.$.style.zIndex -= Math.floor( editor.config.baseFloatZIndex / 2 );
 				CKEDITOR.dialog._.currentTop = this;
 			}
 
@@ -938,7 +941,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					}
 				}
 
-				if ( !enableElements || ( requiredContent && !this._.editor.activeFilter.check( requiredContent ) ) )
+				if ( !enableElements || ( requiredContent && !editor.activeFilter.check( requiredContent ) ) )
 					tab[ 0 ].addClass( 'cke_dialog_tab_disabled' );
 				else
 					tab[ 0 ].removeClass( 'cke_dialog_tab_disabled' );
@@ -956,7 +959,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 				this.fire( 'show', {} );
 
-				this._.editor.fire( 'dialogShow', this );
+				editor.fire( 'dialogShow', this );
 
 				if ( !this._.parentDialog )
 					this._.editor.focusManager.lock();

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1602,11 +1602,11 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			}
 		},
 
-		/*
-		 * Overwrites field default value located in the provided tab with
-		 * {@link CKEDITOR.config.dialog_defaultValues}.
+		/**
+		 * Overwrites field default value located in the given tab with
+		 * {@link CKEDITOR.config#dialog_defaultValues}.
 		 *
-		 * Field default value is left unchanged if config default value doesn't exist.
+		 * Field default value is left unchanged if configuration value doesn't exist.
 		 *
 		 * @since 4.11.0
 		 * @private
@@ -1621,15 +1621,15 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				}, this );
 			}
 
-			var defaultValue = this._getFieldCofigDefaultValue( tabId, element.id );
+			var defaultValue = this._getFieldConfigDefaultValue( tabId, element.id );
 			if ( defaultValue !== null ) {
 				element[ 'default' ] = defaultValue;
 			}
 		},
 
 
-		/*
-		 * Gets field config value from {@link CKEDITOR.config.dialog_defaultValues}
+		/**
+		 * Gets field config value from {@link CKEDITOR.config#dialog_defaultValues}
 		 * for the given tab and element name.
 		 *
 		 * The value is retrieved only for the current dialog definition.
@@ -1642,7 +1642,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		 *
 		 * @returns {String} [defaultValue]
 		 */
-		_getFieldCofigDefaultValue: function( tabId, elementName ) {
+		_getFieldConfigDefaultValue: function( tabId, elementName ) {
 			var defaultValues = this._.editor.config.dialog_defaultValues;
 
 			if ( !defaultValues ) {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1951,14 +1951,17 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 	 * @constructor Creates a definitionObject class instance.
 	 */
 	var definitionObject = function( dialog, dialogDefinition ) {
-			// TODO : Check if needed.
 			this.dialog = dialog;
 
-			// Transform the contents entries in contentObjects.
-			var contents = dialogDefinition.contents;
-			for ( var i = 0, content;
-			( content = contents[ i ] ); i++ )
-				contents[ i ] = content && new contentObject( dialog, content );
+			// Make sure that there is no false value in contents property (#2277), otherwise
+			// following transformations like setting default field value may fail.
+			var contents = CKEDITOR.tools.array.filter( dialogDefinition.contents, Boolean );
+
+			contents = CKEDITOR.tools.array.map( contents, function( content ) {
+				return new contentObject( dialog, content );
+			} );
+
+			dialogDefinition.contents = contents;
 
 			CKEDITOR.tools.extend( this, dialogDefinition );
 		};

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -952,6 +952,10 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				CKEDITOR.ui.fire( 'ready', this );
 
 				this.fire( 'show', {} );
+
+				// Configure default values right after `show` event so they won't be modified by plugin (#2277).
+				setConfigurationDefaultValues( this );
+
 				this._.editor.fire( 'dialogShow', this );
 
 				if ( !this._.parentDialog )
@@ -963,6 +967,28 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				} );
 
 			}, 100, this );
+
+			function setConfigurationDefaultValues( dialog ) {
+				var defaultValues = CKEDITOR.config.dialog_defaultValues;
+
+				if ( !defaultValues ) {
+					return;
+				}
+
+				for ( var chain in defaultValues ) {
+					var props = chain.split( '.' ),
+						name = props[ 0 ],
+						page = props[ 1 ],
+						field = props[ 2 ];
+
+					if ( name === dialog._.name ) {
+						var contentElement = dialog.getContentElement( page, field );
+						if ( contentElement ) {
+							contentElement.setValue( defaultValues[ chain ] );
+						}
+					}
+				}
+			}
 		},
 
 		/**

--- a/tests/plugins/dialog/manual/defaultvalues.html
+++ b/tests/plugins/dialog/manual/defaultvalues.html
@@ -1,0 +1,11 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		dialog_defaultValues: {
+			'link.info.protocol': 'https://',
+			'link.advanced.advId': '1',
+			'link.advanced.advName': 'test'
+		}
+	} );
+</script>

--- a/tests/plugins/dialog/manual/defaultvalues.html
+++ b/tests/plugins/dialog/manual/defaultvalues.html
@@ -5,7 +5,8 @@
 		dialog_defaultValues: {
 			'link.info.protocol': 'https://',
 			'link.advanced.advId': '1',
-			'link.advanced.advName': 'test'
+			'link.advanced.advName': 'test',
+			'link.advanced.download': true
 		}
 	} );
 </script>

--- a/tests/plugins/dialog/manual/defaultvalues.md
+++ b/tests/plugins/dialog/manual/defaultvalues.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.0, feature, 2277
+@bender-tags: 4.11.0, feature, 2277, dialog
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/defaultvalues.md
+++ b/tests/plugins/dialog/manual/defaultvalues.md
@@ -2,18 +2,29 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 
+## Info tab
+
 1. Click `link` button.
 1. Wait until dialog show up.
-1. Compare `Protocol` field with expected results.
-1. Click `Advanced` tab.
-1. Compare `Id` and `Name` fields with expected results.
 
 ## Expected
 
-* `Info:Protocol`: `https://`
-* `Advanced:Id`: `1`
-* `Advanced:Name`: `test`
+Procotol option value is `https://`.
 
 ## Unexpected
 
-Values are different than expected.
+Protocol option value is `http://`.
+
+## Advanced tab
+
+Switch to `Advanced` tab.
+
+## Expected
+
+* ID input value is `1`.
+* Name input value is `test`.
+
+## Unexpected
+
+* ID input value is empty.
+* Name input value is empty.

--- a/tests/plugins/dialog/manual/defaultvalues.md
+++ b/tests/plugins/dialog/manual/defaultvalues.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.11.0, feature, 2277
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link
+
+1. Click `link` button.
+1. Wait until dialog show up.
+1. Compare `Protocol` field with expected results.
+1. Click `Advanced` tab.
+1. Compare `Id` and `Name` fields with expected results.
+
+## Expected
+
+* `Info:Protocol`: `https://`
+* `Advanced:Id`: `1`
+* `Advanced:Name`: `test`
+
+## Unexpected
+
+Values are different than expected.

--- a/tests/plugins/dialog/manual/defaultvalues.md
+++ b/tests/plugins/dialog/manual/defaultvalues.md
@@ -23,8 +23,10 @@ Switch to `Advanced` tab.
 
 * ID input value is `1`.
 * Name input value is `test`.
+* Force download checkbox is checked.
 
 ## Unexpected
 
 * ID input value is empty.
 * Name input value is empty.
+* Force download checkbox is unchecked.

--- a/tests/plugins/dialog/manual/defaultvalues.md
+++ b/tests/plugins/dialog/manual/defaultvalues.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.0, feature, 2277, dialog
+@bender-tags: 4.13.0, feature, 2277, dialog
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/dialog/manual/defaultvaluesreset.html
+++ b/tests/plugins/dialog/manual/defaultvaluesreset.html
@@ -1,0 +1,9 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		dialog_defaultValues: {
+			'link.advanced.download': true
+		}
+	} );
+</script>

--- a/tests/plugins/dialog/manual/defaultvaluesreset.md
+++ b/tests/plugins/dialog/manual/defaultvaluesreset.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.13.0, feature, 2277, dialog
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link
+
+1. Click `link` button.
+2. Wait until dialog show up.
+3. Fill URL with custom value.
+4. Switch to `Advanced` tab.
+
+
+**Expected:** Force download checkbox is checked.
+
+5. Uncheck force download.
+6. Click OK button.
+7. Double click inserted link to open dialog again.
+8. Switch to `Advanced` tab.
+
+**Expected:** Force download checkbox remains unchecked.

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -93,6 +93,16 @@
 								type: 'text',
 								id: 'text2',
 								label: 'text2'
+							},
+							{
+								type: 'hbox',
+								id: 'hbox2',
+								label: 'hbox2',
+								children: [ {
+									type: 'checkbox',
+									id: 'checkbox1',
+									label: 'checkbox1'
+								} ]
 							}
 						]
 					}
@@ -145,6 +155,7 @@
 			dialog_defaultValues: {
 				'testDialog1.info.text1': 'text1',
 				'testDialog1.info.text2': 'text2',
+				'testDialog1.info.checkbox1': true,
 				'testDialogEmptyVal.info.foo': ''
 			}
 		}
@@ -638,6 +649,7 @@
 			this.editorBot.dialog( 'testDialog1', function( dialog ) {
 				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value.' );
 				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value.' );
+				assert.areEqual( true, dialog.getContentElement( 'info', 'checkbox1' ).getValue(), 'checkbox1 field has invalid value.' );
 			} );
 		},
 

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -636,8 +636,8 @@
 		// (#2277)
 		'test default values': function() {
 			this.editorBot.dialog( 'testDialog1', function( dialog ) {
-				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
-				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
+				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value.' );
+				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value.' );
 			} );
 		},
 

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -137,6 +137,7 @@
 		evt.editor.addCommand( 'testDialogDefinitionEvent', new CKEDITOR.dialogCommand( 'testDialogDefinitionEvent' ) );
 
 		evt.editor.addCommand( 'testDialogEmptyVal', new CKEDITOR.dialogCommand( 'testDialogEmptyVal' ) );
+
 	} );
 
 	bender.editor = {
@@ -150,9 +151,6 @@
 	};
 
 	bender.test( {
-		setUp: function() {
-			this.editor.addCommand( 'testDialog1', new CKEDITOR.dialogCommand( 'testDialog1' ) );
-		},
 		'test open dialog from local': function() {
 			var ed = this.editor, tc = this;
 			ed.openDialog( 'testDialog1', function( dialog ) {

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -99,7 +99,27 @@
 				]
 			};
 		} );
+		CKEDITOR.dialog.add( 'testDialogEmptyVal', function() {
+			return {
+				title: 'Test Dialog Empty Value',
+				contents: [
+					{
+						id: 'info',
+						label: 'Test',
+						elements: [
+							{
+								type: 'text',
+								id: 'foo',
+								label: 'bar',
+								'default': 'default value'
+							}
+						]
+					}
+				]
+			};
+		} );
 		CKEDITOR.dialog.add( 'testDialog2', '%TEST_DIR%_assets/testdialog.js' );
+
 		CKEDITOR.dialog.add( 'testGetModel', function() {
 			return dialogDefinitions.testGetModel;
 		} );
@@ -115,13 +135,16 @@
 		evt.editor.addCommand( 'testGetModel', new CKEDITOR.dialogCommand( 'testGetModel' ) );
 		evt.editor.addCommand( 'testGetMode', new CKEDITOR.dialogCommand( 'testGetMode' ) );
 		evt.editor.addCommand( 'testDialogDefinitionEvent', new CKEDITOR.dialogCommand( 'testDialogDefinitionEvent' ) );
+
+		evt.editor.addCommand( 'testDialogEmptyVal', new CKEDITOR.dialogCommand( 'testDialogEmptyVal' ) );
 	} );
 
 	bender.editor = {
 		config: {
 			dialog_defaultValues: {
 				'testDialog1.info.text1': 'text1',
-				'testDialog1.info.text2': 'text2'
+				'testDialog1.info.text2': 'text2',
+				'testDialogEmptyVal.info.foo': ''
 			}
 		}
 	};
@@ -609,6 +632,15 @@
 			this.editorBot.dialog( 'testDialog1', function( dialog ) {
 				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
 				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
+
+				dialog.getButton( 'cancel' ).click();
+			} );
+		},
+
+		// (#2277)
+		'test removing dialog value with config.dialog_defaultValues': function() {
+			this.editorBot.dialog( 'testDialogEmptyVal', function( dialog ) {
+				assert.areEqual( '', dialog.getContentElement( 'info', 'foo' ).getValue(), 'Field has invalid value.' );
 
 				dialog.getButton( 'cancel' ).click();
 			} );

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -127,6 +127,9 @@
 	};
 
 	bender.test( {
+		setUp: function() {
+			this.editor.addCommand( 'testDialog1', new CKEDITOR.dialogCommand( 'testDialog1' ) );
+		},
 		'test open dialog from local': function() {
 			var ed = this.editor, tc = this;
 			ed.openDialog( 'testDialog1', function( dialog ) {
@@ -603,18 +606,12 @@
 
 		// (#2277)
 		'test default values': function() {
-			var tc = this;
-			this.editor.openDialog( 'testDialog1', function( dialog ) {
-				tc.resume( function() {
-					wait( function() {
-						assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
-						assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
+			this.editorBot.dialog( 'testDialog1', function( dialog ) {
+				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
+				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
 
-						dialog.getButton( 'cancel' ).click();
-					}, 100 );
-				} );
+				dialog.getButton( 'cancel' ).click();
 			} );
-			tc.wait();
 		}
 	} );
 

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -659,6 +659,17 @@
 		},
 
 		// (#2277)
+		'test default values are not reinitialized for editing mode': function() {
+			var spy = sinon.spy( CKEDITOR.dialog.prototype, 'reset' );
+
+			this.editorBot.dialog( 'testGetMode', function() {
+				spy.restore();
+
+				assert.isFalse( spy.called, 'Dialog values should remain' );
+			} );
+		},
+
+		// (#2277)
 		'test removing dialog value with config.dialog_defaultValues': function() {
 			this.editorBot.dialog( 'testDialogEmptyVal', function( dialog ) {
 				assert.areEqual( '', dialog.getContentElement( 'info', 'foo' ).getValue(), 'Field is empty.' );

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -651,17 +651,17 @@
 		// (#2277)
 		'test default values': function() {
 			this.editorBot.dialog( 'testDialog1', function( dialog ) {
-				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value.' );
-				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value.' );
-				assert.isTrue( dialog.getContentElement( 'info', 'checkbox1' ).getValue(), 'checkbox1 field has invalid value.' );
-				assert.isFalse( dialog.getContentElement( 'info', 'checkbox2' ).getValue(), 'checkbox1 field has invalid value.' );
+				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has valid value.' );
+				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has valid value.' );
+				assert.isTrue( dialog.getContentElement( 'info', 'checkbox1' ).getValue(), 'checkbox1 field is checked.' );
+				assert.isFalse( dialog.getContentElement( 'info', 'checkbox2' ).getValue(), 'checkbox1 field is unchecked.' );
 			} );
 		},
 
 		// (#2277)
 		'test removing dialog value with config.dialog_defaultValues': function() {
 			this.editorBot.dialog( 'testDialogEmptyVal', function( dialog ) {
-				assert.areEqual( '', dialog.getContentElement( 'info', 'foo' ).getValue(), 'Field has invalid value.' );
+				assert.areEqual( '', dialog.getContentElement( 'info', 'foo' ).getValue(), 'Field is empty.' );
 			} );
 		}
 	} );

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -151,6 +151,14 @@
 	};
 
 	bender.test( {
+		tearDown: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+
+			if ( dialog ) {
+				dialog.hide();
+			}
+		},
+
 		'test open dialog from local': function() {
 			var ed = this.editor, tc = this;
 			ed.openDialog( 'testDialog1', function( dialog ) {
@@ -630,8 +638,6 @@
 			this.editorBot.dialog( 'testDialog1', function( dialog ) {
 				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
 				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
-
-				dialog.getButton( 'cancel' ).click();
 			} );
 		},
 
@@ -639,8 +645,6 @@
 		'test removing dialog value with config.dialog_defaultValues': function() {
 			this.editorBot.dialog( 'testDialogEmptyVal', function( dialog ) {
 				assert.areEqual( '', dialog.getContentElement( 'info', 'foo' ).getValue(), 'Field has invalid value.' );
-
-				dialog.getButton( 'cancel' ).click();
 			} );
 		}
 	} );

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -603,8 +603,9 @@
 
 		// (#2277)
 		'test default values': function() {
+			var tc = this;
 			this.editor.openDialog( 'testDialog1', function( dialog ) {
-				this.resume( function() {
+				tc.resume( function() {
 					wait( function() {
 						assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
 						assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
@@ -613,7 +614,7 @@
 					}, 100 );
 				} );
 			} );
-			this.wait();
+			tc.wait();
 		}
 	} );
 

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -58,7 +58,46 @@
 
 	CKEDITOR.on( 'instanceLoaded', function( evt ) {
 		CKEDITOR.dialog.add( 'testDialog1', function() {
-			return dialogDefinitions.testDialog1;
+			return {
+				title: 'Test Dialog 1',
+				contents: [
+					{
+						id: 'info',
+						label: 'Test',
+						elements: [
+							{
+								type: 'text',
+								id: 'foo',
+								label: 'bar'
+							},
+							{
+								type: 'vbox',
+								id: 'vbox1',
+								label: 'vbox1',
+								children: [
+									{
+										type: 'hbox',
+										id: 'hbox1',
+										label: 'hbox1',
+										children: [
+											{
+												type: 'text',
+												id: 'text1',
+												label: 'text1'
+											}
+										]
+									}
+								]
+							},
+							{
+								type: 'text',
+								id: 'text2',
+								label: 'text2'
+							}
+						]
+					}
+				]
+			};
 		} );
 		CKEDITOR.dialog.add( 'testDialog2', '%TEST_DIR%_assets/testdialog.js' );
 		CKEDITOR.dialog.add( 'testGetModel', function() {
@@ -78,7 +117,14 @@
 		evt.editor.addCommand( 'testDialogDefinitionEvent', new CKEDITOR.dialogCommand( 'testDialogDefinitionEvent' ) );
 	} );
 
-	bender.editor = {};
+	bender.editor = {
+		config: {
+			dialog_defaultValues: {
+				'testDialog1.info.text1': 'text1',
+				'testDialog1.info.text2': 'text2'
+			}
+		}
+	};
 
 	bender.test( {
 		'test open dialog from local': function() {
@@ -553,6 +599,21 @@
 					definition: sinon.match.instanceOf( Object )
 				} ) );
 			} );
+		},
+
+		// (#2277)
+		'test default values': function() {
+			this.editor.openDialog( 'testDialog1', function( dialog ) {
+				this.resume( function() {
+					wait( function() {
+						assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value' );
+						assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value' );
+
+						dialog.getButton( 'cancel' ).click();
+					}, 100 );
+				} );
+			} );
+			this.wait();
 		}
 	} );
 

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -102,6 +102,10 @@
 									type: 'checkbox',
 									id: 'checkbox1',
 									label: 'checkbox1'
+								}, {
+									type: 'checkbox',
+									id: 'checkbox2',
+									label: 'checkbox2'
 								} ]
 							}
 						]
@@ -649,7 +653,8 @@
 			this.editorBot.dialog( 'testDialog1', function( dialog ) {
 				assert.areEqual( 'text1', dialog.getContentElement( 'info', 'text1' ).getValue(), 'text1 field has invalid value.' );
 				assert.areEqual( 'text2', dialog.getContentElement( 'info', 'text2' ).getValue(), 'text2 field has invalid value.' );
-				assert.areEqual( true, dialog.getContentElement( 'info', 'checkbox1' ).getValue(), 'checkbox1 field has invalid value.' );
+				assert.isTrue( dialog.getContentElement( 'info', 'checkbox1' ).getValue(), 'checkbox1 field has invalid value.' );
+				assert.isFalse( dialog.getContentElement( 'info', 'checkbox2' ).getValue(), 'checkbox1 field has invalid value.' );
 			} );
 		},
 

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -576,8 +576,8 @@
 		// (#2423)
 		'test dialog definition allows for overwriting getMode': function() {
 			this.editorBot.dialog( 'testGetMode', function( dialog ) {
-				// Get model may be called during the initialization, that's not a concern of this TC.
-				dialogDefinitions.testGetModel.getModel.reset();
+				// Get mode may be called during the initialization, that's not a concern of this TC.
+				dialogDefinitions.testGetMode.getMode.reset();
 
 				var ret = dialog.getMode( this.editor );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

Overwrite dialog definition with configured `config.dialog_defaultValues` on dialog initialization.

Closes #2277
