### PR TITLE
Show matched emoji name instead of an ID in emoji suggestion box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.14
 
+New features:
+
+* [#2583](https://github.com/ckeditor/ckeditor-dev/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
+
 ## CKEditor 4.13.1
 
 Fixed Issues:

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -383,7 +383,7 @@
 							return acc + emojiTpl.output( {
 									symbol: htmlEncode( item.symbol ),
 									id: htmlEncode( item.id ),
-									name: item._name,
+									name: item.name,
 									group: htmlEncode( item.group ),
 									keywords: htmlEncode( ( item.keywords || [] ).join( ',' ) )
 								} );
@@ -600,7 +600,7 @@
 					editor._.emoji.autocomplete = new CKEDITOR.plugins.autocomplete( editor, {
 						textTestCallback: getTextTestCallback(),
 						dataCallback: dataCallback,
-						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item"><span>{symbol}</span> {_name}</li>',
+						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item"><span>{symbol}</span> {name}</li>',
 						outputTemplate: '{symbol}'
 					} );
 				}
@@ -661,8 +661,8 @@
 	} );
 
 	function addEncodedName( item ) {
-		if ( !item._name ) {
-			item._name = htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
+		if ( !item.name ) {
+			item.name = htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ) );
 		}
 		return item;
 	}

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -599,7 +599,7 @@
 					editor._.emoji.autocomplete = new CKEDITOR.plugins.autocomplete( editor, {
 						textTestCallback: getTextTestCallback(),
 						dataCallback: dataCallback,
-						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item">{symbol} {id}</li>',
+						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item">{symbol} {name}</li>',
 						outputTemplate: '{symbol}'
 					} );
 				}
@@ -641,6 +641,11 @@
 								return a.id > b.id ? 1 : -1;
 							}
 						} );
+					data = arrTools.map( data, function( item ) {
+						return CKEDITOR.tools.extend( item, {
+							name: htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) )
+						} );
+					} );
 					callback( data );
 				}
 			} );

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -599,7 +599,7 @@
 					editor._.emoji.autocomplete = new CKEDITOR.plugins.autocomplete( editor, {
 						textTestCallback: getTextTestCallback(),
 						dataCallback: dataCallback,
-						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item">{symbol} {name}</li>',
+						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item"><span>{symbol}</span> {name}</li>',
 						outputTemplate: '{symbol}'
 					} );
 				}

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -382,7 +382,7 @@
 							return acc + emojiTpl.output( {
 									symbol: htmlEncode( item.symbol ),
 									id: htmlEncode( item.id ),
-									name: htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) ),
+									name: getEmojiName( item ),
 									group: htmlEncode( item.group ),
 									keywords: htmlEncode( ( item.keywords || [] ).join( ',' ) )
 								} );
@@ -643,7 +643,7 @@
 						} );
 					data = arrTools.map( data, function( item ) {
 						return CKEDITOR.tools.extend( item, {
-							name: htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) )
+							name: getEmojiName( item )
 						} );
 					} );
 					callback( data );
@@ -662,6 +662,10 @@
 
 		}
 	} );
+
+	function getEmojiName( item ) {
+		return htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
+	}
 } )();
 
 /**

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -642,10 +642,7 @@
 								return a.id > b.id ? 1 : -1;
 							}
 						} );
-					data = arrTools.map( data, function( item ) {
-						addEncodedName( item );
-						return item;
-					} );
+					data = arrTools.map( data, addEncodedName );
 					callback( data );
 				}
 			} );
@@ -667,6 +664,7 @@
 		if ( !item._name ) {
 			item._name = htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
 		}
+		return item;
 	}
 } )();
 

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -379,10 +379,11 @@
 					return arrTools.reduce(
 						items,
 						function( acc, item ) {
+							addEncodedName( item );
 							return acc + emojiTpl.output( {
 									symbol: htmlEncode( item.symbol ),
 									id: htmlEncode( item.id ),
-									name: getEncodedName( item ),
+									name: item._name,
 									group: htmlEncode( item.group ),
 									keywords: htmlEncode( ( item.keywords || [] ).join( ',' ) )
 								} );
@@ -599,7 +600,7 @@
 					editor._.emoji.autocomplete = new CKEDITOR.plugins.autocomplete( editor, {
 						textTestCallback: getTextTestCallback(),
 						dataCallback: dataCallback,
-						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item"><span>{symbol}</span> {name}</li>',
+						itemTemplate: '<li data-id="{id}" class="cke_emoji-suggestion_item"><span>{symbol}</span> {_name}</li>',
 						outputTemplate: '{symbol}'
 					} );
 				}
@@ -642,9 +643,8 @@
 							}
 						} );
 					data = arrTools.map( data, function( item ) {
-						return CKEDITOR.tools.extend( {}, item, {
-							name: getEncodedName( item )
-						} );
+						addEncodedName( item );
+						return item;
 					} );
 					callback( data );
 				}
@@ -663,9 +663,10 @@
 		}
 	} );
 
-	function getEncodedName( item ) {
-		item._name = item._name || htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
-		return item._name;
+	function addEncodedName( item ) {
+		if ( !item._name ) {
+			item._name = htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
+		}
 	}
 } )();
 

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -382,7 +382,7 @@
 							return acc + emojiTpl.output( {
 									symbol: htmlEncode( item.symbol ),
 									id: htmlEncode( item.id ),
-									name: getEmojiName( item ),
+									name: getEncodedName( item ),
 									group: htmlEncode( item.group ),
 									keywords: htmlEncode( ( item.keywords || [] ).join( ',' ) )
 								} );
@@ -642,8 +642,8 @@
 							}
 						} );
 					data = arrTools.map( data, function( item ) {
-						return CKEDITOR.tools.extend( item, {
-							name: getEmojiName( item )
+						return CKEDITOR.tools.extend( {}, item, {
+							name: getEncodedName( item )
 						} );
 					} );
 					callback( data );
@@ -663,8 +663,9 @@
 		}
 	} );
 
-	function getEmojiName( item ) {
-		return htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
+	function getEncodedName( item ) {
+		item._name = item._name || htmlEncode( item.id.replace( /::.*$/, ':' ).replace( /^:|:$/g, '' ).replace( /_/g, ' ' ) );
+		return item._name;
 	}
 } )();
 

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -10,6 +10,10 @@
 	font-family: sans-serif, Arial, Verdana, "Trebuchet MS", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+.cke_emoji-suggestion_item span {
+	font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
 .cke_emoji-panel {
 	width: 310px;
 	height: 300px;

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -225,19 +225,19 @@
 				} );
 
 				arrayAssert.itemsAreSame( expected, actual );
-				assert.areSame( '😻 smiling_cat_face_with_heart-eyes' , autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
+				assert.areSame( '<span>😻</span> smiling_cat_face_with_heart-eyes' , autocomplete.view.element.getChild( 0 ).getHtml(), 'First element in view should start from "smiling".' );
 			} );
 		},
 
 		// (#2583)
 		'test emoji autocomplete panel displays name': function( editor, bot ) {
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
-				bot.setHtmlWithSelection( '<p>foo 😻 :smiling_cat_face_with_heart-eyes:^</p>' );
+				bot.setHtmlWithSelection( '<p>:smiling_cat_face_with_heart-eyes:^</p>' );
 				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 				var element = CKEDITOR.document.findOne( '.cke_emoji-suggestion_item' );
 
-				assert.areEqual( element.getText(), '😻 smiling_cat_face_with_heart-eyes' );
+				assert.areEqual( element.getHtml(), '<span>😻</span> smiling_cat_face_with_heart-eyes' );
 			} );
 		}
 	};

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -212,6 +212,19 @@
 				arrayAssert.itemsAreSame( expected, actual );
 				assert.areSame( '😻 :smiling_cat_face_with_heart-eyes:', autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
 			} );
+		},
+
+		// (#2583)
+		'test emoji autocomplete panel displays name': function( editor, bot ) {
+			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
+				bot.setHtmlWithSelection( '<p>foo :collision:^</p>' );
+				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				var element = CKEDITOR.document.findOne( '.cke_emoji-suggestion_item' );
+
+				assert.areEqual( element.$.innerText, '💥 collision' );
+
+			} );
 		}
 	};
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -104,11 +104,11 @@
 				return item.id === ':collision:';
 			} )[ 0 ];
 
-			assert.isUndefined( collision._name, 'Emoji name should be undefined.' );
+			assert.isUndefined( collision.name, 'Emoji name should be undefined.' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			assert.areEqual( 'collision', collision._name, 'Emoji name should be cached.' );
+			assert.areEqual( 'collision', collision.name, 'Emoji name should be cached.' );
 		},
 
 		'test emoji objects are added to editor': function( editor ) {
@@ -225,19 +225,19 @@
 				} );
 
 				arrayAssert.itemsAreSame( expected, actual );
-				assert.areSame( '😻 smiling cat face with heart-eyes', autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
+				assert.areSame( '😻 smiling_cat_face_with_heart-eyes' , autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
 			} );
 		},
 
 		// (#2583)
 		'test emoji autocomplete panel displays name': function( editor, bot ) {
 			emojiTools.runAfterInstanceReady( editor, bot, function( editor, bot ) {
-				bot.setHtmlWithSelection( '<p>foo :collision:^</p>' );
+				bot.setHtmlWithSelection( '<p>foo 😻 :smiling_cat_face_with_heart-eyes:^</p>' );
 				editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
 				var element = CKEDITOR.document.findOne( '.cke_emoji-suggestion_item' );
 
-				assert.areEqual( element.getText(), '💥 collision' );
+				assert.areEqual( element.getText(), '😻 smiling_cat_face_with_heart-eyes' );
 			} );
 		}
 	};

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -96,6 +96,21 @@
 			}
 		},
 
+		// This test should be on top of test suite, cause other tests will cache emojis (#2583).
+		'test emoji names cache': function( editor, bot ) {
+			bot.setHtmlWithSelection( '<p>foo :collision:^</p>' );
+
+			var collision = CKEDITOR.tools.array.filter( editor._.emoji.list, function( item ) {
+				return item.id === ':collision:';
+			} )[ 0 ];
+
+			assert.isUndefined( collision._name, 'Emoji name should be undefined.' );
+
+			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			assert.areEqual( 'collision', collision._name, 'Emoji name should be cached.' );
+		},
+
 		'test emoji objects are added to editor': function( editor ) {
 			emojiTools.runAfterInstanceReady( editor, null, function( editor ) {
 				assert.isObject( editor._.emoji, 'Emoji variable doesn\' exists' );

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -225,7 +225,7 @@
 				} );
 
 				arrayAssert.itemsAreSame( expected, actual );
-				assert.areSame( '😻 :smiling_cat_face_with_heart-eyes:', autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
+				assert.areSame( '😻 smiling cat face with heart-eyes', autocomplete.view.element.getChild( 0 ).getText(), 'First element in view should start from "smiling".' );
 			} );
 		},
 

--- a/tests/plugins/emoji/basic.js
+++ b/tests/plugins/emoji/basic.js
@@ -237,8 +237,7 @@
 
 				var element = CKEDITOR.document.findOne( '.cke_emoji-suggestion_item' );
 
-				assert.areEqual( element.$.innerText, '💥 collision' );
-
+				assert.areEqual( element.getText(), '💥 collision' );
 			} );
 		}
 	};

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -36,7 +36,7 @@
 				return item.id === ':collision:';
 			} )[ 0 ];
 
-			assert.isUndefined( collision._name, 'Emoji name should be undefined.' );
+			assert.isUndefined( collision.name, 'Emoji name should be undefined.' );
 
 			bot.panel( 'EmojiPanel', function( panel ) {
 				panel.hide();

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -40,7 +40,7 @@
 
 			bot.panel( 'EmojiPanel', function( panel ) {
 				panel.hide();
-				assert.areEqual( 'collision', collision._name, 'Emoji name should be cached.' );
+				assert.areEqual( 'collision', collision.name, 'Emoji name should be cached.' );
 			} );
 		},
 

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -28,6 +28,22 @@
 		setUp: function() {
 			bender.tools.ignoreUnsupportedEnvironment( 'emoji' );
 		},
+
+		// This test should be on top of test suite, cause other tests will cache emojis (#2583).
+		'test emoji names cache': function() {
+			var bot = this.editorBot,
+				collision = CKEDITOR.tools.array.filter( bot.editor._.emoji.list, function( item ) {
+				return item.id === ':collision:';
+			} )[ 0 ];
+
+			assert.isUndefined( collision._name, 'Emoji name should be undefined.' );
+
+			bot.panel( 'EmojiPanel', function( panel ) {
+				panel.hide();
+				assert.areEqual( 'collision', collision._name, 'Emoji name should be cached.' );
+			} );
+		},
+
 		'test emoji dropdown has proper components': function() {
 			var bot = this.editorBot;
 

--- a/tests/plugins/emoji/manual/emojimatchlabel.html
+++ b/tests/plugins/emoji/manual/emojimatchlabel.html
@@ -1,0 +1,12 @@
+<h1>Classic editor</h1>
+
+<textarea id="editor1" cols="10" rows="10">
+	<p>Foo!</p>
+</textarea>
+
+<script>
+	if ( emojiTools.notSupportedEnvironment) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/plugins/emoji/manual/emojimatchlabel.html
+++ b/tests/plugins/emoji/manual/emojimatchlabel.html
@@ -3,9 +3,8 @@
 </textarea>
 
 <script>
-	if ( emojiTools.notSupportedEnvironment ) {
-		bender.ignore();
-	}
+	bender.tools.ignoreUnsupportedEnvironment( 'emoji' );
+
 	CKEDITOR.replace( 'editor', {
 		removeButtons: 'EmojiPanel'
 	} );

--- a/tests/plugins/emoji/manual/emojimatchlabel.html
+++ b/tests/plugins/emoji/manual/emojimatchlabel.html
@@ -6,5 +6,7 @@
 	if ( emojiTools.notSupportedEnvironment) {
 		bender.ignore();
 	}
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor', {
+		removeButtons: 'EmojiPanel'
+	} );
 </script>

--- a/tests/plugins/emoji/manual/emojimatchlabel.html
+++ b/tests/plugins/emoji/manual/emojimatchlabel.html
@@ -3,7 +3,7 @@
 </textarea>
 
 <script>
-	if ( emojiTools.notSupportedEnvironment) {
+	if ( emojiTools.notSupportedEnvironment ) {
 		bender.ignore();
 	}
 	CKEDITOR.replace( 'editor', {

--- a/tests/plugins/emoji/manual/emojimatchlabel.html
+++ b/tests/plugins/emoji/manual/emojimatchlabel.html
@@ -1,12 +1,10 @@
-<h1>Classic editor</h1>
-
-<textarea id="editor1" cols="10" rows="10">
-	<p>Foo!</p>
+<textarea id="editor" cols="10" rows="10">
+	<p></p>
 </textarea>
 
 <script>
 	if ( emojiTools.notSupportedEnvironment) {
 		bender.ignore();
 	}
-	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/emoji/manual/emojimatchlabel.md
+++ b/tests/plugins/emoji/manual/emojimatchlabel.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.11.2, bug, emoji, 2583
+@bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
+@bender-ui: collapsed
+@bender-include: ../_helpers/tools.js
+
+1. Focus editor.
+1. Type `:collision:`
+
+## Expected:
+
+Panel appears with match: `💥 collision`
+
+## Unexpected:
+
+Panel appears with match: `💥 :collision:`

--- a/tests/plugins/emoji/manual/emojimatchlabel.md
+++ b/tests/plugins/emoji/manual/emojimatchlabel.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.2, bug, emoji, 2583
+@bender-tags: 4.12.0, feature, emoji, 2583
 @bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
 @bender-ui: collapsed
 @bender-include: ../_helpers/tools.js

--- a/tests/plugins/emoji/manual/emojimatchlabel.md
+++ b/tests/plugins/emoji/manual/emojimatchlabel.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.0, feature, emoji, 2583
+@bender-tags: 4.14.0, feature, emoji, 2583
 @bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
 @bender-ui: collapsed
 @bender-include: ../_helpers/tools.js

--- a/tests/plugins/emoji/manual/emojimatchlabel.md
+++ b/tests/plugins/emoji/manual/emojimatchlabel.md
@@ -8,8 +8,8 @@
 
 ## Expected:
 
-Panel appears with match: `💥 collision`
+Emoji suggestion box appears with match: `💥 collision`
 
 ## Unexpected:
 
-Panel appears with match: `💥 :collision:`
+Emoji suggestion box appears with match: `💥 :collision:`

--- a/tests/plugins/emoji/manual/emojimatchlabel.md
+++ b/tests/plugins/emoji/manual/emojimatchlabel.md
@@ -3,13 +3,13 @@
 @bender-ui: collapsed
 @bender-include: ../_helpers/tools.js
 
-1. Focus editor.
+1. Focus the editor.
 1. Type `:smiling_face:`
 
 ## Expected:
 
-Emoji suggestion box appears with match: `☺️ smiling_face`
+The emoji suggestion box appears with the match: `☺️ smiling_face`.
 
 ## Unexpected:
 
-Emoji suggestion box appears with match: `☺️ :smiling_face:`
+The emoji suggestion box appears with the match: `☺️ :smiling_face:`.

--- a/tests/plugins/emoji/manual/emojimatchlabel.md
+++ b/tests/plugins/emoji/manual/emojimatchlabel.md
@@ -4,12 +4,12 @@
 @bender-include: ../_helpers/tools.js
 
 1. Focus editor.
-1. Type `:collision:`
+1. Type `:smiling_face:`
 
 ## Expected:
 
-Emoji suggestion box appears with match: `💥 collision`
+Emoji suggestion box appears with match: `☺️ smiling_face`
 
 ## Unexpected:
 
-Emoji suggestion box appears with match: `💥 :collision:`
+Emoji suggestion box appears with match: `☺️ :smiling_face:`

--- a/tests/plugins/emoji/manual/font.html
+++ b/tests/plugins/emoji/manual/font.html
@@ -1,0 +1,10 @@
+<textarea id="editor" cols="10" rows="10">
+	<p></p>
+</textarea>
+
+<script>
+	if ( emojiTools.notSupportedEnvironment) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/emoji/manual/font.html
+++ b/tests/plugins/emoji/manual/font.html
@@ -3,8 +3,7 @@
 </textarea>
 
 <script>
-	if ( emojiTools.notSupportedEnvironment ) {
-		bender.ignore();
-	}
+	bender.tools.ignoreUnsupportedEnvironment( 'emoji' );
+
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/emoji/manual/font.html
+++ b/tests/plugins/emoji/manual/font.html
@@ -3,7 +3,7 @@
 </textarea>
 
 <script>
-	if ( emojiTools.notSupportedEnvironment) {
+	if ( emojiTools.notSupportedEnvironment ) {
 		bender.ignore();
 	}
 	CKEDITOR.replace( 'editor' );

--- a/tests/plugins/emoji/manual/font.md
+++ b/tests/plugins/emoji/manual/font.md
@@ -3,13 +3,13 @@
 @bender-ui: collapsed
 @bender-include: ../_helpers/tools.js
 
-1. Focus editor.
+1. Focus the editor.
 1. Type `:smiling_face:`
 
 ## Expected:
 
-Nice colored emoji is displayed in emoji suggestion box: <span style="font-family:&quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;;">☺</span>
+Emoji suggestion box displays a nicely colored emoji symbol like this one: <span style="font-family:&quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;;">☺</span>.
 
 ## Unexpected:
 
-Ugly black and white smiley is displayed in emoji suggestion box: <span style="font-family:sans-serif">☺</span>
+Emoji suggestion box displays an ugly black and white smiley like this one: <span style="font-family:sans-serif">☺</span>

--- a/tests/plugins/emoji/manual/font.md
+++ b/tests/plugins/emoji/manual/font.md
@@ -1,10 +1,10 @@
-@bender-tags: 4.12.0, feature, emoji, 2583
+@bender-tags: 4.14.0, feature, emoji, 2583
 @bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
 @bender-ui: collapsed
 @bender-include: ../_helpers/tools.js
 
 1. Focus editor.
-1. Type `:smilling_face:`
+1. Type `:smiling_face:`
 
 ## Expected:
 

--- a/tests/plugins/emoji/manual/font.md
+++ b/tests/plugins/emoji/manual/font.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.12.0, feature, emoji, 2583
+@bender-ckeditor-plugins: wysiwygarea, toolbar, emoji
+@bender-ui: collapsed
+@bender-include: ../_helpers/tools.js
+
+1. Focus editor.
+1. Type `:smilling_face:`
+
+## Expected:
+
+Nice colored emoji is displayed in emoji suggestion box: <span style="font-family:&quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;;">☺</span>
+
+## Unexpected:
+
+Ugly black and white smiley is displayed in emoji suggestion box: <span style="font-family:sans-serif">☺</span>


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature/task

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

Changed emoji suggestion box item template to show `item.name` instead of `item.id`.

## Changelog
```
* [#2583](https://github.com/ckeditor/ckeditor-dev/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
```

Closes #2583
