### PR TITLE
Enable widget clipboard manipulation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ New Features:
 * [#3359](https://github.com/ckeditor/ckeditor-dev/issues/3359): Improved [dialog](https://ckeditor.com/cke4/addon/dialog) positioning and behavior when the browser window is resized, the dialog is resized or moved.
 * [#2227](https://github.com/ckeditor/ckeditor-dev/issues/2227): Added the [`config.linkDefaultProtocol`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-linkDefaultProtocol) configuration option that allows setting the default URL protocol for the [Link](https://ckeditor.com/cke4/addon/link) plugin dialog.
 * [#3240](https://github.com/ckeditor/ckeditor-dev/issues/3240): Extended the [`CKEDITOR.plugins.widget#mask`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html#property-mask) property to allow masking only the specified part of a [widget](https://ckeditor.com/cke4/addon/widget).
+* [#3138](https://github.com/ckeditor/ckeditor-dev/issues/3138): Added possibility to use [`widgetDefinition.getClipboardHtml()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html#method-getClipboardHtml) method to customize [Widget](https://ckeditor.com/cke4/addon/widget) HTML during copy, cut and drag operations.
 
 Fixed Issues:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3419,7 +3419,7 @@
 				widget.edit();
 				// CTRL+C or CTRL+X.
 			} else if ( keyCode == CKEDITOR.CTRL + 67 || keyCode == CKEDITOR.CTRL + 88 ) {
-				// copyWidgets( widget.editor, keyCode == CKEDITOR.CTRL + 88 );
+				copyWidgets( widget.editor, keyCode == CKEDITOR.CTRL + 88 );
 				return; // Do not preventDefault.
 				// Pass chosen keystrokes to other plugins or default fake sel handlers.
 				// Pass all CTRL/ALT keystrokes.

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -859,6 +859,23 @@
 
 		// Extend this widget with widgetDef-specific methods and properties.
 		CKEDITOR.tools.extend( this, widgetDef, {
+
+			/**
+			 * Returns HTML of the widget. Can be overridden to customize HTML copied to the clipboard
+			 * during copy&cut and drag&drop events.
+			 *
+			 * @since 4.12.0
+			 * @returns {String} Widget HTML.
+			 */
+			getClipboardHtml: function() {
+				var range = this.editor.createRange();
+
+				range.setStartBefore( this.wrapper );
+				range.setEndAfter( this.wrapper );
+
+				return this.editor.editable().getHtmlFromRange( range ).getHtml();
+			},
+
 			/**
 			 * The editor instance.
 			 *
@@ -2592,7 +2609,7 @@
 			delete CKEDITOR.plugins.clipboard.dragStartContainerChildCount;
 			delete CKEDITOR.plugins.clipboard.dragEndContainerChildCount;
 
-			evt.data.dataTransfer.setData( 'text/html', editor.editable().getHtmlFromRange( dragRange ).getHtml() );
+			evt.data.dataTransfer.setData( 'text/html', sourceWidget.getClipboardHtml() );
 			editor.widgets.destroy( sourceWidget, true );
 		} );
 
@@ -3228,13 +3245,9 @@
 
 		copybin.setStyle( editor.config.contentsLangDirection == 'ltr' ? 'left' : 'right', '-5000px' );
 
-		var range = editor.createRange();
-		range.setStartBefore( widget.wrapper );
-		range.setEndAfter( widget.wrapper );
-
 		copybin.setHtml(
 			'<span data-cke-copybin-start="1">\u200b</span>' +
-			editor.editable().getHtmlFromRange( range ).getHtml() +
+			widget.getClipboardHtml() +
 			'<span data-cke-copybin-end="1">\u200b</span>' );
 
 		// Save snapshot with the current state.
@@ -3257,7 +3270,7 @@
 		// Once the clone of the widget is inside of copybin, select
 		// the entire contents. This selection will be copied by the
 		// native browser's clipboard system.
-		range = editor.createRange();
+		var range = editor.createRange();
 		range.selectNodeContents( copybin );
 		range.select();
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3221,13 +3221,20 @@
 	function copyWidgets( editor, isCut ) {
 		var doc = editor.document,
 			focused = editor.widgets.focused,
-			isEdge16 = CKEDITOR.env.edge && CKEDITOR.env.version >= 16;
+			isEdge16 = CKEDITOR.env.edge && CKEDITOR.env.version >= 16,
+			bookmarks;
 
 		// We're still handling previous copy/cut.
 		// When keystroke is used to copy/cut this will also prevent
 		// conflict with copySingleWidget called again for native copy/cut event.
 		if ( doc.getById( 'cke_copybin' ) ) {
 			return;
+		}
+
+		// When more than one widget is selected, we must save selection to restore it
+		// after destroying copybin (#3138).
+		if ( !focused && !isCut ) {
+			bookmarks = editor.getSelection().createBookmarks( true );
 		}
 
 		// [IE] Use span for copybin and its container to avoid bug with expanding
@@ -3293,6 +3300,10 @@
 			// [IE] Focus widget before removing copybin to avoid scroll jump.
 			if ( !isCut && focused ) {
 				focused.focus();
+			}
+
+			if ( bookmarks ) {
+				editor.getSelection().selectBookmarks( bookmarks );
 			}
 
 			copybinContainer.remove();

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -4580,6 +4580,9 @@
  *
  * If not set, current widget HTML will be used instead.
  *
+ * Note: this method will overwrite HTML for the whole widget, **including**
+ * any nested widgets.
+ *
  * @method getClipboardHtml
  * @since 4.13.0
  * @returns {String} Widget HTML.

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3268,9 +3268,6 @@
 			getClipboardHtml() +
 			'<span data-cke-copybin-end="1">\u200b</span>' );
 
-		// Save snapshot with the current state.
-		editor.fire( 'saveSnapshot' );
-
 		// Ignore copybin.
 		editor.fire( 'lockSnapshot' );
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2955,12 +2955,19 @@
 				return;
 
 			var toBeDowncasted = downcastingSessions[ evt.data.downcastingSessionId ],
-				toBe, widget, widgetElement, retElement, editableElement, e;
+				toBe, widget, widgetElement, retElement, editableElement, e, parserFragment;
 
 			while ( ( toBe = toBeDowncasted.shift() ) ) {
 				widget = toBe.widget;
 				widgetElement = toBe.element;
 				retElement = widget._.downcastFn && widget._.downcastFn.call( widget, widgetElement );
+
+				// In case of copying widgets, we replace the widget with clipboard data (#3138).
+				if ( evt.data.widgetsCopy && widget.getClipboardHtml ) {
+					parserFragment = CKEDITOR.htmlParser.fragment.fromHtml( widget.getClipboardHtml() );
+
+					retElement = parserFragment.children[ 0 ];
+				}
 
 				// Replace nested editables' content with their output data.
 				for ( e in toBe.editables ) {
@@ -3308,6 +3315,10 @@
 			if ( editor.widgets.focused ) {
 				return editor.widgets.focused.getClipboardHtml();
 			}
+
+			editor.once( 'toDataFormat', function( evt ) {
+				evt.data.widgetsCopy = true;
+			}, null, null, -1 );
 
 			return editor.dataProcessor.toDataFormat( selectedHtml );
 		}

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3233,7 +3233,7 @@
 
 		// When more than one widget is selected, we must save selection to restore it
 		// after destroying copybin (#3138).
-		if ( !focused && !isCut ) {
+		if ( !focused ) {
 			bookmarks = editor.getSelection().createBookmarks( true );
 		}
 
@@ -3314,9 +3314,8 @@
 			editor.fire( 'unlockSnapshot' );
 
 			// Prevent cutting in read-only editor (#1570).
-			if ( isCut && focused && !editor.readOnly ) {
-				editor.widgets.del( focused );
-				editor.fire( 'saveSnapshot' );
+			if ( isCut && !editor.readOnly ) {
+				handleCut();
 			}
 		}, 100 ); // Use 100ms, so Chrome (@Mac) will be able to grab the content.
 
@@ -3332,6 +3331,16 @@
 			}, null, null, -1 );
 
 			return editor.dataProcessor.toDataFormat( selectedHtml );
+		}
+
+		function handleCut() {
+			if ( focused ) {
+				editor.widgets.del( focused );
+			} else {
+				editor.extractSelectedHtml();
+			}
+
+			editor.fire( 'saveSnapshot' );
 		}
 	}
 
@@ -3410,7 +3419,7 @@
 				widget.edit();
 				// CTRL+C or CTRL+X.
 			} else if ( keyCode == CKEDITOR.CTRL + 67 || keyCode == CKEDITOR.CTRL + 88 ) {
-				copyWidgets( widget.editor, keyCode == CKEDITOR.CTRL + 88 );
+				// copyWidgets( widget.editor, keyCode == CKEDITOR.CTRL + 88 );
 				return; // Do not preventDefault.
 				// Pass chosen keystrokes to other plugins or default fake sel handlers.
 				// Pass all CTRL/ALT keystrokes.

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2800,8 +2800,11 @@
 		} );
 
 		function eventListener( evt ) {
-			if ( widgetsRepo.focused )
-				copySingleWidget( widgetsRepo.focused, evt.name == 'cut' );
+			if ( widgetsRepo.selected.length < 0 ) {
+				return;
+			}
+
+			copyWidgets( editor, evt.name === 'cut' );
 		}
 	}
 
@@ -3208,9 +3211,9 @@
 		evt.cancel();
 	}
 
-	function copySingleWidget( widget, isCut ) {
-		var editor = widget.editor,
-			doc = editor.document,
+	function copyWidgets( editor, isCut ) {
+		var doc = editor.document,
+			focused = editor.widgets.focused,
 			isEdge16 = CKEDITOR.env.edge && CKEDITOR.env.version >= 16;
 
 		// We're still handling previous copy/cut.
@@ -3248,7 +3251,7 @@
 
 		copybin.setHtml(
 			'<span data-cke-copybin-start="1">\u200b</span>' +
-			widget.getClipboardHtml() +
+			getClipboardHtml() +
 			'<span data-cke-copybin-end="1">\u200b</span>' );
 
 		// Save snapshot with the current state.
@@ -3261,7 +3264,7 @@
 		editor.editable().append( copybinContainer );
 
 		var listener1 = editor.on( 'selectionChange', cancel, null, null, 0 ),
-			listener2 = widget.repository.on( 'checkSelection', cancel, null, null, 0 );
+			listener2 = editor.widgets.on( 'checkSelection', cancel, null, null, 0 );
 
 		if ( needsScrollHack ) {
 			var docElement = doc.getDocumentElement().$,
@@ -3281,8 +3284,8 @@
 
 		setTimeout( function() {
 			// [IE] Focus widget before removing copybin to avoid scroll jump.
-			if ( !isCut ) {
-				widget.focus();
+			if ( !isCut && focused ) {
+				focused.focus();
 			}
 
 			copybinContainer.remove();
@@ -3293,11 +3296,21 @@
 			editor.fire( 'unlockSnapshot' );
 
 			// Prevent cutting in read-only editor (#1570).
-			if ( isCut && !editor.readOnly ) {
-				widget.repository.del( widget );
+			if ( isCut && focused && !editor.readOnly ) {
+				editor.widgets.del( focused );
 				editor.fire( 'saveSnapshot' );
 			}
 		}, 100 ); // Use 100ms, so Chrome (@Mac) will be able to grab the content.
+
+		function getClipboardHtml() {
+			var selectedHtml = editor.getSelectedHtml( true );
+
+			if ( editor.widgets.focused ) {
+				return editor.widgets.focused.getClipboardHtml();
+			}
+
+			return editor.dataProcessor.toDataFormat( selectedHtml );
+		}
 	}
 
 	// Extracts classes array from style instance.
@@ -3373,15 +3386,13 @@
 			// ENTER.
 			if ( keyCode == 13 ) {
 				widget.edit();
-			}
-			// CTRL+C or CTRL+X.
-			else if ( keyCode == CKEDITOR.CTRL + 67 || keyCode == CKEDITOR.CTRL + 88 ) {
-				copySingleWidget( widget, keyCode == CKEDITOR.CTRL + 88 );
+				// CTRL+C or CTRL+X.
+			} else if ( keyCode == CKEDITOR.CTRL + 67 || keyCode == CKEDITOR.CTRL + 88 ) {
+				copyWidgets( widget.editor, keyCode == CKEDITOR.CTRL + 88 );
 				return; // Do not preventDefault.
-			}
-			// Pass chosen keystrokes to other plugins or default fake sel handlers.
-			// Pass all CTRL/ALT keystrokes.
-			else if ( keyCode in keystrokesNotBlockedByWidget ||
+				// Pass chosen keystrokes to other plugins or default fake sel handlers.
+				// Pass all CTRL/ALT keystrokes.
+			} else if ( keyCode in keystrokesNotBlockedByWidget ||
 				( CKEDITOR.CTRL & keyCode ) ||
 				( CKEDITOR.ALT & keyCode ) ) {
 				return;

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1266,8 +1266,9 @@
 		},
 
 		/**
-		 * Returns HTML of the widget. Can be overridden to customize HTML copied to the clipboard
-		 * during copy&cut and drag&drop events.
+		 * Returns HTML of the widget. Can be overridden by
+		 * {@link CKEDITOR.plugins.widget.definition#getClipboardHtml widgetDefinition.getClipboardHtml}
+		 * to customize HTML copied to the clipboard during copy, cut and drop events.
 		 *
 		 * @since 4.12.0
 		 * @returns {String} Widget HTML.
@@ -4463,8 +4464,19 @@
  */
 
 /**
- * Whether the widget should be draggable. Defaults to `true`.
- * If set to `false`, the drag handler will not be displayed when hovering the widget.
+ * Customizes widget HTML copied to the clipboard
+ * during copy, cut and drop operations.
+ *
+ * If not set, current widget HTML will be used instead.
+ *
+ * @method getClipboardHtml
+ * @since 4.13.0
+ * @returns {String} Widget HTML.
+ */
+
+/**
+ * Whether widget should be draggable. Defaults to `true`.
+ * If set to `false` drag handler will not be displayed when hovering widget.
  *
  * @property {Boolean} draggable
  */

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2535,7 +2535,6 @@
 	// * FF tends to copy all blocks up to the copybin container.
 	// * IE tends to copy only the copybin, without its container.
 	// * We use spans on IE and blockless editors, but divs in other cases.
-	// We are really sorry for summoning Zalgo…
 	var pasteReplaceRegex = new RegExp(
 		'^' +
 		'(?:<(?:div|span)(?: data-cke-temp="1")?(?: id="cke_copybin")?(?: data-cke-temp="1")?>)?' +

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -859,23 +859,6 @@
 
 		// Extend this widget with widgetDef-specific methods and properties.
 		CKEDITOR.tools.extend( this, widgetDef, {
-
-			/**
-			 * Returns HTML of the widget. Can be overridden to customize HTML copied to the clipboard
-			 * during copy&cut and drag&drop events.
-			 *
-			 * @since 4.12.0
-			 * @returns {String} Widget HTML.
-			 */
-			getClipboardHtml: function() {
-				var range = this.editor.createRange();
-
-				range.setStartBefore( this.wrapper );
-				range.setEndAfter( this.wrapper );
-
-				return this.editor.editable().getHtmlFromRange( range ).getHtml();
-			},
-
 			/**
 			 * The editor instance.
 			 *
@@ -1280,6 +1263,22 @@
 		 */
 		getClasses: function() {
 			return this.repository.parseElementClasses( this.element.getAttribute( 'class' ) );
+		},
+
+		/**
+		 * Returns HTML of the widget. Can be overridden to customize HTML copied to the clipboard
+		 * during copy&cut and drag&drop events.
+		 *
+		 * @since 4.12.0
+		 * @returns {String} Widget HTML.
+		 */
+		getClipboardHtml: function() {
+			var range = this.editor.createRange();
+
+			range.setStartBefore( this.wrapper );
+			range.setEndAfter( this.wrapper );
+
+			return this.editor.editable().getHtmlFromRange( range ).getHtml();
 		},
 
 		/**

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3351,6 +3351,7 @@
 
 	function copyWidgets( editor, isCut ) {
 		var focused = editor.widgets.focused,
+			isWholeSelection,
 			copyBin,
 			bookmarks;
 
@@ -3370,6 +3371,10 @@
 				if ( bookmarks ) {
 					editor.getSelection().selectBookmarks( bookmarks );
 				}
+
+				if ( isWholeSelection ) {
+					CKEDITOR.plugins.widgetselection.addFillers( editor.editable() );
+				}
 			},
 
 			afterDestroy: function() {
@@ -3381,9 +3386,11 @@
 		} );
 
 		// When more than one widget is selected, we must save selection to restore it
-		// after destroying copybin (#3138).
+		// after destroying copybin. Additionally we have to work around issue with selecting all in
+		// Blink and WebKit, when widgets are at the beginning and at the end of the content (#3138).
 		if ( !focused ) {
-			bookmarks = editor.getSelection().createBookmarks( true );
+			isWholeSelection = CKEDITOR.env.webkit && CKEDITOR.plugins.widgetselection.isWholeContentSelected( editor.editable() );
+			bookmarks = !isWholeSelection && editor.getSelection().createBookmarks( true );
 		}
 
 		copyBin.handle( getClipboardHtml() );

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2800,7 +2800,7 @@
 		} );
 
 		function eventListener( evt ) {
-			if ( widgetsRepo.selected.length < 0 ) {
+			if ( widgetsRepo.selected.length < 1 ) {
 				return;
 			}
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1270,7 +1270,7 @@
 		 * {@link CKEDITOR.plugins.widget.definition#getClipboardHtml widgetDefinition.getClipboardHtml}
 		 * to customize HTML copied to the clipboard during copy, cut and drop events.
 		 *
-		 * @since 4.12.0
+		 * @since 4.13.0
 		 * @returns {String} Widget HTML.
 		 */
 		getClipboardHtml: function() {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3282,7 +3282,10 @@
 					docElement = editor.document.getDocumentElement().$,
 					range = editor.createRange(),
 					that = this,
-					waitForContent = window.requestAnimationFrame ? requestAnimationFrame : setTimeout,
+					// We need 100ms timeout for Chrome on macOS so it will be able to grab the content on cut.
+					isMacWebkit = CKEDITOR.env.mac && CKEDITOR.env.webkit,
+					copyTimeout = isMacWebkit ? 100 : 0,
+					waitForContent = window.requestAnimationFrame && !isMacWebkit ? requestAnimationFrame : setTimeout,
 					listener1,
 					listener2,
 					scrollTop;
@@ -3294,6 +3297,7 @@
 
 				// Ignore copybin.
 				editor.fire( 'lockSnapshot' );
+
 
 				container.append( copyBin );
 				editor.editable().append( container );
@@ -3333,7 +3337,7 @@
 						}
 
 						resolve();
-					} );
+					}, copyTimeout );
 				} );
 			}
 		},

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2535,6 +2535,7 @@
 	// * FF tends to copy all blocks up to the copybin container.
 	// * IE tends to copy only the copybin, without its container.
 	// * We use spans on IE and blockless editors, but divs in other cases.
+	// We are really sorry for summoning Zalgo…
 	var pasteReplaceRegex = new RegExp(
 		'^' +
 		'(?:<(?:div|span)(?: data-cke-temp="1")?(?: id="cke_copybin")?(?: data-cke-temp="1")?>)?' +

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3282,6 +3282,7 @@
 					docElement = editor.document.getDocumentElement().$,
 					range = editor.createRange(),
 					that = this,
+					waitForContent = window.requestAnimationFrame ? requestAnimationFrame : setTimeout,
 					listener1,
 					listener2,
 					scrollTop;
@@ -3315,7 +3316,7 @@
 				}
 
 				return new CKEDITOR.tools.promise( function( resolve ) {
-					setTimeout( function() {
+					waitForContent( function() {
 						if ( that.beforeDestroy ) {
 							that.beforeDestroy();
 						}
@@ -3332,7 +3333,7 @@
 						}
 
 						resolve();
-					}, 100 ); // Use 100ms, so Chrome (@Mac) will be able to grab the content.
+					} );
 				} );
 			}
 		},

--- a/tests/plugins/widget/manual/clipboardhtml.html
+++ b/tests/plugins/widget/manual/clipboardhtml.html
@@ -4,6 +4,26 @@
 	<p>Consectetur dolores voluptatibus illo ipsam eveniet?</p>
 	<div data-widget="customwidget">Widget</div>
 	<p>Lorem ipsum dolor sit amet.</p>
+	<div data-widget="customnestedwidget">
+		<p>Widget</p>
+		<div class="ned">
+			<div data-widget="customwidget">Nested widget</div>
+		</div>
+	</div>
+	<p>Many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many</p>
+	<p>lines to test scrollhack for IE.</p>
 </div>
 
 <script>
@@ -24,11 +44,24 @@
 				button: 'Add widget',
 				template: '<div>Widget</div>',
 
-				getClipboardHtml: function() {
-					counter++;
-					return '<div data-widget="customwidget">Widget copied ' + counter + ' times!</div>';
+				getClipboardHtml: getClipboardHtml
+			} );
+
+			editor.widgets.add( 'customnestedwidget', {
+				button: 'Add nested widget',
+				template: '<div><p>Widget</p><div class="ned"><div data-widget="customwidget">Nested widget</div></div></div>',
+				getClipboardHtml: getClipboardHtml,
+
+				editables: {
+					ned: '.ned'
 				}
 			} );
+
+			function getClipboardHtml() {
+				counter++;
+
+				return '<div data-widget="' + this.name + '">Widget copied ' + counter + ' times!</div>';
+			}
 		}
 	} );
 </script>

--- a/tests/plugins/widget/manual/clipboardhtml.html
+++ b/tests/plugins/widget/manual/clipboardhtml.html
@@ -2,6 +2,8 @@
 	<p>Adipisicing corporis rem repellendus vel mollitia vero?</p>
 	<div data-widget="customwidget">Widget</div>
 	<p>Consectetur dolores voluptatibus illo ipsam eveniet?</p>
+	<div data-widget="customwidget">Widget</div>
+	<p>Lorem ipsum dolor sit amet.</p>
 </div>
 
 <script>

--- a/tests/plugins/widget/manual/clipboardhtml.html
+++ b/tests/plugins/widget/manual/clipboardhtml.html
@@ -1,0 +1,32 @@
+<div id="editor">
+	<p>Adipisicing corporis rem repellendus vel mollitia vero?</p>
+	<div data-widget="customwidget">Widget</div>
+	<p>Consectetur dolores voluptatibus illo ipsam eveniet?</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'span',
+		extraPlugins: 'customwidget',
+		allowedContent: true
+	} );
+
+	CKEDITOR.plugins.add( 'customwidget', {
+		requires: 'widget',
+		allowedContent: 'div(copied)',
+
+		init: function ( editor )	{
+			var counter = 0;
+
+			editor.widgets.add( 'customwidget', {
+				button: 'Add widget',
+				template: '<div>Widget</div>',
+
+				getClipboardHtml: function() {
+					counter++;
+					return '<div data-widget="customwidget">Widget copied ' + counter + ' times!</div>';
+				}
+			} );
+		}
+	} );
+</script>

--- a/tests/plugins/widget/manual/clipboardhtml.md
+++ b/tests/plugins/widget/manual/clipboardhtml.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.12.0, feature, 3138
+@bender-tags: 4.13.0, feature, 3138
 @bender-ui: collapsed
 @bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
 
@@ -14,7 +14,7 @@
 
 	## Expected
 
-	After each operation manipulated widget's content changes into `Widget has beed copied X times!` where `X` changes after every operation.
+	After each operation manipulated widget's content changes into `Widget copied X times!` where `X` changes after every operation.
 
 	## Unexpected
 
@@ -28,3 +28,7 @@
 	## Unexpected
 
 	Operations are broken into several steps.
+
+### Additional check for IE
+
+Check if selection is still visible on screen after copying and cutting.

--- a/tests/plugins/widget/manual/clipboardhtml.md
+++ b/tests/plugins/widget/manual/clipboardhtml.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.12.0, feature, 3138
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, wysiwygarea, toolbar
+
+**NOTE:** It's expected that if you paste the same widget multiple times, message won't change. Counter changes only during `copy`, `cut` and `drop` operations.
+
+Manipulate the widget by:
+
+* copying and pasting
+* cutting and pasting
+* dragging and droping
+
+## Expected
+
+After each operation widget content changes into `Widget has beed copied X times!` where `X` changes after every operation. 
+
+## Unexpected
+
+Widget message doesn't change.

--- a/tests/plugins/widget/manual/clipboardhtml.md
+++ b/tests/plugins/widget/manual/clipboardhtml.md
@@ -1,19 +1,30 @@
 @bender-tags: 4.12.0, feature, 3138
 @bender-ui: collapsed
-@bender-ckeditor-plugins: widget, wysiwygarea, toolbar
+@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
 
-**NOTE:** It's expected that if you paste the same widget multiple times, message won't change. Counter changes only during `copy`, `cut` and `drop` operations.
+**NOTE:** It's expected that if you paste the same copied content multiple times, widget copy counter won't change. Counter changes only during `copy`, `cut` and `drop` operations. Please also note that the counter is the same for every widget instance.
 
-Manipulate the widget by:
+1. Manipulate the content by:
 
-* copying and pasting
-* cutting and pasting
-* dragging and droping
+	* copying and pasting
+	* cutting and pasting
+	* dragging and droping
 
-## Expected
+	both with one widget and content containing more than one widget.
 
-After each operation widget content changes into `Widget has beed copied X times!` where `X` changes after every operation. 
+	## Expected
 
-## Unexpected
+	After each operation manipulated widget's content changes into `Widget has beed copied X times!` where `X` changes after every operation.
 
-Widget message doesn't change.
+	## Unexpected
+
+	Widget message doesn't change.
+2. Check if undo is working correctly after performing operations (you can use the button above the editor to reset undo stack)
+
+	## Expected
+
+	Every operation is atomic, it does not create unnecessary, intermediate steps.
+
+	## Unexpected
+
+	Operations are broken into several steps.

--- a/tests/plugins/widget/manual/clipboardhtml.md
+++ b/tests/plugins/widget/manual/clipboardhtml.md
@@ -6,9 +6,11 @@
 
 1. Manipulate the content by:
 
-	* copying and pasting
-	* cutting and pasting
-	* dragging and droping
+	copying and pasting,
+
+	cutting and pasting,
+
+	dragging and droping,
 
 	both with one widget and content containing more than one widget.
 

--- a/tests/plugins/widget/manual/clipboardhtmlselectall.html
+++ b/tests/plugins/widget/manual/clipboardhtmlselectall.html
@@ -1,0 +1,31 @@
+<div id="editor">
+	<div data-widget="customwidget">Widget</div>
+	<p>Adipisicing corporis rem repellendus vel mollitia vero? Consectetur dolores voluptatibus illo ipsam eveniet? Lorem ipsum dolor sit amet.</p>
+	<div data-widget="customwidget">Widget</div>
+</div>
+
+<script>
+	if ( bender.env.mobile || !CKEDITOR.env.webkit ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'span',
+		extraPlugins: 'customwidget',
+		allowedContent: true
+	} );
+
+	CKEDITOR.plugins.add( 'customwidget', {
+		requires: 'widget',
+		allowedContent: 'div',
+
+		init: function ( editor )	{
+			var counter = 0;
+
+			editor.widgets.add( 'customwidget', {
+				button: 'Add widget',
+				template: '<div>Widget</div>'
+			} );
+		}
+	} );
+</script>

--- a/tests/plugins/widget/manual/clipboardhtmlselectall.md
+++ b/tests/plugins/widget/manual/clipboardhtmlselectall.md
@@ -1,0 +1,21 @@
+@bender-tags: 4.13.0, feature, 3138
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
+
+1. Open console.
+2. Select all.
+3. Copy
+
+## Expected
+
+* Content is copied correctly, there are no errors inside the console.
+* Selection is correctly restored after copying.
+
+## Unexpected
+
+* The error is thrown inside the console:
+
+	```
+	Uncaught TypeError: Cannot read property 'getParent' of null
+	```
+* Selection is not restored after copying.

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -818,7 +818,7 @@
 		},
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for copying': function() {
+		'test shadowed clipboard HTML is used for copying (single widget)': function() {
 			var editor = this.editor;
 
 			this.editorBot.setData( '<div id="w1" data-widget="test3">test3</div>', function() {
@@ -838,7 +838,7 @@
 		},
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for cutting': function() {
+		'test shadowed clipboard HTML is used for cutting (single widget)': function() {
 			var editor = this.editor;
 
 			this.editorBot.setData( '<div id="w1" data-widget="test3">test3</div>', function() {
@@ -853,6 +853,60 @@
 
 				wait( function() {
 					assert.isMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+				}, 150 );
+			} );
+		},
+
+		// (#3138)
+		'test shadowed clipboard HTML is used for copying (multiple widget)': function() {
+			var editor = this.editor;
+
+			this.editorBot.setData( '<p>Lorem</p><div id="w1" data-widget="test3">test3</div><div id="w2" data-widget="test3">test3</div><p>Ipsum</p>', function() {
+				var range = editor.createRange(),
+					editable = editor.editable(),
+					startNode = editable.findOne( '#w1' ),
+					endNode = editable.findOne( '#w2' ),
+					clipboardHtml;
+
+				range.setStartBefore( startNode );
+				range.setEndAfter( endNode );
+				range.select();
+
+				editor.editable().once( 'copy', function() {
+					clipboardHtml = editor.getSelectedHtml( true );
+				} );
+
+				editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+
+				wait( function() {
+					assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
+				}, 150 );
+			} );
+		},
+
+		// (#3138)
+		'test shadowed clipboard HTML is used for cutting (multiple widget)': function() {
+			var editor = this.editor;
+
+			this.editorBot.setData( '<p>Lorem</p><div id="w1" data-widget="test3">test3</div><div id="w2" data-widget="test3">test3</div><p>Ipsum</p>', function() {
+				var range = editor.createRange(),
+					editable = editor.editable(),
+					startNode = editable.findOne( '#w1' ),
+					endNode = editable.findOne( '#w2' ),
+					clipboardHtml;
+
+				range.setStartBefore( startNode );
+				range.setEndAfter( endNode );
+				range.select();
+
+				editor.editable().once( 'cut', function() {
+					clipboardHtml = editor.getSelectedHtml( true );
+				} );
+
+				editor.editable().fire( 'cut', new CKEDITOR.dom.event( {} ) );
+
+				wait( function() {
+					assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
 				}, 150 );
 			} );
 		},

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -830,222 +830,180 @@
 		},
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for copying (single widget)': function() {
-			var editor = this.editor;
+		'test shadowed clipboard HTML is used for copying (single widget)': createCopyCutTest( {
+			event: 'copy',
+			html: '<div id="w1" data-widget="test3">test3</div>',
 
-			this.editorBot.setData( '<div id="w1" data-widget="test3">test3</div>', function() {
+			init: function( editor ) {
 				var widget = getWidgetById( editor, 'w1' );
 
 				widget.focus();
+			},
 
-				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 67 } ) ); // CTRL + C
-
-				// At this point copybin is selected.
-				var clipboardHtml = editor.getSelectedHtml( true );
-
-				wait( function() {
-					assert.isMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
-				}, 150 );
-			} );
-		},
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+			}
+		} ),
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for cutting (single widget)': function() {
-			var editor = this.editor;
+		'test shadowed clipboard HTML is used for cutting (single widget)': createCopyCutTest( {
+			event: 'cut',
+			html: '<div id="w1" data-widget="test3">test3</div>',
 
-			this.editorBot.setData( '<div id="w1" data-widget="test3">test3</div>', function() {
+			init: function( editor ) {
 				var widget = getWidgetById( editor, 'w1' );
 
 				widget.focus();
+			},
 
-				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 88 } ) ); // CTRL + X
-
-				// At this point copybin is selected.
-				var clipboardHtml = editor.getSelectedHtml( true );
-
-				wait( function() {
-					assert.isMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
-				}, 150 );
-			} );
-		},
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+			}
+		} ),
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for copying (multiple widget)': function() {
-			var editor = this.editor;
+		'test shadowed clipboard HTML is used for copying (multiple widgets)': createCopyCutTest( {
+			event: 'copy',
+			html: '<p>Lorem</p>' +
+				'<div id="w1" data-widget="test3">test3</div>' +
+				'<div id="w2" data-widget="test3">test3</div>' +
+				'<p>Ipsum</p>',
 
-			this.editorBot.setData( '<p>Lorem</p><div id="w1" data-widget="test3">test3</div><div id="w2" data-widget="test3">test3</div><p>Ipsum</p>', function() {
+			init: function( editor ) {
 				var range = editor.createRange(),
 					editable = editor.editable(),
 					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' ),
-					clipboardHtml;
+					endNode = editable.findOne( '#w2' );
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );
 				range.select();
+			},
 
-				editor.editable().once( 'copy', function() {
-					clipboardHtml = editor.getSelectedHtml( true );
-				} );
-
-				editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
-
-				wait( function() {
-					assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
-				}, 150 );
-			} );
-		},
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
+			}
+		} ),
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for cutting (multiple widget)': function() {
-			var editor = this.editor;
+		'test shadowed clipboard HTML is used for cutting (multiple widgets)': createCopyCutTest( {
+			event: 'cut',
+			html: '<p>Lorem</p>' +
+				'<div id="w1" data-widget="test3">test3</div>' +
+				'<div id="w2" data-widget="test3">test3</div>' +
+				'<p>Ipsum</p>',
 
-			this.editorBot.setData( '<p>Lorem</p><div id="w1" data-widget="test3">test3</div><div id="w2" data-widget="test3">test3</div><p>Ipsum</p>', function() {
+			init: function( editor ) {
 				var range = editor.createRange(),
 					editable = editor.editable(),
 					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' ),
-					clipboardHtml;
+					endNode = editable.findOne( '#w2' );
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );
 				range.select();
+			},
 
-				editor.editable().once( 'cut', function() {
-					clipboardHtml = editor.getSelectedHtml( true );
-				} );
-
-				editor.editable().fire( 'cut', new CKEDITOR.dom.event( {} ) );
-
-				wait( function() {
-					assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
-				}, 150 );
-			} );
-		},
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
+			}
+		} ),
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for copying (single nested widget)': function() {
-			var editor = this.editor,
-				html = '<div data-widget="test4" id="w1">' +
-					'<div class="ned">' +
-						'<div id="w2" data-widget="test3">test3</div>' +
-					'</div>' +
-				'</div>';
-
-			this.editorBot.setData( html, function() {
-				var widget = getWidgetById( editor, 'w1' ),
-					clipboardHtml;
-
-				widget.focus();
-
-				editor.editable().once( 'copy', function() {
-					clipboardHtml = editor.getSelectedHtml( true );
-				} );
-
-				editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
-
-				wait( function() {
-					assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/, clipboardHtml );
-					assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
-				}, 150 );
-			} );
-		},
-
-		// (#3138)
-		'test shadowed clipboard HTML is used for cutting (single nested widget)': function() {
-			var editor = this.editor,
-				html = '<div data-widget="test4" id="w1">' +
-					'<div class="ned">' +
-						'<div id="w2" data-widget="test3">test3</div>' +
-					'</div>' +
-				'</div>';
-
-			this.editorBot.setData( html, function() {
-				var widget = getWidgetById( editor, 'w1' ),
-					clipboardHtml;
-
-				widget.focus();
-
-				editor.editable().once( 'cut', function() {
-					clipboardHtml = editor.getSelectedHtml( true );
-				} );
-
-				editor.editable().fire( 'cut', new CKEDITOR.dom.event( {} ) );
-
-				wait( function() {
-					assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/, clipboardHtml );
-					assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
-				}, 150 );
-			} );
-		},
-
-		// (#3138)
-		'test shadowed clipboard HTML is used for copying (multiple nested widgets)': function() {
-			var editor = this.editor,
-				html = '<div data-widget="test4" id="w1">' +
-					'<div class="ned">' +
-						'<div id="w2" data-widget="test3">test3</div>' +
-					'</div>' +
+		'test shadowed clipboard HTML is used for copying (single nested widget)': createCopyCutTest( {
+			event: 'copy',
+			html: '<div data-widget="test4" id="w1">' +
+				'<div class="ned">' +
+					'<div id="w2" data-widget="test3">test3</div>' +
 				'</div>' +
-				'<div data-widget="test4" id="w3">' +
-					'<div class="ned">' +
-						'<div id="w4" data-widget="test3">test3</div>' +
-					'</div>' +
-				'</div>';
+			'</div>',
 
-			this.editorBot.setData( html, function() {
-				var range = editor.createRange(),
-					clipboardHtml;
+			init: function( editor ) {
+				var widget = getWidgetById( editor, 'w1' );
+
+				widget.focus();
+			},
+
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/, clipboardHtml );
+				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+			}
+		} ),
+
+		// (#3138)
+		'test shadowed clipboard HTML is used for cutting (single nested widget)': createCopyCutTest( {
+			event: 'cut',
+			html: '<div data-widget="test4" id="w1">' +
+				'<div class="ned">' +
+					'<div id="w2" data-widget="test3">test3</div>' +
+				'</div>' +
+			'</div>',
+
+			init: function( editor ) {
+				var widget = getWidgetById( editor, 'w1' );
+
+				widget.focus();
+			},
+
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/, clipboardHtml );
+				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+			}
+		} ),
+
+		// (#3138)
+		'test shadowed clipboard HTML is used for copying (multiple nested widgets)': createCopyCutTest( {
+			event: 'copy',
+			html: '<div data-widget="test4" id="w1">' +
+				'<div class="ned">' +
+					'<div id="w2" data-widget="test3">test3</div>' +
+				'</div>' +
+			'</div>' +
+			'<div data-widget="test4" id="w3">' +
+				'<div class="ned">' +
+					'<div id="w4" data-widget="test3">test3</div>' +
+				'</div>' +
+			'</div>',
+
+			init: function( editor ) {
+				var range = editor.createRange();
 
 				range.selectNodeContents( editor.editable() );
 				range.select();
+			},
 
-				editor.editable().once( 'copy', function() {
-					clipboardHtml = editor.getSelectedHtml( true );
-				} );
-
-				editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
-
-				wait( function() {
-					assert.isMatching( /(<div data-cke-nested-widget="true">Content<\/div>){2}/, clipboardHtml );
-					assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
-				}, 150 );
-			} );
-		},
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /(<div data-cke-nested-widget="true">Content<\/div>){2}/, clipboardHtml );
+				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+			}
+		} ),
 
 		// (#3138)
-		'test shadowed clipboard HTML is used for cutting (multiple nested widgets)': function() {
-			var editor = this.editor,
-				html = '<div data-widget="test4" id="w1">' +
-					'<div class="ned">' +
-						'<div id="w2" data-widget="test3">test3</div>' +
-					'</div>' +
+		'test shadowed clipboard HTML is used for cutting (multiple nested widgets)': createCopyCutTest( {
+			event: 'cut',
+			html: '<div data-widget="test4" id="w1">' +
+				'<div class="ned">' +
+					'<div id="w2" data-widget="test3">test3</div>' +
 				'</div>' +
-				'<div data-widget="test4" id="w3">' +
-					'<div class="ned">' +
-						'<div id="w4" data-widget="test3">test3</div>' +
-					'</div>' +
-				'</div>';
+			'</div>' +
+			'<div data-widget="test4" id="w3">' +
+				'<div class="ned">' +
+					'<div id="w4" data-widget="test3">test3</div>' +
+				'</div>' +
+			'</div>',
 
-			this.editorBot.setData( html, function() {
-				var range = editor.createRange(),
-					clipboardHtml;
+			init: function( editor ) {
+				var range = editor.createRange();
 
 				range.selectNodeContents( editor.editable() );
 				range.select();
+			},
 
-				editor.editable().once( 'cut', function() {
-					clipboardHtml = editor.getSelectedHtml( true );
-				} );
-
-				editor.editable().fire( 'cut', new CKEDITOR.dom.event( {} ) );
-
-				wait( function() {
-					assert.isMatching( /(<div data-cke-nested-widget="true">Content<\/div>){2}/, clipboardHtml );
-					assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
-				}, 150 );
-			} );
-		},
+			assert: function( editor, clipboardHtml ) {
+				assert.isMatching( /(<div data-cke-nested-widget="true">Content<\/div>){2}/, clipboardHtml );
+				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+			}
+		} ),
 
 		'test single inserted widget is focused': function() {
 			var editor = this.editor,
@@ -1317,4 +1275,29 @@
 			} );
 		}
 	} );
+
+	function createCopyCutTest( options ) {
+		return function() {
+			var evtName = options.event || 'copy',
+				editor = this.editor;
+
+			this.editorBot.setData( options.html, function() {
+				var clipboardHtml;
+
+				if ( options.init ) {
+					options.init( editor );
+				}
+
+				editor.editable().once( evtName, function() {
+					clipboardHtml = editor.getSelectedHtml( true );
+				} );
+
+				editor.editable().fire( evtName, new CKEDITOR.dom.event( {} ) );
+
+				wait( function() {
+					options.assert( editor, clipboardHtml );
+				}, 150 );
+			} );
+		};
+	}
 } )();

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -871,9 +871,8 @@
 
 			init: function( editor ) {
 				var range = editor.createRange(),
-					editable = editor.editable(),
-					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' );
+					startNode = getWidgetById( editor, 'w1' ).wrapper,
+					endNode = getWidgetById( editor, 'w2' ).wrapper;
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );
@@ -881,7 +880,10 @@
 			},
 
 			assert: function( editor, clipboardHtml ) {
-				assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
+				// Due to weird HTML in IE8 we can't use assert.isMatching here.
+				var match = clipboardHtml.match( /.*?data-cke-test3-widget.*?/g );
+
+				assert.areSame( 2, match.length );
 			}
 		} ),
 
@@ -895,9 +897,8 @@
 
 			init: function( editor ) {
 				var range = editor.createRange(),
-					editable = editor.editable(),
-					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' );
+					startNode = getWidgetById( editor, 'w1' ).wrapper,
+					endNode = getWidgetById( editor, 'w2' ).wrapper;
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );
@@ -905,7 +906,10 @@
 			},
 
 			assert: function( editor, clipboardHtml ) {
-				assert.isMatching( /(.*data-cke-test3-widget.*){2}/, clipboardHtml );
+				// Due to weird HTML in IE8 we can't use assert.isMatching here.
+				var match = clipboardHtml.match( /.*?data-cke-test3-widget.*?/g );
+
+				assert.areSame( 2, match.length );
 			}
 		} ),
 
@@ -925,7 +929,7 @@
 			},
 
 			assert: function( editor, clipboardHtml ) {
-				assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/, clipboardHtml );
+				assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/i, clipboardHtml );
 				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
 			}
 		} ),
@@ -946,7 +950,7 @@
 			},
 
 			assert: function( editor, clipboardHtml ) {
-				assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/, clipboardHtml );
+				assert.isMatching( /<div data-cke-nested-widget="true">Content<\/div>/i, clipboardHtml );
 				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
 			}
 		} ),
@@ -954,7 +958,8 @@
 		// (#3138)
 		'test shadowed clipboard HTML is used for copying (multiple nested widgets)': createCopyCutTest( {
 			event: 'copy',
-			html: '<div data-widget="test4" id="w1">' +
+			html: '<p>Lorem</p>' +
+			'<div data-widget="test4" id="w1">' +
 				'<div class="ned">' +
 					'<div id="w2" data-widget="test3">test3</div>' +
 				'</div>' +
@@ -963,25 +968,35 @@
 				'<div class="ned">' +
 					'<div id="w4" data-widget="test3">test3</div>' +
 				'</div>' +
-			'</div>',
+			'</div>' +
+			'<p>ipsum</p>',
 
+			// Safari has issues with selecting multiple nested widgets, so we must anchor
+			// selection in text before and after widgets.
 			init: function( editor ) {
-				var range = editor.createRange();
+				var range = editor.createRange(),
+					paragraphs = editor.editable().find( 'p' ).toArray(),
+					startNode = paragraphs[ 0 ].getChild( 0 ),
+					endNode = paragraphs[ 1 ].getChild( 0 );
 
-				range.selectNodeContents( editor.editable() );
+				range.setStart( startNode, 4 );
+				range.setEnd( endNode, 3 );
 				range.select();
 			},
 
 			assert: function( editor, clipboardHtml ) {
-				assert.isMatching( /(<div data-cke-nested-widget="true">Content<\/div>){2}/, clipboardHtml );
-				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+				// Due to weird HTML in IE8 we can't use assert.isMatching here.
+				var match = clipboardHtml.match( /<div data-cke-nested-widget="true">Content<\/div>/gi );
+
+				assert.areSame( 2, match.length );
 			}
 		} ),
 
 		// (#3138)
 		'test shadowed clipboard HTML is used for cutting (multiple nested widgets)': createCopyCutTest( {
 			event: 'cut',
-			html: '<div data-widget="test4" id="w1">' +
+			html: '<p>Lorem</p>' +
+			'<div data-widget="test4" id="w1">' +
 				'<div class="ned">' +
 					'<div id="w2" data-widget="test3">test3</div>' +
 				'</div>' +
@@ -990,18 +1005,27 @@
 				'<div class="ned">' +
 					'<div id="w4" data-widget="test3">test3</div>' +
 				'</div>' +
-			'</div>',
+			'</div>' +
+			'<p>ipsum</p>',
 
+			// Safari has issues with selecting multiple nested widgets, so we must anchor
+			// selection in text before and after widgets.
 			init: function( editor ) {
-				var range = editor.createRange();
+				var range = editor.createRange(),
+					paragraphs = editor.editable().find( 'p' ).toArray(),
+					startNode = paragraphs[ 0 ].getChild( 0 ),
+					endNode = paragraphs[ 1 ].getChild( 0 );
 
-				range.selectNodeContents( editor.editable() );
+				range.setStart( startNode, 4 );
+				range.setEnd( endNode, 3 );
 				range.select();
 			},
 
 			assert: function( editor, clipboardHtml ) {
-				assert.isMatching( /(<div data-cke-nested-widget="true">Content<\/div>){2}/, clipboardHtml );
-				assert.isNotMatching( /.*data-cke-test3-widget.*/, clipboardHtml );
+				// Due to weird HTML in IE8 we can't use assert.isMatching here.
+				var match = clipboardHtml.match( /<div data-cke-nested-widget="true">Content<\/div>/gi );
+
+				assert.areSame( 2, match.length );
 			}
 		} ),
 
@@ -1033,9 +1057,8 @@
 
 			init: function( editor ) {
 				var range = editor.createRange(),
-					editable = editor.editable(),
-					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' );
+					startNode = getWidgetById( editor, 'w1' ).wrapper,
+					endNode = getWidgetById( editor, 'w2' ).wrapper;
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );
@@ -1043,20 +1066,12 @@
 			},
 
 			// Different browsers anchor selection to different elements, that's why
-			// we use such logic to check if selection is inside widgets.
+			// we use such logic to check if selection contains widgets.
 			assert: function( editor ) {
 				var range = editor.getSelection().getRanges()[ 0 ],
-					startContainer = range.startContainer.getAscendant( findWrapper, true ),
-					endContainer = range.endContainer.getAscendant( findWrapper, true ),
-					widget1 = getWidgetById( editor, 'w1' ).wrapper,
-					widget2 = getWidgetById( editor, 'w2' ).wrapper;
+					widgets = range._find( '[data-widget]', true );
 
-				assert.areSame( widget1, startContainer, 'start container' );
-				assert.areSame( widget2, endContainer, 'end container' );
-
-				function findWrapper( node ) {
-					return node.data && node.data( 'cke-widget-wrapper' );
-				}
+				assert.areSame( 2, widgets.length );
 			}
 		} ),
 
@@ -1113,9 +1128,8 @@
 
 			init: function( editor ) {
 				var range = editor.createRange(),
-					editable = editor.editable(),
-					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' );
+					startNode = getWidgetById( editor, 'w1' ).wrapper,
+					endNode = getWidgetById( editor, 'w2' ).wrapper;
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );
@@ -1139,9 +1153,8 @@
 
 			init: function( editor ) {
 				var range = editor.createRange(),
-					editable = editor.editable(),
-					startNode = editable.findOne( '#w1' ),
-					endNode = editable.findOne( '#w2' );
+					startNode = getWidgetById( editor, 'w1' ).wrapper,
+					endNode = getWidgetById( editor, 'w2' ).wrapper;
 
 				range.setStartBefore( startNode );
 				range.setEndAfter( endNode );


### PR DESCRIPTION
## What is the purpose of this pull request?

Feature request

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Proposed changelog entry

```
* [#3138](https://github.com/ckeditor/ckeditor-dev/issues/3138): Use [`widgetDefinition.getClipboardHtml()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html#method-getClipboardHtml) method to customize [Widget](https://ckeditor.com/cke4/addon/widget) HTML during copy, cut and drag operations.
```

## What changes did you make?

Added new widget `getClipboardHtml` member allowing to customize HTML copied to the clipboard during copy, cut and drop operations.

Closes #3138.
