### PR TITLE
Bugfix: when use mention, for the typing korean for the text search on the IE 11

### DIFF
--- a/plugins/textwatcher/plugin.js
+++ b/plugins/textwatcher/plugin.js
@@ -249,6 +249,9 @@
 			}
 
 			var selectionRange = sel.getRanges()[ 0 ];
+			// when use mention, if typing korean for the text search on the IE 11, need this line.
+			selectionRange.collapse();
+
 			if ( !selectionRange ) {
 				return;
 			}


### PR DESCRIPTION
IE 11 issue

## What is the purpose of this pull request?
Bug Fix


## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What changes did you make?
Bugfix: when use mention, for the typing korean for the text search on the IE 11

*Give an overview…*
