### PR TITLE
Fix for: [Edge]: opening dialogs results in error `permission denied`

### DIFF
--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -270,7 +270,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 		// The script must be appended because if placed before the
 		// doctype, IE will go into quirks mode and mess with
 		// the editable, e.g. by changing its default height.
-		if ( CKEDITOR.env.ie )
+		if ( CKEDITOR.env.ie && !CKEDITOR.env.edge )
 			html = html.replace( /(?:^\s*<!DOCTYPE[^>]*?>)|^/i, '$&\n<script data-cke-temp="1">(' + CKEDITOR.tools.fixDomain + ')();</script>' );
 
 		this.$.write( html );

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -689,7 +689,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 					];
 
 					// Support for custom document.domain on IE. (https://dev.ckeditor.com/ticket/10165)
-					html.push( CKEDITOR.env.ie ?
+					html.push( ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ?
 						'(function(){' + encodeURIComponent(
 							'document.open();' +
 							'(' + CKEDITOR.tools.fixDomain + ')();' +
@@ -1442,7 +1442,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 						'</body></html>',
 						'<script>',
 							// Support for custom document.domain in IE.
-							CKEDITOR.env.ie ? '(' + CKEDITOR.tools.fixDomain + ')();' : '',
+						( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ? '(' + CKEDITOR.tools.fixDomain + ')();' : '',
 
 							'window.parent.CKEDITOR.tools.callFunction(' + callNumber + ');',
 							'window.onbeforeunload = function() {window.parent.CKEDITOR.tools.callFunction(' + unloadNumber + ')}',

--- a/plugins/docprops/dialogs/docprops.js
+++ b/plugins/docprops/dialogs/docprops.js
@@ -148,7 +148,7 @@ CKEDITOR.dialog.add( 'docProps', function( editor ) {
 	var previewSrc = 'javascript:' + // jshint ignore:line
 		'void((function(){' + encodeURIComponent(
 			'document.open();' +
-			( CKEDITOR.env.ie ? '(' + CKEDITOR.tools.fixDomain + ')();' : '' ) +
+			( ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ? '(' + CKEDITOR.tools.fixDomain + ')();' : '' ) +
 			'document.write( \'<html style="background-color: #ffffff; height: 100%"><head></head><body style="width: 100%; height: 100%; margin: 0px">' + lang.previewHtml + '</body></html>\' );' +
 			'document.close();'
 		) + '})())';

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -165,7 +165,7 @@
 		// In Firefox src must exist and be different than about:blank to emit load event.
 		CKEDITOR.env.gecko ? 'javascript:true' : // jshint ignore:line
 		// Support for custom document.domain in IE.
-		CKEDITOR.env.ie ? 'javascript:' + // jshint ignore:line
+		( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ? 'javascript:' + // jshint ignore:line
 						'void((function(){' + encodeURIComponent(
 							'document.open();' +
 							'(' + CKEDITOR.tools.fixDomain + ')();' +

--- a/plugins/preview/plugin.js
+++ b/plugins/preview/plugin.js
@@ -64,7 +64,7 @@
 			var sOpenUrl = '',
 				ieLocation;
 
-			if ( CKEDITOR.env.ie ) {
+			if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
 				window._cke_htmlToLoad = eventData.dataValue;
 				ieLocation = 'javascript:void( (function(){' + // jshint ignore:line
 					'document.open();' +

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -23,7 +23,7 @@
 			editor.addMode( 'wysiwyg', function( callback ) {
 				var src = 'document.open();' +
 					// In IE, the document domain must be set any time we call document.open().
-					( CKEDITOR.env.ie ? '(' + CKEDITOR.tools.fixDomain + ')();' : '' ) +
+					( ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) ? '(' + CKEDITOR.tools.fixDomain + ')();' : '' ) +
 					'document.close();';
 
 				// With IE, the custom domain has to be taken care at first,


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

**Tests not included, change is straight forward. It removes call of method which shouldn't be called on Edge anyway.**

## What changes did you make?

See comment: https://github.com/ckeditor/ckeditor-dev/issues/3029#issuecomment-479885050

Closes #3029 

**Edit:** I need to check this solution again, it might cause some issues.