### PR TITLE
Added support for dragging block widgets into tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Features:
 
 * [#2598](https://github.com/ckeditor/ckeditor-dev/issues/2598): [Page Break](https://ckeditor.com/cke4/addon/pagebreak) feature support for [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
 * [#2048](https://github.com/ckeditor/ckeditor-dev/issues/2048): [Enhanced Image](https://ckeditor.com/cke4/addon/image2) added config option [CKEDITOR.config.image2_maxSize](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-image2_maxSize) that allows setting a maximum size that image can be resized to with resizer.
+* [#1648](https://github.com/ckeditor/ckeditor-dev/issues/1648): [Widget](https://ckeditor.com/cke4/addon/widget) added support for [dragging](https://ckeditor.com/docs/ckeditor4/latest/examples/draganddrop.html) into [tables](https://ckeditor.com/cke4/addon/table).
 
 Fixed Issues:
 

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -170,18 +170,25 @@
 			}
 
 			return function( el, type ) {
-				var alt;
+				var alt, shouldNormalize;
+
+				shouldNormalize = is( type, CKEDITOR.LINEUTILS_AFTER ) && isStatic( alt = el.getNext() ) && alt.isVisible();
 
 				// Normalization to avoid duplicates:
 				// CKEDITOR.LINEUTILS_AFTER becomes CKEDITOR.LINEUTILS_BEFORE of el.getNext().
-				if ( is( type, CKEDITOR.LINEUTILS_AFTER ) && isStatic( alt = el.getNext() ) && alt.isVisible() ) {
+				if ( shouldNormalize ) {
 					merge( alt, CKEDITOR.LINEUTILS_BEFORE, this.relations );
 					type ^= CKEDITOR.LINEUTILS_AFTER;
 				}
 
+				shouldNormalize = is( type, CKEDITOR.LINEUTILS_INSIDE ) && isStatic( alt = el.getFirst() ) && alt.isVisible();
+
+				// `br` can't be used for creating line, because it has 0 width (#1648).
+				shouldNormalize = shouldNormalize && !( alt.getName && alt.getName() === 'br' );
+
 				// Normalization to avoid duplicates:
 				// CKEDITOR.LINEUTILS_INSIDE becomes CKEDITOR.LINEUTILS_BEFORE of el.getFirst().
-				if ( is( type, CKEDITOR.LINEUTILS_INSIDE ) && isStatic( alt = el.getFirst() ) && alt.isVisible() ) {
+				if ( shouldNormalize ) {
 					merge( alt, CKEDITOR.LINEUTILS_BEFORE, this.relations );
 					type ^= CKEDITOR.LINEUTILS_INSIDE;
 				}

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -191,10 +191,6 @@
 					return false;
 				}
 
-				if ( !is( type, expectedType ) ) {
-					return false;
-				}
-
 				if ( !isStatic( alt ) ) {
 					return false;
 				}

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -186,7 +186,6 @@
 			}
 
 			function shouldNormalize( alt, type, expectedType ) {
-				// `br` can't be used for creating line, because it has 0 width (#1648).
 				if ( !is( type, expectedType ) ) {
 					return false;
 				}
@@ -199,6 +198,7 @@
 					return false;
 				}
 
+				// `br` can't be used for creating line, because it has 0 width (#1648).
 				return !alt.getName && alt.getName() !== 'br';
 			}
 

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -483,7 +483,8 @@
 				var sib = rel.element[ type === CKEDITOR.LINEUTILS_BEFORE ? 'getPrevious' : 'getNext' ]();
 
 				// Return the middle point between siblings.
-				if ( sib && isStatic( sib ) ) {
+				// Ignore elements that are not visible (#1648).
+				if ( sib && isStatic( sib ) && sib.isVisible() ) {
 					rel.siblingRect = sib.getClientRect();
 
 					if ( type == CKEDITOR.LINEUTILS_BEFORE ) {

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -170,30 +170,29 @@
 			}
 
 			return function( el, type ) {
-				var alt, shouldNormalize;
-
-				shouldNormalize = is( type, CKEDITOR.LINEUTILS_AFTER ) && isStatic( alt = el.getNext() ) && alt.isVisible();
+				var alt;
 
 				// Normalization to avoid duplicates:
 				// CKEDITOR.LINEUTILS_AFTER becomes CKEDITOR.LINEUTILS_BEFORE of el.getNext().
-				if ( shouldNormalize ) {
+				if ( shouldNormalize( CKEDITOR.LINEUTILS_AFTER ) ) {
 					merge( alt, CKEDITOR.LINEUTILS_BEFORE, this.relations );
 					type ^= CKEDITOR.LINEUTILS_AFTER;
 				}
 
-				shouldNormalize = is( type, CKEDITOR.LINEUTILS_INSIDE ) && isStatic( alt = el.getFirst() ) && alt.isVisible();
-
-				// `br` can't be used for creating line, because it has 0 width (#1648).
-				shouldNormalize = shouldNormalize && !( alt.getName && alt.getName() === 'br' );
-
 				// Normalization to avoid duplicates:
 				// CKEDITOR.LINEUTILS_INSIDE becomes CKEDITOR.LINEUTILS_BEFORE of el.getFirst().
-				if ( shouldNormalize ) {
+				if ( shouldNormalize( CKEDITOR.LINEUTILS_INSIDE ) ) {
 					merge( alt, CKEDITOR.LINEUTILS_BEFORE, this.relations );
 					type ^= CKEDITOR.LINEUTILS_INSIDE;
 				}
 
 				merge( el, type, this.relations );
+
+				function shouldNormalize( expectedType ) {
+					alt = expectedType === CKEDITOR.LINEUTILS_AFTER ? el.getNext() : el.getFirst();
+					// `br` can't be used for creating line, because it has 0 width (#1648).
+					return is( type, expectedType ) && isStatic( alt ) && alt.isVisible() && !( alt.getName && alt.getName() === 'br' );
+				}
 			};
 		} )(),
 

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -160,7 +160,7 @@
 		 */
 		store: ( function() {
 			return function( el, type ) {
-				var alt = getAlternative( el, CKEDITOR.LINEUTILS_AFTER );
+				var alt = el.getNext();
 
 				// Normalization to avoid duplicates:
 				// CKEDITOR.LINEUTILS_AFTER becomes CKEDITOR.LINEUTILS_BEFORE of el.getNext().
@@ -169,21 +169,17 @@
 					type ^= CKEDITOR.LINEUTILS_AFTER;
 				}
 
-				alt = getAlternative( el, CKEDITOR.LINEUTILS_INSIDE );
+				alt = el.getFirst();
 
 				// Normalization to avoid duplicates:
 				// CKEDITOR.LINEUTILS_INSIDE becomes CKEDITOR.LINEUTILS_BEFORE of el.getFirst().
-				if ( shouldNormalize( alt, CKEDITOR.LINEUTILS_INSIDE ) ) {
+				if ( shouldNormalize( alt, type, CKEDITOR.LINEUTILS_INSIDE ) ) {
 					merge( alt, CKEDITOR.LINEUTILS_BEFORE, this.relations );
 					type ^= CKEDITOR.LINEUTILS_INSIDE;
 				}
 
 				merge( el, type, this.relations );
 			};
-
-			function getAlternative( el, expectedType ) {
-				return expectedType === CKEDITOR.LINEUTILS_AFTER ? el.getNext() : el.getFirst();
-			}
 
 			function shouldNormalize( alt, type, expectedType ) {
 				if ( !is( type, expectedType ) ) {
@@ -199,7 +195,7 @@
 				}
 
 				// `br` can't be used for creating line, because it has 0 width (#1648).
-				return !alt.getName && alt.getName() !== 'br';
+				return !alt.is || !alt.is( 'br' );
 			}
 
 			function merge( el, type, relations ) {

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -187,7 +187,23 @@
 
 			function shouldNormalize( alt, type, expectedType ) {
 				// `br` can't be used for creating line, because it has 0 width (#1648).
-				return is( type, expectedType ) && isStatic( alt ) && alt.isVisible() && !( alt.getName && alt.getName() === 'br' );
+				if ( !is( type, expectedType ) ) {
+					return false;
+				}
+
+				if ( !is( type, expectedType ) ) {
+					return false;
+				}
+
+				if ( !isStatic( alt ) ) {
+					return false;
+				}
+
+				if ( !alt.isVisible() ) {
+					return false;
+				}
+
+				return !alt.getName && alt.getName() !== 'br';
 			}
 
 			function merge( el, type, relations ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3506,30 +3506,31 @@
 			cell.append( fakeParagraph, before );
 		}
 
-		/**
-		 * Sorts relations by actual distance.
-		 *
-		 * @param {Object} relations {@link CKEDITOR.plugins.lineutils.finder#relations}
-		 * @param {Object} locations {@link CKEDITOR.plugins.lineutils.locator}
-		 * @param {Object} coordinates
-		 * @param {Number} coordinates.x horizontal coordinate
-		 * @param {Number} coordinates.y vertical coordinate
-		 * @returns [Array] Sorted array representation of relations {@link CKEDITOR.plugins.lineutils.finder#relations}
-		 */
+		// Sorts the relations by the actual distance.
+		//
+		// @param {Object} relations {@link CKEDITOR.plugins.lineutils.finder#relations}
+		// @param {Object} locations {@link CKEDITOR.plugins.lineutils.locator}
+		// @param {Object} coordinates
+		// @param {Number} coordinates.x horizontal coordinate
+		// @param {Number} coordinates.y vertical coordinate
+		// @returns [Array] Sorted array representation of relations {@link CKEDITOR.plugins.lineutils.finder#relations}
 		function sortByDistance( relations, locations, coordinates ) {
 			var x = coordinates.x,
 				y = coordinates.y,
 				sorted = [];
 
 			for ( var id in locations ) {
+				// The calculations are split for horizontal and vertical value, then the Pythagorean Theorem is used to calculate the actual distance.
 				var relation = relations[ id ],
 					rect = relation.elementRect,
 					type = relation.type,
 					verticalDistance, horizontalDistance, isStored, distanceBefore, distanceAfter;
 
 				if ( relation.type === CKEDITOR.LINEUTILS_INSIDE ) {
+					// Calculate the distance for the elements top and the bottom, and store the lower value.
 					horizontalDistance = getDistance( y, rect.top, rect.bottom );
 				} else {
+					// Calculate the distance for the elements before and after positions. Store the lower value, and it's type.
 					rect = relation.element.getParent().getClientRect();
 
 					distanceBefore = getDistance( y, locations[ id ][ 1 ] );
@@ -3550,12 +3551,13 @@
 					}
 				}
 
+				// Calculate the distance for the elements left and the right, and store the lowest.
 				verticalDistance = getDistance( x, rect.left, rect.right );
 
 				relation = {
 					uid: id,
 					type: type,
-					dist: Math.sqrt( Math.pow( verticalDistance, 2 ) + Math.pow( horizontalDistance, 2 ) )
+					dist: Math.sqrt( Math.pow( verticalDistance, 2 ) + Math.pow( horizontalDistance, 2 ) ) // Pythagorean Theorem
 				};
 
 				isStored = !!CKEDITOR.tools.array.find( sorted, function( item, index ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2627,7 +2627,7 @@
 
 							// Allow line only on one side of fake paragraph.
 							if ( el.hasClass( 'cke_fake-paragraph' ) ) {
-								return el.getAttribute( 'data-cke-fake-paragraph' );
+								return el.data( 'cke-fake-paragraph' );
 							}
 
 							return isCell ? CKEDITOR.LINEUTILS_INSIDE : CKEDITOR.LINEUTILS_BEFORE | CKEDITOR.LINEUTILS_AFTER;

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2627,7 +2627,7 @@
 
 							// Allow line only on one side of fake paragraph.
 							if ( el.hasClass( 'cke_fake-paragraph' ) ) {
-								return el.data( 'cke-fake-paragraph' );
+								return el.getIndex() === 0 ? CKEDITOR.LINEUTILS_BEFORE : CKEDITOR.LINEUTILS_AFTER;
 							}
 
 							return isCell ? CKEDITOR.LINEUTILS_INSIDE : CKEDITOR.LINEUTILS_BEFORE | CKEDITOR.LINEUTILS_AFTER;
@@ -3453,9 +3453,6 @@
 					liner.cleanup();
 				}
 			} );
-
-		fakeParagraphs[ 0 ].data( 'cke-fake-paragraph', CKEDITOR.LINEUTILS_BEFORE );
-		fakeParagraphs[ 1 ].data( 'cke-fake-paragraph', CKEDITOR.LINEUTILS_AFTER );
 
 		// Let's have the "dragging cursor" over entire editable.
 		editable.addClass( 'cke_widget_dragging' );

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3438,7 +3438,7 @@
 		// Harvest all possible relations and display some closest.
 		var relations = finder.greedySearch(),
 			buffer = CKEDITOR.tools.eventsBuffer( 50, function() {
-				if (  target.getName() in { td: 1, th: 1 } ) {
+				if ( target.getName() in { td: 1, th: 1 } ) {
 					placeFakeParagraph( target );
 					placeFakeParagraph( target, true );
 				}

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3597,9 +3597,7 @@
 			var dropRange = finder.getRange( sorted[ 0 ] ),
 				bookmark = dropRange.createBookmark();
 
-			CKEDITOR.tools.array.forEach( fakeParagraphs, function( fakeParagraph ) {
-				fakeParagraph.remove();
-			} );
+			cleanFakeParagraphs();
 
 			// Remove any references to temporary elements.
 			fakeParagraphs.length = 0;
@@ -3615,6 +3613,8 @@
 				dropRange: dropRange,
 				target: dropRange.startContainer
 			} );
+		} else {
+			cleanFakeParagraphs();
 		}
 
 		// Clean-up custom cursor for editable.
@@ -3625,6 +3625,15 @@
 
 		// Clean-up drag & drop.
 		editor.fire( 'dragend', { target: dragTarget } );
+	}
+
+	function cleanFakeParagraphs() {
+		CKEDITOR.tools.array.forEach( fakeParagraphs, function( fakeParagraph ) {
+			fakeParagraph.remove();
+		} );
+
+		// Remove any references to temporary elements.
+		fakeParagraphs.length = 0;
 	}
 
 	function setupEditables( widget ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3409,7 +3409,7 @@
 		widget.dragHandlerContainer = container;
 	}
 
-	var fakeParagraphs = [];
+	var fakeParagraphs;
 
 	function onBlockWidgetDrag( evt ) {
 		// Allow to drag widget only with left mouse button (#711).
@@ -3432,8 +3432,10 @@
 
 		var fakeParagraphHtml = '<p class="cke_fake-paragraph" style="height:0;margin:0;padding:0"></p>';
 
-		fakeParagraphs.push( CKEDITOR.dom.element.createFromHtml( fakeParagraphHtml ) );
-		fakeParagraphs.push( CKEDITOR.dom.element.createFromHtml( fakeParagraphHtml ) );
+		fakeParagraphs = {
+			before: CKEDITOR.dom.element.createFromHtml( fakeParagraphHtml ),
+			after: CKEDITOR.dom.element.createFromHtml( fakeParagraphHtml )
+		};
 
 		// Harvest all possible relations and display some closest.
 		var relations = finder.greedySearch(),
@@ -3490,13 +3492,14 @@
 			var isText = node.type === CKEDITOR.NODE_TEXT,
 				isInline = node.is && node.is( CKEDITOR.dtd.$inline ),
 				isBr = node.getName && node.getName() === 'br',
+				position = before ? 'before' : 'after',
 				fakeParagraph;
 
 			if ( !isText && !isInline || isBr ) {
 				return null;
 			}
 
-			fakeParagraph = fakeParagraphs[ before ? 0 : 1 ];
+			fakeParagraph = fakeParagraphs[ position ];
 
 			finder.store( fakeParagraph, before ? CKEDITOR.LINEUTILS_BEFORE : CKEDITOR.LINEUTILS_AFTER );
 
@@ -3663,11 +3666,9 @@
 	}
 
 	function cleanFakeParagraphs() {
-		CKEDITOR.tools.array.forEach( fakeParagraphs, function( fakeParagraph ) {
-			fakeParagraph.remove();
-		} );
-
-		fakeParagraphs.length = 0;
+		fakeParagraphs.before.remove();
+		fakeParagraphs.after.remove();
+		fakeParagraphs = null;
 	}
 
 	function setupEditables( widget ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3605,7 +3605,6 @@
 				}
 
 				return horizontalDistance === distanceBefore ? CKEDITOR.LINEUTILS_BEFORE : CKEDITOR.LINEUTILS_AFTER;
-
 			}
 
 			// Pythagorean Theorem

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3440,7 +3440,7 @@
 		// Harvest all possible relations and display some closest.
 		var relations = finder.greedySearch(),
 			buffer = CKEDITOR.tools.eventsBuffer( 50, function() {
-				if ( target.getName() in { td: 1, th: 1 } ) {
+				if ( target.is( 'td', 'th') ) {
 					placeFakeParagraph( target );
 					placeFakeParagraph( target, true );
 				}

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2580,27 +2580,22 @@
 					lookups: {
 						// Element is block but not list item and not in nested editable.
 						'default': function( el ) {
-							var ret;
-							if ( el.getName() in { td: 1, th: 1 } ) {
-								ret = CKEDITOR.LINEUTILS_INSIDE;
+							var isCell = el.getName() in { td: 1, th: 1 };
+
+							if ( el.is( CKEDITOR.dtd.$listItem ) ) {
+								return;
 							}
 
-							// Allow line only on one side of fake paragraph.
-							if ( el.hasClass( 'cke_fake-paragraph' ) ) {
-								ret = el.getAttribute( 'data-cke-fake-paragraph' );
+							if ( !isCell && !el.is( CKEDITOR.dtd.$block ) ) {
+								return;
 							}
-
-							if ( el.is( CKEDITOR.dtd.$listItem ) )
-								return;
-
-							if ( !ret && !el.is( CKEDITOR.dtd.$block ) )
-								return;
 
 							// Allow drop line inside, but never before or after nested editable (https://dev.ckeditor.com/ticket/12006).
-							if ( Widget.isDomNestedEditable( el ) )
+							if ( Widget.isDomNestedEditable( el ) ) {
 								return;
+							}
 
-							// Do not allow droping inside the widget being dragged (https://dev.ckeditor.com/ticket/13397).
+							// Do not allow dropping inside the widget being dragged (https://dev.ckeditor.com/ticket/13397).
 							if ( widgetsRepo._.draggedWidget.wrapper.contains( el ) ) {
 								return;
 							}
@@ -2611,19 +2606,26 @@
 								var draggedWidget = widgetsRepo._.draggedWidget;
 
 								// Don't let the widget to be dropped into its own nested editable.
-								if ( widgetsRepo.getByElement( nestedEditable ) == draggedWidget )
+								if ( widgetsRepo.getByElement( nestedEditable ) == draggedWidget ) {
 									return;
+								}
 
 								var filter = CKEDITOR.filter.instances[ nestedEditable.data( 'cke-filter' ) ],
 									draggedRequiredContent = draggedWidget.requiredContent;
 
 								// There will be no relation if the filter of nested editable does not allow
 								// requiredContent of dragged widget.
-								if ( filter && draggedRequiredContent && !filter.check( draggedRequiredContent ) )
+								if ( filter && draggedRequiredContent && !filter.check( draggedRequiredContent ) ) {
 									return;
+								}
 							}
 
-							return ret || CKEDITOR.LINEUTILS_BEFORE | CKEDITOR.LINEUTILS_AFTER;
+							// Allow line only on one side of fake paragraph.
+							if ( el.hasClass( 'cke_fake-paragraph' ) ) {
+								return el.getAttribute( 'data-cke-fake-paragraph' );
+							}
+
+							return isCell ? CKEDITOR.LINEUTILS_INSIDE : CKEDITOR.LINEUTILS_BEFORE | CKEDITOR.LINEUTILS_AFTER;
 						}
 					}
 				} ),

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3435,8 +3435,7 @@
 				}, 0 ),
 			fakeParagraphHtml = '<p class="cke_fake-paragraph" style="height:0;margin:0;padding:0"></p>',
 			// To be adjusted. Higher value could be used for newer browsers and lower for older browsers.
-			limit = 100,
-			relations;
+			limit = 100;
 
 		if ( cellCount <= limit ) {
 			var cells = editable.find( 'td' ).toArray().concat( editable.find( 'th' ).toArray() );
@@ -3444,24 +3443,23 @@
 		}
 
 		// Harvest all possible relations and display some closest.
-		relations = finder.greedySearch();
+		var relations = finder.greedySearch(),
+			buffer = CKEDITOR.tools.eventsBuffer( 50, function() {
+				if ( cellCount > limit && target.getName() in { td:1, th:1 } ) {
+					storeFakeParagraph( addFakeParagraph( target ) );
+					storeFakeParagraph( addFakeParagraph( target, true ) );
+				}
 
-		var buffer = CKEDITOR.tools.eventsBuffer( 50, function() {
-			if ( cellCount > limit && target.getName() in { td:1, th:1 } ) {
-				storeFakeParagraph( addFakeParagraph( target ) );
-				storeFakeParagraph( addFakeParagraph( target, true ) );
-			}
+				locations = locator.locate( relations );
 
-			locations = locator.locate( relations );
+				sorted = sortByDistance( relations, locations, { x: x, y: y } );
 
-			sorted = sortByDistance( relations, locations, { x: x, y: y } );
-
-			if ( sorted.length ) {
-				liner.prepare( relations, locations );
-				liner.placeLine( sorted[ 0 ] );
-				liner.cleanup();
-			}
-		} );
+				if ( sorted.length ) {
+					liner.prepare( relations, locations );
+					liner.placeLine( sorted[ 0 ] );
+					liner.cleanup();
+				}
+			} );
 
 		// Let's have the "dragging cursor" over entire editable.
 		editable.addClass( 'cke_widget_dragging' );

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3435,7 +3435,7 @@
 				}, 0 ),
 			fakeParagraphHtml = '<p class="cke_fake-paragraph" style="height:0;margin:0;padding:0"></p>',
 			// To be adjusted. Higher value could be used for newer browsers and lower for older browsers.
-			limit = 0,
+			limit = 100,
 			relations;
 
 		if ( cellCount <= limit ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3644,6 +3644,8 @@
 		CKEDITOR.tools.array.forEach( fakeParagraphs, function( fakeParagraph ) {
 			fakeParagraph.remove();
 		} );
+
+		fakeParagraphs.length = 0;
 	}
 
 	function setupEditables( widget ) {

--- a/tests/plugins/widget/dragintotable.html
+++ b/tests/plugins/widget/dragintotable.html
@@ -3,19 +3,19 @@
 		<thead>
 		<tr>
 			<th width="100"></th>
-			<th width="100"></th>
-			<th width="100"></th>
+			<th width="100">Foo</th>
+			<th width="100"><em>Bar</em></th>
 		</tr>
 		</thead>
 		<tbody>
 		<tr>
+			<td width="100"><em>Bar</em></td>
 			<td width="100"></td>
-			<td width="100"></td>
-			<td width="100"></td>
+			<td width="100">Foo</td>
 		</tr>
 		<tr>
-			<td width="100"></td>
-			<td width="100"></td>
+			<td width="100">Foo</td>
+			<td width="100"><em>Bar</em></td>
 			<td width="100"></td>
 		</tr>
 		</tbody>

--- a/tests/plugins/widget/dragintotable.html
+++ b/tests/plugins/widget/dragintotable.html
@@ -1,0 +1,27 @@
+<div id="editor-content">
+	<table border="1" cellspacing="1" cellpadding="1">
+		<thead>
+		<tr>
+			<th width="100"></th>
+			<th width="100"></th>
+			<th width="100"></th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<td width="100"></td>
+			<td width="100"></td>
+			<td width="100"></td>
+		</tr>
+		<tr>
+			<td width="100"></td>
+			<td width="100"></td>
+			<td width="100"></td>
+		</tr>
+		</tbody>
+	</table>
+	<figure class="image">
+		<img width="60" src="/tests/_assets/lena.jpg"/>
+		<figcaption>Caption</figcaption>
+	</figure>
+</div>

--- a/tests/plugins/widget/dragintotable.html
+++ b/tests/plugins/widget/dragintotable.html
@@ -1,4 +1,4 @@
-<div id="editor-content">
+<div id="synchronous-lines">
 	<table border="1" cellspacing="1" cellpadding="1">
 		<thead>
 		<tr>
@@ -24,4 +24,156 @@
 		<img width="60" src="/tests/_assets/lena.jpg"/>
 		<figcaption>Caption</figcaption>
 	</figure>
+</div>
+
+<div id="asynchronous-lines">
+	<table border="1" cellspacing="1" cellpadding="1">
+		<thead>
+		<tr>
+			<th width="100"></th>
+			<th width="100">Foo</th>
+			<th width="100"><em>Bar</em></th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<td width="100"><em>Bar</em></td>
+			<td width="100"></td>
+			<td width="100">Foo</td>
+		</tr>
+		<tr>
+			<td width="100">Foo</td>
+			<td width="100"><em>Bar</em></td>
+			<td width="100"></td>
+		</tr>
+		</tbody>
+	</table>
+	<figure class="image">
+		<img width="60" src="/tests/_assets/lena.jpg"/>
+		<figcaption>Caption</figcaption>
+	</figure>
+	<table>
+		<tbody>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		<tr>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+			<td>foo</td>
+		</tr>
+		</tbody>
+	</table>
 </div>

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -46,12 +46,12 @@
 		'test drag into table left top cell - empty': assertDragLine( 'table tr:nth-child(1) th:nth-child(1)', 'inside' ),
 		'test drag into table middle cell - empty': assertDragLine( 'table tr:nth-child(1) td:nth-child(2)', 'inside' ),
 		'test drag into table right bottom cell - empty': assertDragLine( 'table tr:nth-child(2) td:nth-child(3)', 'inside' ),
-		'test drag into table middle top cell - empty': assertDragLine( 'table tr:nth-child(1) th:nth-child(2)', 'before' ),
-		'test drag into table right middle cell - empty': assertDragLine( 'table tr:nth-child(1) td:nth-child(3)', 'after' ),
-		'test drag into table left bottom  cell - empty': assertDragLine( 'table tr:nth-child(2) td:nth-child(1)', 'before' ),
-		'test drag into table right top cell - empty': assertDragLine( 'table tr:nth-child(1) th:nth-child(3)', 'after' ),
-		'test drag into table left middle cell - empty': assertDragLine( 'table tr:nth-child(1) td:nth-child(1)', 'before' ),
-		'test drag into table middle bottom cell - empty': assertDragLine( 'table tr:nth-child(2) td:nth-child(2)', 'after' )
+		'test drag into table middle top cell - text': assertDragLine( 'table tr:nth-child(1) th:nth-child(2)', 'before' ),
+		'test drag into table right middle cell - text': assertDragLine( 'table tr:nth-child(1) td:nth-child(3)', 'after' ),
+		'test drag into table left bottom  cell - text': assertDragLine( 'table tr:nth-child(2) td:nth-child(1)', 'before' ),
+		'test drag into table right top cell - inline element': assertDragLine( 'table tr:nth-child(1) th:nth-child(3)', 'after' ),
+		'test drag into table left middle cell - inline element': assertDragLine( 'table tr:nth-child(1) td:nth-child(1)', 'before' ),
+		'test drag into table middle bottom cell - inline element': assertDragLine( 'table tr:nth-child(2) td:nth-child(2)', 'after' )
 	} );
 
 	function assertDragLine( selector, position ) {

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -56,6 +56,10 @@
 
 	function assertDragLine( selector, position ) {
 		return function() {
+			// Ignore IE8 (#3004).
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+				assert.ignore();
+			}
 			this.editorBot.setData( CKEDITOR.document.findOne( '#editor-content' ).getHtml(), function() {
 				var editor = this.editor,
 					editable = editor.editable(),

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -91,8 +91,8 @@
 								actual = getPoint( lineRect, position ),
 								expected = getPoint( elementRect, position );
 
-							assert.isNumberInRange( expected.x, actual.x - 1, actual.x + 1, 'Line vertical position' );
-							assert.isNumberInRange( expected.y, actual.y - 1, actual.y + 1, 'Line horizontal position' );
+							assert.isNumberInRange( Math.round( expected.x ), Math.round( actual.x - 1 ), Math.round( actual.x + 1 ), 'Line vertical position' );
+							assert.isNumberInRange( Math.round( expected.y ), Math.round( actual.y - 1 ), Math.round( actual.y + 1 ), 'Line horizontal position' );
 
 							editor.once( 'paste', function() {
 								resume( function() {

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -35,11 +35,11 @@
 			overlay.setStyle( 'display', 'none' );
 		},
 		// (#1648)
-		'test drag into table left top cell': assertDragLine( 'table tr:nth-child(1) th:nth-child(1)' ),
+		'test drag into table left top cell - empty': assertDragLine( 'table tr:nth-child(1) th:nth-child(1)' ),
 		// (#1648)
-		'test drag into table middle cell': assertDragLine( 'table tr:nth-child(1) td:nth-child(2)' ),
+		'test drag into table middle cell - empty': assertDragLine( 'table tr:nth-child(1) td:nth-child(2)' ),
 		// (#1648)
-		'test drag into table right bottom cell': assertDragLine( 'table tr:nth-child(2) td:nth-child(3)' )
+		'test drag into table right bottom cell - empty': assertDragLine( 'table tr:nth-child(2) td:nth-child(3)' )
 	} );
 
 	function assertDragLine( selector ) {

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -55,7 +55,7 @@
 					element = editable.findOne( selector ),
 					coordinates = getPoint( element.getClientRect(), 'inside' );
 
-				// Adjust mouse position closer to tested edge of cell.
+				// Adjust mouse position closer to the tested edge of cell.
 				if ( position in { before: 1 , after: 1 } ) {
 					coordinates.y += position === 'before' ? -1 : 1;
 				}

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -102,6 +102,7 @@
 								resume( function() {
 									var widget = editable.findOne( 'figure' );
 									assert.isTrue( element[ position === 'after' ? 'getLast' : 'getFirst' ]().contains( widget ), 'Widget in cell' );
+									arrayAssert.isEmpty( editable.find( '.cke_fake-paragraph' ).toArray(), 'Temporary fake paragraphs removed.' );
 								} );
 							}, null, null, 999 );
 

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -61,14 +61,12 @@
 				}
 
 				handler.once( 'mousedown', function() {
-
 					editable.fire( 'mousemove', {
 						$: {
 							clientX: coordinates.x,
 							clientY: coordinates.y
 						}
 					} );
-
 				}, null, null, 9999 );
 
 				editable.once( 'mousemove', function() {

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -34,7 +34,15 @@
 		tearDown: function() {
 			overlay.setStyle( 'display', 'none' );
 		},
+		// When dragging into table cell drag line should appear in right place, and widget should be pasted in right place.
+		// Cases covered by tests:
+		// 	- Cell is empty. Line should appear in the middle of cell. Widget is pasted into cell.
+		// 	- Cell has text node. Line should appear at the position of of hovered temporary fake paragraph.
+		// 	There are two such paragraphs, one at the start of cell and one at the end of cell. Widget should replace hovered temporary paragraph.
+		// 	- Cell has inline element. Line should appear at the top or at the bottom edge of inline element depending on which edge is hovered.
+		// 	Widget should be pasted before or after inline element depending on which end is hovered.
 		// (#1648)
+
 		'test drag into table left top cell - empty': assertDragLine( 'table tr:nth-child(1) th:nth-child(1)', 'inside' ),
 		'test drag into table middle cell - empty': assertDragLine( 'table tr:nth-child(1) td:nth-child(2)', 'inside' ),
 		'test drag into table right bottom cell - empty': assertDragLine( 'table tr:nth-child(2) td:nth-child(3)', 'inside' ),

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -1,0 +1,112 @@
+/* bender-tags: widgetcore */
+/* bender-ckeditor-plugins: wysiwygarea, toolbar, table, image2, clipboard */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {
+			allowedContent: true
+		}
+	};
+
+	var overlay;
+
+	bender.test( {
+		// Hide editor under an overlay, to prevent accidental mouse move which might break TC.
+		setUp: function() {
+			if ( !overlay ) {
+				overlay = new CKEDITOR.dom.element( 'div' );
+
+				overlay.setStyles( {
+					position: 'fixed',
+					width: '100%',
+					height: '100%',
+					left: 0,
+					top: 0
+				} );
+
+				CKEDITOR.document.getBody().append( overlay );
+			} else {
+				overlay.removeStyle( 'display' );
+			}
+		},
+		tearDown: function() {
+			overlay.setStyle( 'display', 'none' );
+		},
+		// (#1648)
+		'test drag into table left top cell': assertDragLine( 'table tr:nth-child(1) th:nth-child(1)' ),
+		// (#1648)
+		'test drag into table middle cell': assertDragLine( 'table tr:nth-child(1) td:nth-child(2)' ),
+		// (#1648)
+		'test drag into table right bottom cell': assertDragLine( 'table tr:nth-child(2) td:nth-child(3)' )
+	} );
+
+	function assertDragLine( selector ) {
+		return function() {
+			this.editorBot.setData( CKEDITOR.document.findOne( '#editor-content' ).getHtml(), function() {
+				var editor = this.editor,
+					editable = editor.editable(),
+					handler = editable.findOne( '.cke_widget_drag_handler' ),
+					element = editable.findOne( selector ),
+					coordinates = getMiddlePoint( element.getClientRect() );
+
+				handler.once( 'mousedown', function() {
+
+					editable.fire( 'mousemove', {
+						$: {
+							clientX: coordinates.x,
+							clientY: coordinates.y
+						}
+					} );
+
+				}, null, null, 9999 );
+
+				editable.once( 'mousemove', function() {
+					// Wait for event buffer which is 50ms.
+					setTimeout( function() {
+						resume( function() {
+							var elementRect = element.getClientRect( true ),
+								visible = editor.widgets.liner.visible,
+								lineRect = visible[ CKEDITOR.tools.objectKeys( visible )[ 0 ] ].getClientRect( true ),
+								actual = getMiddlePoint( lineRect ),
+								expected = getMiddlePoint( elementRect );
+
+							assert.isNumberInRange( expected.x, actual.x - 1, actual.x + 1, 'Line vertical position' );
+							assert.isNumberInRange( expected.y, actual.y - 1, actual.y + 1, 'Line horizontal position' );
+
+							editor.once( 'paste', function() {
+								resume( function() {
+									assert.isNotNull( element.findOne( 'figure' ), 'Widget in cell' );
+								} );
+							}, null, null, 999 );
+
+							CKEDITOR.document.fire( 'mouseup', {
+								button: CKEDITOR.MOUSE_BUTTON_LEFT,
+								getTarget: function() {
+									return element;
+								}
+							} );
+
+							wait();
+						} );
+					}, 55 );
+				}, null, null, 9999 );
+
+				handler.fire( 'mousedown', new CKEDITOR.dom.event( {
+					button: CKEDITOR.MOUSE_BUTTON_LEFT,
+					target: handler
+				} ) );
+
+				wait();
+			} );
+		};
+	}
+
+	function getMiddlePoint( rect ) {
+		return {
+			x: ( rect.right + rect.left ) / 2,
+			y: ( rect.bottom + rect.top ) / 2
+		};
+	}
+} )();

--- a/tests/plugins/widget/dragintotable.js
+++ b/tests/plugins/widget/dragintotable.js
@@ -66,8 +66,8 @@
 
 	function testDragLine( selector, position, asyncLines ) {
 		return function() {
-			// Ignore IE8 (#3004).
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+			// Ignore older IEs, also on IE8 there is an issue with drag line placement (#3004).
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 				assert.ignore();
 			}
 

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -4,7 +4,7 @@
 		<tr>
 			<th width="100"></th>
 			<th width="100"></th>
-			<th width="100">Foo</th>
+			<th width="100"><em>Foo</em></th>
 		</tr>
 		</thead>
 		<tbody>

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -4,7 +4,7 @@
 		<tr>
 			<th width="100"></th>
 			<th width="100"></th>
-			<th width="100"><em>Foo</em></th>
+			<th width="100"><em>Inline element</em></th>
 		</tr>
 		</thead>
 		<tbody>
@@ -14,9 +14,9 @@
 			<td width="100"></td>
 		</tr>
 		<tr>
-			<td width="100">Foo</td>
+			<td width="100">Just text</td>
 			<td width="100"></td>
-			<td width="100"></td>
+			<td width="100"><p>Paragraph</p></td>
 		</tr>
 		</tbody>
 	</table>

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -27,7 +27,8 @@
 </textarea>
 
 <script>
-	if ( bender.tools.env.mobile ) {
+	// Ignore IE8 (#3004).
+	if ( bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
 		bender.ignore();
 	}
 	CKEDITOR.replace( 'editor', {

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -1,0 +1,37 @@
+<textarea id="editor">
+	<table border="1" cellspacing="1" cellpadding="1">
+		<thead>
+		<tr>
+			<th width="100"></th>
+			<th width="100"></th>
+			<th width="100"></th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<td width="100"></td>
+			<td width="100"></td>
+			<td width="100"></td>
+		</tr>
+		<tr>
+			<td width="100"></td>
+			<td width="100"></td>
+			<td width="100"></td>
+		</tr>
+		</tbody>
+	</table>
+	<figure class="image">
+		<img width="60" src="/tests/_assets/lena.jpg"/>
+		<figcaption>Caption</figcaption>
+	</figure>
+</textarea>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+	CKEDITOR.replace( 'editor', {
+		height: 400,
+		allowedContent: true
+	} );
+</script>

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -4,7 +4,7 @@
 		<tr>
 			<th width="100"></th>
 			<th width="100"></th>
-			<th width="100"></th>
+			<th width="100">Foo</th>
 		</tr>
 		</thead>
 		<tbody>
@@ -14,7 +14,7 @@
 			<td width="100"></td>
 		</tr>
 		<tr>
-			<td width="100"></td>
+			<td width="100">Foo</td>
 			<td width="100"></td>
 			<td width="100"></td>
 		</tr>

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -1,4 +1,4 @@
-<textarea id="editor">
+<textarea id="editor1">
 	<table border="1" cellspacing="1" cellpadding="1">
 		<thead>
 		<tr>
@@ -26,13 +26,47 @@
 	</figure>
 </textarea>
 
+<textarea id="editor2">
+	<figure class="image">
+		<img width="60" src="/tests/_assets/lena.jpg"/>
+		<figcaption>Caption</figcaption>
+	</figure>
+
+	<table border="1" cellspacing="1" cellpadding="1" width="500">
+		<tbody></tbody>
+	</table>
+</textarea>
+
 <script>
 	// Ignore IE8 (#3004).
 	if ( bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
 		bender.ignore();
 	}
-	CKEDITOR.replace( 'editor', {
+
+	CKEDITOR.replace( 'editor1', {
 		height: 400,
-		allowedContent: true
+		extraAllowedContent: 'td[width];th[width]'
 	} );
+
+	CKEDITOR.replace( 'editor2', {
+		height: 400,
+		extraAllowedContent: 'td[width];th[width]',
+		on: {
+			instanceReady: function() {
+				var tBody = this.editable().findOne( 'tbody' );
+
+				for ( var i = 0; i < 25; i++ ) {
+					var tr = new CKEDITOR.dom.element( 'tr' );
+
+					for ( var j = 0; j < 5; j++ ) {
+						var td = new CKEDITOR.dom.element( 'td' );
+						td.setText( 'foo' );
+						tr.append( td );
+					}
+
+					tBody.append( tr );
+				}
+			}
+		}
+	} )
 </script>

--- a/tests/plugins/widget/manual/dragintotable.html
+++ b/tests/plugins/widget/manual/dragintotable.html
@@ -26,17 +26,6 @@
 	</figure>
 </textarea>
 
-<textarea id="editor2">
-	<figure class="image">
-		<img width="60" src="/tests/_assets/lena.jpg"/>
-		<figcaption>Caption</figcaption>
-	</figure>
-
-	<table border="1" cellspacing="1" cellpadding="1" width="500">
-		<tbody></tbody>
-	</table>
-</textarea>
-
 <script>
 	// Ignore IE8 (#3004).
 	if ( bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) ) {
@@ -47,26 +36,4 @@
 		height: 400,
 		extraAllowedContent: 'td[width];th[width]'
 	} );
-
-	CKEDITOR.replace( 'editor2', {
-		height: 400,
-		extraAllowedContent: 'td[width];th[width]',
-		on: {
-			instanceReady: function() {
-				var tBody = this.editable().findOne( 'tbody' );
-
-				for ( var i = 0; i < 25; i++ ) {
-					var tr = new CKEDITOR.dom.element( 'tr' );
-
-					for ( var j = 0; j < 5; j++ ) {
-						var td = new CKEDITOR.dom.element( 'td' );
-						td.setText( 'foo' );
-						tr.append( td );
-					}
-
-					tBody.append( tr );
-				}
-			}
-		}
-	} )
 </script>

--- a/tests/plugins/widget/manual/dragintotable.md
+++ b/tests/plugins/widget/manual/dragintotable.md
@@ -7,6 +7,8 @@ Play around with dragging widget into and out of table.
 ## Expected
 
 - Widget can be dragged to any table cell.
+- When dragging into empty cell line appears in the middle of cell.
+- When dragging into cell with text line appears at the top or at the bottom of cell.
 
 ## Unexpected
 

--- a/tests/plugins/widget/manual/dragintotable.md
+++ b/tests/plugins/widget/manual/dragintotable.md
@@ -1,6 +1,6 @@
 @bender-tags: widget, bug, 4.11.4, 1648
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, table, undo, sourcearea
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, table, undo, sourcearea, basicstyles
 
 Play around with dragging widget into and out of table.
 

--- a/tests/plugins/widget/manual/dragintotable.md
+++ b/tests/plugins/widget/manual/dragintotable.md
@@ -1,4 +1,4 @@
-@bender-tags: widget, bug, 4.11.4, 1648
+@bender-tags: widget, feature, 4.12.0, 1648
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, table, undo, sourcearea, basicstyles
 

--- a/tests/plugins/widget/manual/dragintotable.md
+++ b/tests/plugins/widget/manual/dragintotable.md
@@ -1,0 +1,14 @@
+@bender-tags: widget, bug, 4.11.4, 1648
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2, table, undo, sourcearea
+
+Play around with dragging widget into and out of table.
+
+## Expected
+
+- Widget can be dragged to any table cell.
+
+## Unexpected
+
+- Widget can't be dragged into table.
+- Horizontal drag marker is wrongly positioned.

--- a/tests/plugins/widget/manual/dragintotable.md
+++ b/tests/plugins/widget/manual/dragintotable.md
@@ -2,8 +2,6 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, table, undo, sourcearea, basicstyles
 
-# For both editors
-
 Play around with dragging widget into and out of table.
 
 ## Expected

--- a/tests/plugins/widget/manual/dragintotable.md
+++ b/tests/plugins/widget/manual/dragintotable.md
@@ -2,6 +2,8 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, image2, table, undo, sourcearea, basicstyles
 
+# For both editors
+
 Play around with dragging widget into and out of table.
 
 ## Expected


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What changes did you make?

To allow fully dragging widgets into tables plenty of things had to be solved.

Widget can be dropped before and after block elements, this had to be changed, so it can be dropped into tables as well.

`lineutils` plugin exposes few classes which has plenty of methods for finding elements, calculating position of places where line can be placed, storing them, sorting them, creating line and placing it.

Unfortunately it was designed to work only only with one dimension `y` axis. As table is two dimensional grid, cells in one row were calculated to have same distance from mouse position, so it was possible to drag only into first cell. See https://github.com/ckeditor/ckeditor-dev/issues/1648#issuecomment-477148369 .

Fixing that within `lineutils` was possible in one of two ways:
- Breaking changes: basically rewrite half of plugin.
- Overload methods resulting in overly complicated code.

I decided to not do any of above. So I added new private function that calculates actual (2d) distance of relations (places where line can be placed) and sorts them based on that distance. This function is now used instead of `CKEDITOR.plugins.lineutils.Locator.sort`.

That fixed case of dropping into empty table cell, but in case of cell with text widget could be dropped only before text, not after. Additionally line would appear in the middle of cell - over the text.

My first idea to workaround this was to create range containing the text, and use `range.getClientRects()`, however all logic to place lines was based on actual elements, just passing rect wasn't enough. I've dropped that idea and decided to place collapsed temporary paragraphs instead. They doesn't take any place so no flickering occurs. Paragraphs are removed on `mouseup`, so they exist only during widget dnd and shouldn't leak.

The last issue was that line didn't appear in cells with inline elements. To not add much extra logic I've allowed creation of fake paragraphs next to inline elements too.

Closes #1648 