### PR TITLE
Fix for: Element/Image drag to move within table is no longer available

### DIFF
--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -379,22 +379,18 @@
 	}
 
 	function fakeSelectionDragHandler( evt ) {
-		var table = evt.data.getTarget().getAscendant( 'table', true );
+		var table = evt.data.getTarget().getAscendant( 'table', true ),
+			editor = evt.editor || evt.sender.editor;
 
-		// (#2945)
-		if ( table && table.hasAttribute( ignoredTableAttribute ) ) {
+		// (#547)
+		if ( table && evt.name == 'dragstart' ) {
+			table.data( ignoredTableAttribute, '' );
 			return;
+		} else if ( table && evt.name == 'drop' ) {
+			table.data( ignoredTableAttribute, false );
 		}
-
-		var cell = evt.data.getTarget().getAscendant( { td: 1, th: 1 }, true );
-
-		if ( !cell || cell.hasClass( fakeSelectedClass ) ) {
-			return;
-		}
-
-		// We're not supporting dragging in our table selection for the time being.
-		evt.cancel();
-		evt.data.preventDefault();
+		editor.getSelection().reset();
+		clearFakeCellSelection( editor, true );
 	}
 
 	function copyTable( editor, isCut ) {
@@ -1192,6 +1188,7 @@
 				editable.attachListener( mouseHost, 'mouseup', fakeSelectionMouseHandler, null, evtInfo );
 
 				editable.attachListener( editable, 'dragstart', fakeSelectionDragHandler );
+				editable.attachListener( editable, 'drop', fakeSelectionDragHandler );
 				editable.attachListener( editor, 'selectionCheck', fakeSelectionChangeHandler );
 
 				CKEDITOR.plugins.tableselection.keyboardIntegration( editor );

--- a/tests/plugins/tableselection/manual/integrations/clipboard/draganddrop.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/draganddrop.html
@@ -1,0 +1,75 @@
+<div id="editor1">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:100%">
+		<tbody>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+	<p><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/wow/symbols/1f636-color.png" style="height:50px; width:50px" /></p>
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>
+					<p>1.1</p>
+				</td>
+				<td>
+					<p>1.2</p>
+				</td>
+			</tr>
+			<tr>
+				<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/like/symbols/1f60a-color.png" style="height:50px; width:50px" /></td>
+				<td>
+					<p>2.2</p>
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<p>3.1</p>
+				</td>
+				<td>
+				<table border="1" cellpadding="1" cellspacing="1" style="width:100%">
+					<tbody>
+						<tr>
+							<td><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/angry/symbols/2639-color.png" style="height:50px; width:50px" /></td>
+							<td>&nbsp;</td>
+						</tr>
+						<tr>
+							<td>&nbsp;</td>
+							<td>&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<p><img alt="" src="https://cdn.emojics.com/v1.0.0/emojis/sad/symbols/1f641-color.png" style="height:50px; width:50px" /></p>
+	<table border="1" cellpadding="1" cellspacing="1" style="width:100%">
+		<tbody>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+<div id="editor2">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:100%">
+		<tbody>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+
+	CKEDITOR.replace( 'editor1', { height: 500 } );
+	CKEDITOR.replace( 'editor2', { height: 100 } );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/clipboard/draganddrop.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/draganddrop.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
-@bender-tags: bug, 547, 4.13.0
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath, image
+@bender-tags: bug, 547, 4.14.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath, image, link
 
 ## Important:
 **After each scenario use `undo` button to revert editor to the basic state.** Observe if undoing works correctly.

--- a/tests/plugins/tableselection/manual/integrations/clipboard/draganddrop.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/draganddrop.md
@@ -1,0 +1,45 @@
+@bender-ui: collapsed
+@bender-tags: bug, 547, 4.13.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath, image
+
+## Important:
+**After each scenario use `undo` button to revert editor to the basic state.** Observe if undoing works correctly.
+
+For each scenario **Expected** and **Unexpected** results are the same:
+
+**Expected:**
+Emoji was dropped in the new location without creating additional elements (like nested table, additional row or whitespaces).
+
+**Unexpected:**
+Drop target was not droppable or some elements (mentioned above) appeared from nowhere.
+
+## Scenarios:
+
+1. Drag <span style="color:#59bb34">green (happy)</span> emoji to the cell 1.1.
+
+1. Drag <span style="color:#e74433">red (angry)</span> emoji to each of the cells in the table nested in cell 3.2, then drag it to the cell 2.2.
+
+1. Drag <span style="color:#59bb34">green (happy)</span> emoji to the table at the beginning of WYSIWYG area and back to the cell 2.1.
+
+1. Drag <span style="color:#e74433">red (angry)</span> emoji to the table at the end of WYSIWYG area and back to the nested table.
+
+1. Drag <span style="color:#f2c041">yellow (neutral)</span> emoji to the cell 1.1.
+
+1. Drag <span style="color:#f2c041">yellow (neutral)</span> emoji to any cell in the nested table.
+
+1. Drag <span style="color:#e47a3b">orange (sad)</span> emoji to the cell 1.1.
+
+1. Drag <span style="color:#e47a3b">orange (sad)</span> emoji to any cell in the nested table.
+
+1. Drag <span style="color:#e47a3b">orange (sad)</span> emoji to the table in second editor instance.
+
+1. Drag <span style="color:#e74433">red (angry)</span> emoji to the table in second editor instance.
+
+1. Last one is a little bit tricky:
+  * Select text in cell 1.1.
+  * Still holding mouse button move coursor to another cell and go back to cell 1.1
+(the point is it should become fake selected).
+  * Drag text to another cell.
+
+  If you need there is a recording of potential bug we try to catch in this scenario:
+https://github.com/ckeditor/ckeditor-dev/pull/3244#pullrequestreview-258421144.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests are not reliable as mentioned [here](https://github.com/ckeditor/ckeditor-dev/pull/3244#pullrequestreview-258421144)
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

`[#547](https://github.com/ckeditor/ckeditor-dev/issues/547): Fixed: Element/Image drag to move within table is no longer available when using [Table Selection plugin](https://ckeditor.com/cke4/addon/tableselection).`

## What changes did you make?

Added drag&drop handling so that table selection no longer needs to cancel those events.

Closes #547.