### PR TITLE
Add additional keystroke for toolbar focusing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,14 @@
 
 ## CKEditor 4.11.2
 
+New Features:
+
+* [#2618](https://github.com/ckeditor/ckeditor-dev/issues/2618): [Toolbar](https://ckeditor.com/cke4/addon/toolbar) can be focused using the <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>F10</kbd> keystroke.
+
 Fixed Issues:
 
 * [#1986](https://github.com/ckeditor/ckeditor-dev/issues/1986): Fixed: Cell Properties dialog from [Table Tools](https://ckeditor.com/cke4/addon/tabletools) plugin shows styles that are not allowed through [`config.allowedContent`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent).
+* [#2618](https://github.com/ckeditor/ckeditor-dev/issues/2618): Fixed: [Toolbar](https://ckeditor.com/cke4/addon/toolbar) can't be focused on Linux Mint.
 
 Other Changes:
 

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -406,6 +406,8 @@
 
 			editor.addCommand( 'toolbarFocus', commands.toolbarFocus );
 			editor.setKeystroke( CKEDITOR.ALT + 121 /*F10*/, 'toolbarFocus' );
+			// Adding alternative keystroke for some OS-es (#2618).
+			editor.setKeystroke( CKEDITOR.SHIFT + CKEDITOR.ALT + 121 /*F10*/, 'toolbarFocus' );
 
 			editor.ui.add( '-', CKEDITOR.UI_SEPARATOR, {} );
 			editor.ui.addHandler( CKEDITOR.UI_SEPARATOR, {

--- a/tests/plugins/toolbar/basic.js
+++ b/tests/plugins/toolbar/basic.js
@@ -123,5 +123,36 @@ bender.test( {
 				assert.areSame( resizeData[ 0 ].outerHeight, resizeData[ 2 ].outerHeight, 'Height should properly restore to same value.' );
 			}
 		);
-	}
+	},
+
+	'test Alt+F10 keystroke': assertKeystroke(),
+
+	// (#2618)
+	'test Shift+Alt+F10 keystroke': assertKeystroke( true )
 } );
+
+function assertKeystroke( withShift ) {
+	return function() {
+		bender.editorBot.create( {
+			name: 'test_keystroke_' + Number( withShift )
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			editor.on( 'afterCommandExec', function( evt ) {
+				resume( function() {
+					if ( evt.data.name === 'toolbarFocus' ) {
+						assert.pass();
+					}
+				} );
+			}, 100 );
+
+			editor.focus();
+			editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {
+				keyCode: 121,
+				altKey: true,
+				shiftKey: !!withShift
+			} ) );
+			wait();
+		} );
+	};
+}

--- a/tests/plugins/toolbar/manual/focusmint.html
+++ b/tests/plugins/toolbar/manual/focusmint.html
@@ -1,0 +1,9 @@
+<div id="editor">
+
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/toolbar/manual/focusmint.md
+++ b/tests/plugins/toolbar/manual/focusmint.md
@@ -1,0 +1,26 @@
+@bender-tags: 4.11.2, bug, 2618
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar,stylescombo, format, colorbutton, font, a11yhelp
+
+1. Focus the editor.
+2. Press <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F10</kbd>.
+	### Expected
+
+	Focus is moved to the editor's toolbar.
+
+	### Unexpected
+
+	Nothing happens.
+
+---
+
+1. Focus the editor.
+2. Press <kbd>Alt</kbd>+<kbd>0</kbd>
+3. Scroll to "Editor Toolbar" section.
+	### Expected
+
+	There are two keystrokes listed there: <kbd>Alt</kbd>+<kbd>F10</kbd> and <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F10</kbd>.
+
+	### Unexpected
+
+	Only one keystroke is listed there.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What changes did you make?

I've added new keystroke for focusing toolbar, <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>F10</kbd>.

Closes #2618.