### PR TITLE
Fix for failing test on IE10: Added extra check for startNode first element, due to TypeError

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -208,7 +208,8 @@ CKEDITOR.dom.range = function( root ) {
 		// We need to handle situation when selection startNode is type of NODE_ELEMENT (#426).
 		if ( isClone &&
 			endNode.type == CKEDITOR.NODE_TEXT &&
-			( startNode.equals( endNode ) || ( startNode.type === CKEDITOR.NODE_ELEMENT && startNode.getFirst().equals( endNode ) ) ) ) {
+			( startNode.equals( endNode ) || ( startNode.type === CKEDITOR.NODE_ELEMENT &&
+				( startNode.getFirst() && startNode.getFirst().equals( endNode ) ) ) ) ) {
 
 			// Here we should always be inside one text node.
 			docFrag.append( range.document.createText( endNode.substring( startOffset, endOffset ) ) );

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -206,14 +206,28 @@ CKEDITOR.dom.range = function( root ) {
 		// and hence we can easily handle this case as many others.
 
 		// We need to handle situation when selection startNode is type of NODE_ELEMENT (#426).
-		if ( isClone &&
-			endNode.type == CKEDITOR.NODE_TEXT &&
-			( startNode.equals( endNode ) || ( startNode.type === CKEDITOR.NODE_ELEMENT &&
-				( startNode.getFirst() && startNode.getFirst().equals( endNode ) ) ) ) ) {
-
+		if ( shouldAppend() ) {
 			// Here we should always be inside one text node.
 			docFrag.append( range.document.createText( endNode.substring( startOffset, endOffset ) ) );
 			return;
+		}
+
+		function shouldAppend() {
+			if ( !isClone ) {
+				return false;
+			}
+
+			if ( endNode.type != CKEDITOR.NODE_TEXT ) {
+				return false;
+			}
+
+			if ( startNode.equals( endNode ) ) {
+				return true;
+			}
+
+			var firstChild = startNode.type === CKEDITOR.NODE_ELEMENT && startNode.getFirst();
+
+			return firstChild && firstChild.equals( endNode );
 		}
 
 		// For text containers, we must simply split the node and point to the

--- a/tests/core/dom/range/clonecontents.js
+++ b/tests/core/dom/range/clonecontents.js
@@ -629,6 +629,31 @@
 		'test cloneContents - multiple nested elements': function() {
 			this.assertHtmlFragment( this.editors.classic, '<p>fo[o <strong>bar <em>baz</em></strong></p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo]o</p>',
 			'<p>o <strong>bar <em>baz</em></strong>@</p><table><tbody><tr><td>hello</td></tr><tr><td>world</td></tr></tbody></table><p>fo</p>' );
+		},
+
+		// In some cases of selection typeError was thrown (#2534).
+		'test cloneContents - start at empty element end at text node': function() {
+			this.editorBots.classic.setData( '<p></p><p>foo</p>', function() {
+				var editor = this.editors.classic,
+					paragraphs = editor.editable().find( 'p' ).toArray(),
+					start = paragraphs[ 0 ],
+					end = paragraphs[ 1 ].getFirst(),
+					range = editor.createRange(),
+					spy = sinon.stub( start, 'getFirst' );
+
+				spy.returns( false );
+				range.setStart( start, 0 );
+				range.setEnd( end, 1 );
+
+				try {
+					range.cloneContents();
+					spy.restore();
+					assert.isTrue( true, 'Test passes without errors.' );
+				}
+				catch ( err ) {
+					assert.isTrue( false, 'Error thrown!' );
+				}
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix for failing test 

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?

Added extra check for element that is causing TypeError.

Closes #2534 