### PR TITLE
Expose info about readonly state to a11y tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Fixed Issues:
 * [#898](https://github.com/ckeditor/ckeditor-dev/issues/898): Fixed: [Enhanced Image](https://ckeditor.com/cke4/addon/image2) long alt text protrudes into editor when image is selected.
 * [#1113](https://github.com/ckeditor/ckeditor-dev/issues/1113): [Firefox] Fixed: Nested contenteditable elements path not updated on focus with [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin.
 * [#1682](https://github.com/ckeditor/ckeditor-dev/issues/1682) Fixed: Hovering [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) panel changes its size causing flickering.
+* [#1904](https://github.com/ckeditor/ckeditor-dev/issues/1904) Fixed: Readonly editors incorrectly marked up for Assistive Technology.
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -518,6 +518,14 @@
 			 */
 			setReadOnly: function( isReadOnly ) {
 				this.setAttribute( 'contenteditable', !isReadOnly );
+
+				// To correctly announce that the field is read-only,
+				// JAWS needs [aria-readonly] attribute on iframe in classic editor (#1904).
+				if ( this.isInline() ) {
+					this.setAttribute( 'aria-readonly', !!isReadOnly );
+				} else {
+					this.getWindow().getFrame().setAttribute( 'aria-readonly', !!isReadOnly );
+				}
 			},
 
 			/**

--- a/core/editable.js
+++ b/core/editable.js
@@ -519,13 +519,8 @@
 			setReadOnly: function( isReadOnly ) {
 				this.setAttribute( 'contenteditable', !isReadOnly );
 
-				// To correctly announce that the field is read-only,
-				// JAWS needs [aria-readonly] attribute on iframe in classic editor (#1904).
-				if ( this.isInline() ) {
-					this.setAttribute( 'aria-readonly', !!isReadOnly );
-				} else {
-					this.getWindow().getFrame().setAttribute( 'aria-readonly', !!isReadOnly );
-				}
+				// Add info about readonly state for JAWS (#1904).
+				this.setAttribute( 'aria-readonly', !!isReadOnly );
 			},
 
 			/**

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -79,7 +79,12 @@
 
 				iframe.setAttributes( {
 					tabIndex: editor.tabIndex,
-					allowTransparency: 'true'
+					allowTransparency: 'true',
+
+					// To correctly announce read-only state, JAWS neeeds to identify
+					// iframe as multiline textbox (#1904).
+					role: 'textbox',
+					'aria-multiline': 'true'
 				} );
 
 				// Execute onLoad manually for all non IE||Gecko browsers.

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -510,6 +510,14 @@
 				}
 			},
 
+			setReadOnly: function( isReadOnly ) {
+				this.setAttribute( 'contenteditable', !isReadOnly );
+
+				// To correctly announce that the field is read-only,
+				// JAWS needs [aria-readonly] attribute on iframe in classic editor (#1904).
+				this.getWindow().getFrame().setAttribute( 'aria-readonly', !!isReadOnly );
+			},
+
 			focus: function() {
 				if ( this._.isLoadingData )
 					this._.isPendingFocus = true;

--- a/tests/core/editable/aria.js
+++ b/tests/core/editable/aria.js
@@ -57,6 +57,54 @@
 				assert.areSame( 1, fired, 'event was fired once' );
 				assert.isNull( describedBy, 'editable does not have has aria-describedby attribute' );
 			} );
+		},
+
+		// (#1904)
+		'test initial value of [aria-readonly] attribute (writable editor)': function() {
+			bender.editorBot.create( {
+				name: 'readonly-initial-writable',
+				creator: 'inline'
+			}, function( bot ) {
+				var editor = bot.editor,
+					readonlyAttr = editor.editable().getAttribute( 'aria-readonly' );
+
+				assert.areSame( 'false', readonlyAttr, 'editable has appropriate value of [aria-readonly] attribute' );
+			} );
+		},
+
+		// (#1904)
+		'test initial value of [aria-readonly] attribute (readonly editor)': function() {
+			bender.editorBot.create( {
+				name: 'readonly-initial-readonly',
+				creator: 'inline',
+				config: {
+					readOnly: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					readonlyAttr = editor.editable().getAttribute( 'aria-readonly' );
+
+				assert.areSame( 'true', readonlyAttr, 'editable has appropriate value of [aria-readonly] attribute' );
+			} );
+		},
+
+		// (#1904)
+		'test update value of [aria-readonly] attribute': function() {
+			bender.editorBot.create( {
+				name: 'readonly-update',
+				creator: 'inline',
+				config: {
+					readOnly: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					readonlyAttr;
+
+				editor.setReadOnly( false );
+				readonlyAttr = editor.editable().getAttribute( 'aria-readonly' );
+
+				assert.areSame( 'false', readonlyAttr, 'editable has appropriate value of [aria-readonly] attribute' );
+			} );
 		}
 	} );
 } )();

--- a/tests/core/editable/manual/readonlyjaws.html
+++ b/tests/core/editable/manual/readonlyjaws.html
@@ -1,0 +1,38 @@
+<h2>Classic</h2>
+
+<div id="classic">
+	<p>Test</p>
+	<p>Test</p>
+</div>
+
+<h2>Divarea</h2>
+
+<div id="divarea" contenteditable="true">
+	<p>Test</p>
+	<p>Test</p>
+</div>
+
+<h2>Inline</h2>
+
+<div id="inline" contenteditable="false">
+	<p>Test</p>
+	<p>Test</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		// JAWS is supported only with Firefox.
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic', {
+		readOnly: true
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		readOnly: true
+	} );
+
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/core/editable/manual/readonlyjaws.md
+++ b/tests/core/editable/manual/readonlyjaws.md
@@ -1,0 +1,20 @@
+@bender-tags: 4.10.2, bug, 1904, accessibility
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, link, floatingspace, elementspath
+
+For each editor:
+
+1. Run JAWS.
+1. Focus the editor.
+
+## Expected
+
+Name of the editor is announced, followed by "readonly edit".
+
+## Unexpected
+
+There is no "readonly edit" part in editor's announcement.
+
+## Known issues:
+
+* [#2445](https://github.com/ckeditor/ckeditor-dev/issues/2445) Name in iframe-based editor is announced twice.

--- a/tests/plugins/wysiwygarea/aria.js
+++ b/tests/plugins/wysiwygarea/aria.js
@@ -58,6 +58,65 @@
 				assert.areSame( 1, fired, 'event was fired once' );
 				assert.isNull( describedBy, 'iframe does not have aria-describedby attribute' );
 			} );
+		},
+
+		// (#1904)
+		'test editor role and [aria-multiline] attribute': function() {
+			bender.editorBot.create( {
+				name: 'role-textbox'
+			}, function( bot ) {
+				var editor = bot.editor,
+					frame = editor.editable().getWindow().getFrame();
+
+				assert.areSame( 'textbox', frame.getAttribute( 'role' ), 'editor frame has appropriate role' );
+				assert.areSame( 'true', frame.getAttribute( 'aria-multiline' ),
+					'editor frame has appropriate value of [aria-multiline] attribute' );
+			} );
+		},
+
+		// (#1904)
+		'test initial value of [aria-readonly] attribute (writable editor)': function() {
+			bender.editorBot.create( {
+				name: 'readonly-initial-writable'
+			}, function( bot ) {
+				var editor = bot.editor,
+					readonlyAttr = editor.editable().getWindow().getFrame().getAttribute( 'aria-readonly' );
+
+				assert.areSame( 'false', readonlyAttr, 'editor frame has appropriate value of [aria-readonly] attribute' );
+			} );
+		},
+
+		// (#1904)
+		'test initial value of [aria-readonly] attribute (readonly editor)': function() {
+			bender.editorBot.create( {
+				name: 'readonly-initial-readonly',
+				config: {
+					readOnly: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					readonlyAttr = editor.editable().getWindow().getFrame().getAttribute( 'aria-readonly' );
+
+				assert.areSame( 'true', readonlyAttr, 'editor frame has appropriate value of [aria-readonly] attribute' );
+			} );
+		},
+
+		// (#1904)
+		'test update value of [aria-readonly] attribute': function() {
+			bender.editorBot.create( {
+				name: 'readonly-update',
+				config: {
+					readOnly: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					readonlyAttr;
+
+				editor.setReadOnly( false );
+				readonlyAttr = readonlyAttr = editor.editable().getWindow().getFrame().getAttribute( 'aria-readonly' );
+
+				assert.areSame( 'false', readonlyAttr, 'editor frame has appropriate value of [aria-readonly] attribute' );
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added `[aria-readonly]` attribute to the editable.

However I discovered that in case of iframe-based editor JAWS recognises this information only after applying it to the `iframe` element, not editable itself. Additionally `iframe` must have also `[role=textbox]` and `[aria-multiline=true]` attributes, otherwise JAWS does not announce newly added `[aria-readonly]` attribute.

Closes #1904.
