### PR TITLE
Fix for: Invalid display name for links with mailto href

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#3415](https://github.com/ckeditor/ckeditor4/issues/3415): [Firefox] Fixed: Pasting individual list elements fails. Thanks to [Jack Wickham](https://github.com/jackwickham)!
 * [#3413](https://github.com/ckeditor/ckeditor4/issues/3413): Fixed: Menu items with labels containing double quotes are rendered incorrectly.
 * [#3475](https://github.com/ckeditor/ckeditor4/issues/3475): [Firefox] Fixed: Pasting plain text over existing content fails and throws an error.
+* [#2027](https://github.com/ckeditor/ckeditor4/issues/2027): Fixed: Incorrect email display text after reopening [Link](https://ckeditor.com/cke4/addon/link) dialog for display names starting with `@`.
 
 ## CKEditor 4.13
 

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -90,8 +90,8 @@
 				element = selectedElements[ i ];
 				href = element.data( 'cke-saved-href' );
 				isDisplayChanged = data.linkText && initialLinkText != data.linkText;
-				isURLEqualDisplay = ( href == initialLinkText );
-				isEmailEqualDisplay = ( data.type == 'email' && href == 'mailto:' + initialLinkText );
+				isURLEqualDisplay = href == initialLinkText;
+				isEmailEqualDisplay = data.type == 'email' && href == 'mailto:' + initialLinkText;
 
 				element.setAttributes( attributes.set );
 				element.removeAttributes( attributes.removed );

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -97,7 +97,7 @@
 				if ( data.linkText && initialLinkText != data.linkText ) {
 					// Display text has been changed.
 					newText = data.linkText;
-				} else if ( href == textView || data.type == 'email' && textView.indexOf( '@' ) != -1 ) {
+				} else if ( href == textView || ( data.type == 'email' && href == 'mailto:' + initialLinkText ) ) {
 					// Update text view when user changes protocol (https://dev.ckeditor.com/ticket/4612).
 					// Short mailto link text view (https://dev.ckeditor.com/ticket/5736).
 					newText = data.type == 'email' ? data.email.address : attributes.set[ 'data-cke-saved-href' ];

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -77,9 +77,11 @@
 		function editLinksInSelection( editor, selectedElements, data ) {
 			var attributes = plugin.getLinkAttributes( editor, data ),
 				ranges = [],
+				isDisplayChanged,
+				isEmailEqualDisplay,
+				isURLEqualDisplay,
 				element,
 				href,
-				textView,
 				newText,
 				i;
 
@@ -87,15 +89,17 @@
 				// We're only editing an existing link, so just overwrite the attributes.
 				element = selectedElements[ i ];
 				href = element.data( 'cke-saved-href' );
-				textView = element.getHtml();
+				isDisplayChanged = data.linkText && initialLinkText != data.linkText;
+				isURLEqualDisplay = ( href == initialLinkText );
+				isEmailEqualDisplay = ( data.type == 'email' && href == 'mailto:' + initialLinkText );
 
 				element.setAttributes( attributes.set );
 				element.removeAttributes( attributes.removed );
 
-				if ( data.linkText && initialLinkText != data.linkText ) {
+				if ( isDisplayChanged ) {
 					// Display text has been changed.
 					newText = data.linkText;
-				} else if ( href == textView || ( data.type == 'email' && href == 'mailto:' + initialLinkText ) ) {
+				} else if ( isURLEqualDisplay || isEmailEqualDisplay ) {
 					// Update text view when user changes protocol (https://dev.ckeditor.com/ticket/4612).
 					// Short mailto link text view (https://dev.ckeditor.com/ticket/5736).
 					newText = data.type == 'email' ? data.email.address : attributes.set[ 'data-cke-saved-href' ];
@@ -199,8 +203,9 @@
 		};
 
 		var commitParams = function( page, data ) {
-			if ( !data[ page ] )
+			if ( !data[ page ] ) {
 				data[ page ] = {};
+			}
 
 			data[ page ][ this.id ] = this.getValue() || '';
 		};

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -65,7 +65,6 @@
 					nestedLinks[ j ].remove( true );
 				}
 
-
 				// Apply style.
 				style.applyToRange( range, editor );
 
@@ -93,7 +92,6 @@
 				element.setAttributes( attributes.set );
 				element.removeAttributes( attributes.removed );
 
-
 				if ( data.linkText && initialLinkText != data.linkText ) {
 					// Display text has been changed.
 					newText = data.linkText;
@@ -116,97 +114,104 @@
 
 		// Handles the event when the "Target" selection box is changed.
 		var targetChanged = function() {
-				var dialog = this.getDialog(),
-					popupFeatures = dialog.getContentElement( 'target', 'popupFeatures' ),
-					targetName = dialog.getContentElement( 'target', 'linkTargetName' ),
-					value = this.getValue();
+			var dialog = this.getDialog(),
+				popupFeatures = dialog.getContentElement( 'target', 'popupFeatures' ),
+				targetName = dialog.getContentElement( 'target', 'linkTargetName' ),
+				value = this.getValue();
 
-				if ( !popupFeatures || !targetName )
-					return;
+			if ( !popupFeatures || !targetName ) {
+				return;
+			}
 
-				popupFeatures = popupFeatures.getElement();
-				popupFeatures.hide();
-				targetName.setValue( '' );
+			popupFeatures = popupFeatures.getElement();
+			popupFeatures.hide();
+			targetName.setValue( '' );
 
-				switch ( value ) {
-					case 'frame':
-						targetName.setLabel( editor.lang.link.targetFrameName );
-						targetName.getElement().show();
-						break;
-					case 'popup':
-						popupFeatures.show();
-						targetName.setLabel( editor.lang.link.targetPopupName );
-						targetName.getElement().show();
-						break;
-					default:
-						targetName.setValue( value );
-						targetName.getElement().hide();
-						break;
-				}
+			switch ( value ) {
+				case 'frame':
+					targetName.setLabel( editor.lang.link.targetFrameName );
+					targetName.getElement().show();
+					break;
+				case 'popup':
+					popupFeatures.show();
+					targetName.setLabel( editor.lang.link.targetPopupName );
+					targetName.getElement().show();
+					break;
+				default:
+					targetName.setValue( value );
+					targetName.getElement().hide();
+					break;
+			}
 
-			};
+		};
 
 		// Handles the event when the "Type" selection box is changed.
 		var linkTypeChanged = function() {
-				var dialog = this.getDialog(),
-					partIds = [ 'urlOptions', 'anchorOptions', 'emailOptions', 'telOptions' ],
-					typeValue = this.getValue(),
-					uploadTab = dialog.definition.getContents( 'upload' ),
-					uploadInitiallyHidden = uploadTab && uploadTab.hidden;
+			var dialog = this.getDialog(),
+				partIds = [ 'urlOptions', 'anchorOptions', 'emailOptions', 'telOptions' ],
+				typeValue = this.getValue(),
+				uploadTab = dialog.definition.getContents( 'upload' ),
+				uploadInitiallyHidden = uploadTab && uploadTab.hidden;
 
-				if ( typeValue == 'url' ) {
-					if ( editor.config.linkShowTargetTab )
-						dialog.showPage( 'target' );
-					if ( !uploadInitiallyHidden )
-						dialog.showPage( 'upload' );
+			if ( typeValue == 'url' ) {
+				if ( editor.config.linkShowTargetTab ) {
+					dialog.showPage( 'target' );
+				}
+				if ( !uploadInitiallyHidden ) {
+					dialog.showPage( 'upload' );
+				}
+			} else {
+				dialog.hidePage( 'target' );
+				if ( !uploadInitiallyHidden ) {
+					dialog.hidePage( 'upload' );
+				}
+			}
+
+			for ( var i = 0; i < partIds.length; i++ ) {
+				var element = dialog.getContentElement( 'info', partIds[ i ] );
+				if ( !element ) {
+					continue;
+				}
+
+				element = element.getElement().getParent().getParent();
+				if ( partIds[ i ] == typeValue + 'Options' ) {
+					element.show();
 				} else {
-					dialog.hidePage( 'target' );
-					if ( !uploadInitiallyHidden )
-						dialog.hidePage( 'upload' );
+					element.hide();
 				}
+			}
 
-				for ( var i = 0; i < partIds.length; i++ ) {
-					var element = dialog.getContentElement( 'info', partIds[ i ] );
-					if ( !element )
-						continue;
-
-					element = element.getElement().getParent().getParent();
-					if ( partIds[ i ] == typeValue + 'Options' )
-						element.show();
-					else
-						element.hide();
-				}
-
-				dialog.layout();
-			};
+			dialog.layout();
+		};
 
 		var setupParams = function( page, data ) {
-				if ( data[ page ] )
-					this.setValue( data[ page ][ this.id ] || '' );
-			};
+			if ( data[ page ] ) {
+				this.setValue( data[ page ][ this.id ] || '' );
+			}
+		};
 
 		var setupPopupParams = function( data ) {
-				return setupParams.call( this, 'target', data );
-			};
+			return setupParams.call( this, 'target', data );
+		};
 
 		var setupAdvParams = function( data ) {
-				return setupParams.call( this, 'advanced', data );
-			};
+			return setupParams.call( this, 'advanced', data );
+		};
 
 		var commitParams = function( page, data ) {
-				if ( !data[ page ] )
-					data[ page ] = {};
+			if ( !data[ page ] )
+				data[ page ] = {};
 
-				data[ page ][ this.id ] = this.getValue() || '';
-			};
+			data[ page ][ this.id ] = this.getValue() || '';
+		};
 
 		var commitPopupParams = function( data ) {
-				return commitParams.call( this, 'target', data );
-			};
+			return commitParams.call( this, 'target', data );
+		};
 
 		var commitAdvParams = function( data ) {
-				return commitParams.call( this, 'advanced', data );
-			};
+			return commitParams.call( this, 'advanced', data );
+		};
 
 		var commonLang = editor.lang.common,
 			linkLang = editor.lang.link,
@@ -287,8 +292,9 @@
 								}
 							},
 							commit: function( data ) {
-								if ( !data.url )
+								if ( !data.url ) {
 									data.url = {};
+								}
 
 								data.url.protocol = this.getValue();
 							}
@@ -306,9 +312,9 @@
 								var protocolCmb = this.getDialog().getContentElement( 'info', 'protocol' ),
 									url = this.getValue(),
 									urlOnChangeProtocol = /^(http|https|ftp|news):\/\/(?=.)/i,
-									urlOnChangeTestOther = /^((javascript:)|[#\/\.\?])/i;
+									urlOnChangeTestOther = /^((javascript:)|[#\/\.\?])/i,
+									protocol = urlOnChangeProtocol.exec( url );
 
-								var protocol = urlOnChangeProtocol.exec( url );
 								if ( protocol ) {
 									this.setValue( url.substr( protocol[ 0 ].length ) );
 									protocolCmb.setValue( protocol[ 0 ].toLowerCase() );
@@ -319,30 +325,36 @@
 								this.allowOnChange = true;
 							},
 							onChange: function() {
-								if ( this.allowOnChange ) // Dont't call on dialog load.
-								this.onKeyUp();
+								// Dont't call on dialog load.
+								if ( this.allowOnChange ) {
+									this.onKeyUp();
+								}
 							},
 							validate: function() {
 								var dialog = this.getDialog();
 
-								if ( dialog.getContentElement( 'info', 'linkType' ) && dialog.getValueOf( 'info', 'linkType' ) != 'url' )
+								if ( dialog.getContentElement( 'info', 'linkType' ) && dialog.getValueOf( 'info', 'linkType' ) != 'url' ) {
 									return true;
+								}
 
 								if ( !editor.config.linkJavaScriptLinksAllowed && ( /javascript\:/ ).test( this.getValue() ) ) {
 									alert( commonLang.invalidValue ); // jshint ignore:line
 									return false;
 								}
 
-								if ( this.getDialog().fakeObj ) // Edit Anchor.
-								return true;
+								// Edit Anchor.
+								if ( this.getDialog().fakeObj ) {
+									return true;
+								}
 
 								var func = CKEDITOR.dialog.validate.notEmpty( linkLang.noUrl );
 								return func.apply( this );
 							},
 							setup: function( data ) {
 								this.allowOnChange = false;
-								if ( data.url )
+								if ( data.url ) {
 									this.setValue( data.url.url );
+								}
 								this.allowOnChange = true;
 
 							},
@@ -351,16 +363,18 @@
 								// to carry all the operations https://dev.ckeditor.com/ticket/4724
 								this.onChange();
 
-								if ( !data.url )
+								if ( !data.url ) {
 									data.url = {};
+								}
 
 								data.url.url = this.getValue();
 								this.allowOnChange = false;
 							}
 						} ],
 						setup: function() {
-							if ( !this.getDialog().getContentElement( 'info', 'linkType' ) )
+							if ( !this.getDialog().getContentElement( 'info', 'linkType' ) ) {
 								this.getElement().show();
+							}
 						}
 					},
 					{
@@ -404,21 +418,25 @@
 
 									if ( anchors ) {
 										for ( var i = 0; i < anchors.length; i++ ) {
-											if ( anchors[ i ].name )
+											if ( anchors[ i ].name ) {
 												this.add( anchors[ i ].name );
+											}
 										}
 									}
 
-									if ( data.anchor )
+									if ( data.anchor ) {
 										this.setValue( data.anchor.name );
+									}
 
 									var linkType = this.getDialog().getContentElement( 'info', 'linkType' );
-									if ( linkType && linkType.getValue() == 'email' )
+									if ( linkType && linkType.getValue() == 'email' ) {
 										this.focus();
+									}
 								},
 								commit: function( data ) {
-									if ( !data.anchor )
+									if ( !data.anchor ) {
 										data.anchor = {};
+									}
 
 									data.anchor.name = this.getValue();
 								}
@@ -438,17 +456,20 @@
 
 									if ( anchors ) {
 										for ( var i = 0; i < anchors.length; i++ ) {
-											if ( anchors[ i ].id )
+											if ( anchors[ i ].id ) {
 												this.add( anchors[ i ].id );
+											}
 										}
 									}
 
-									if ( data.anchor )
+									if ( data.anchor ) {
 										this.setValue( data.anchor.id );
+									}
 								},
 								commit: function( data ) {
-									if ( !data.anchor )
+									if ( !data.anchor ) {
 										data.anchor = {};
+									}
 
 									data.anchor.id = this.getValue();
 								}
@@ -470,8 +491,9 @@
 						}
 					} ],
 					setup: function() {
-						if ( !this.getDialog().getContentElement( 'info', 'linkType' ) )
+						if ( !this.getDialog().getContentElement( 'info', 'linkType' ) ) {
 							this.getElement().hide();
+						}
 					}
 				},
 				{
@@ -486,23 +508,27 @@
 						validate: function() {
 							var dialog = this.getDialog();
 
-							if ( !dialog.getContentElement( 'info', 'linkType' ) || dialog.getValueOf( 'info', 'linkType' ) != 'email' )
+							if ( !dialog.getContentElement( 'info', 'linkType' ) || dialog.getValueOf( 'info', 'linkType' ) != 'email' ) {
 								return true;
+							}
 
 							var func = CKEDITOR.dialog.validate.notEmpty( linkLang.noEmail );
 							return func.apply( this );
 						},
 						setup: function( data ) {
-							if ( data.email )
+							if ( data.email ) {
 								this.setValue( data.email.address );
+							}
 
 							var linkType = this.getDialog().getContentElement( 'info', 'linkType' );
-							if ( linkType && linkType.getValue() == 'email' )
+							if ( linkType && linkType.getValue() == 'email' ) {
 								this.select();
+							}
 						},
 						commit: function( data ) {
-							if ( !data.email )
+							if ( !data.email ) {
 								data.email = {};
+							}
 
 							data.email.address = this.getValue();
 						}
@@ -512,12 +538,14 @@
 						id: 'emailSubject',
 						label: linkLang.emailSubject,
 						setup: function( data ) {
-							if ( data.email )
+							if ( data.email ) {
 								this.setValue( data.email.subject );
+							}
 						},
 						commit: function( data ) {
-							if ( !data.email )
+							if ( !data.email ) {
 								data.email = {};
+							}
 
 							data.email.subject = this.getValue();
 						}
@@ -529,19 +557,22 @@
 						rows: 3,
 						'default': '',
 						setup: function( data ) {
-							if ( data.email )
+							if ( data.email ) {
 								this.setValue( data.email.body );
+							}
 						},
 						commit: function( data ) {
-							if ( !data.email )
+							if ( !data.email ) {
 								data.email = {};
+							}
 
 							data.email.body = this.getValue();
 						}
 					} ],
 					setup: function() {
-						if ( !this.getDialog().getContentElement( 'info', 'linkType' ) )
+						if ( !this.getDialog().getContentElement( 'info', 'linkType' ) ) {
 							this.getElement().hide();
+						}
 					}
 				},
 				{
@@ -600,13 +631,15 @@
 						],
 						onChange: targetChanged,
 						setup: function( data ) {
-							if ( data.target )
+							if ( data.target ) {
 								this.setValue( data.target.type || 'notSet' );
+							}
 							targetChanged.call( this );
 						},
 						commit: function( data ) {
-							if ( !data.target )
+							if ( !data.target ) {
 								data.target = {};
+							}
 
 							data.target.type = this.getValue();
 						}
@@ -617,12 +650,14 @@
 						label: linkLang.targetFrameName,
 						'default': '',
 						setup: function( data ) {
-							if ( data.target )
+							if ( data.target ) {
 								this.setValue( data.target.name );
+							}
 						},
 						commit: function( data ) {
-							if ( !data.target )
+							if ( !data.target ) {
 								data.target = {};
+							}
 
 							data.target.name = this.getValue().replace( /([^\x00-\x7F]|\s)/gi, '' );
 						}
@@ -652,7 +687,6 @@
 								label: linkLang.popupStatusBar,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							} ]
 						},
 						{
@@ -663,7 +697,6 @@
 								label: linkLang.popupLocationBar,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							},
 							{
 								type: 'checkbox',
@@ -671,7 +704,6 @@
 								label: linkLang.popupToolbar,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							} ]
 						},
 						{
@@ -682,7 +714,6 @@
 								label: linkLang.popupMenuBar,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							},
 							{
 								type: 'checkbox',
@@ -690,7 +721,6 @@
 								label: linkLang.popupFullScreen,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							} ]
 						},
 						{
@@ -701,7 +731,6 @@
 								label: linkLang.popupScrollBars,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							},
 							{
 								type: 'checkbox',
@@ -709,7 +738,6 @@
 								label: linkLang.popupDependent,
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							} ]
 						},
 						{
@@ -722,7 +750,6 @@
 								id: 'width',
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							},
 							{
 								type: 'text',
@@ -732,7 +759,6 @@
 								id: 'left',
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							} ]
 						},
 						{
@@ -745,7 +771,6 @@
 								id: 'height',
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							},
 							{
 								type: 'text',
@@ -755,7 +780,6 @@
 								id: 'top',
 								setup: setupPopupParams,
 								commit: commitPopupParams
-
 							} ]
 						} ]
 					} ]
@@ -824,7 +848,6 @@
 							maxLength: 1,
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						} ]
 					},
 					{
@@ -837,7 +860,6 @@
 							requiredContent: 'a[name]',
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						},
 						{
 							type: 'text',
@@ -848,7 +870,6 @@
 							'default': '',
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						},
 						{
 							type: 'text',
@@ -859,7 +880,6 @@
 							maxLength: 5,
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						} ]
 					} ]
 				},
@@ -877,7 +897,6 @@
 							id: 'advTitle',
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						},
 						{
 							type: 'text',
@@ -887,7 +906,6 @@
 							id: 'advContentType',
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						} ]
 					},
 					{
@@ -901,7 +919,6 @@
 							id: 'advCSSClasses',
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						},
 						{
 							type: 'text',
@@ -911,7 +928,6 @@
 							id: 'advCharset',
 							setup: setupAdvParams,
 							commit: commitAdvParams
-
 						} ]
 					},
 					{
@@ -946,8 +962,9 @@
 							requiredContent: 'a[download]',
 							label: linkLang.download,
 							setup: function( data ) {
-								if ( data.download !== undefined )
+								if ( data.download !== undefined ) {
 									this.setValue( 'checked', 'checked' );
+								}
 							},
 							commit: function( data ) {
 								if ( this.getValue() ) {
@@ -1003,11 +1020,13 @@
 				}
 			},
 			onLoad: function() {
-				if ( !editor.config.linkShowAdvancedTab )
+				if ( !editor.config.linkShowAdvancedTab ) {
 					this.hidePage( 'advanced' ); //Hide Advanded tab.
+				}
 
-				if ( !editor.config.linkShowTargetTab )
+				if ( !editor.config.linkShowTargetTab ) {
 					this.hidePage( 'target' ); //Hide Target tab.
+				}
 			},
 			// Inital focus on 'url' field if link is of type URL.
 			onFocus: function() {

--- a/tests/plugins/link/emailprotectionencode.html
+++ b/tests/plugins/link/emailprotectionencode.html
@@ -1,1 +1,0 @@
-<textarea id="test_create_link_editor"></textarea>

--- a/tests/plugins/link/emailprotectionfunctionalcall.html
+++ b/tests/plugins/link/emailprotectionfunctionalcall.html
@@ -1,1 +1,0 @@
-<textarea id="test_create_link_editor"></textarea>

--- a/tests/plugins/link/emailwithatsign.html
+++ b/tests/plugins/link/emailwithatsign.html
@@ -1,1 +1,0 @@
-<textarea id="test_create_link_editor"></textarea>

--- a/tests/plugins/link/emailwithatsign.html
+++ b/tests/plugins/link/emailwithatsign.html
@@ -1,0 +1,1 @@
+<textarea id="test_create_link_editor"></textarea>

--- a/tests/plugins/link/emailwithatsign.js
+++ b/tests/plugins/link/emailwithatsign.js
@@ -1,0 +1,19 @@
+/* bender-tags: editor, link, email */
+/* bender-ckeditor-plugins: link,button,toolbar,dialog */
+
+bender.editor = {};
+
+bender.test( {
+	// (#2027)
+	'test link target keywords': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<h1>Mail to <a href="mailto:ckeditor@cksource.com">[@CKSource]</a>!</h1>' );
+
+		bot.dialog( 'link', function( dialog ) {
+			dialog.getButton( 'ok' ).click();
+
+			assert.areSame( '<h1>Mail to <a href="mailto:ckeditor@cksource.com">@CKSource</a>!</h1>', bot.getData() );
+		} );
+	}
+} );

--- a/tests/plugins/link/manual/emailwithatsign.html
+++ b/tests/plugins/link/manual/emailwithatsign.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Mail to <a href="mailto:ckeditor@cksource.com">@CKSource</a>!</p>
+	<p>Or <a href="mailto:Victoria@ckeditor.com">Victoria@ckeditor.com</a>.</p>
+</div>
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/link/manual/emailwithatsign.md
+++ b/tests/plugins/link/manual/emailwithatsign.md
@@ -1,0 +1,29 @@
+@bender-tags: bug, link, 4.13.0, 2027
+@bender-ui: collapsed
+@bender-ckeditor-plugins: link, toolbar, wysiwygarea, sourcearea, basicstyles, undo
+
+## Scenario 1:
+
+1. Open link dialog for first link (@CKSource).
+1. Click OK.
+
+**Expected:**
+
+Display text for link didn't change.
+
+**Unexpected:**
+
+Display text change to link's href.
+
+## Scenario 2:
+
+1. Open link dialog for second link (Victoria@ckeditor.com).
+2. Change E-mail Address to whatever.
+
+**Expected:**
+
+Display name changed alongside address.
+
+**Unexpected:**
+
+Display name changed to something else or didn't change at all.

--- a/tests/plugins/link/manual/emailwithatsign.md
+++ b/tests/plugins/link/manual/emailwithatsign.md
@@ -7,11 +7,11 @@
 1. Open link dialog for first link (@CKSource).
 1. Click OK.
 
-**Expected:**
+### Expected:
 
 Display text for link didn't change.
 
-**Unexpected:**
+### Unexpected:
 
 Display text change to link's href.
 
@@ -20,10 +20,10 @@ Display text change to link's href.
 1. Open link dialog for second link (Victoria@ckeditor.com).
 2. Change E-mail Address to whatever.
 
-**Expected:**
+### Expected:
 
 Display name changed alongside address.
 
-**Unexpected:**
+### Unexpected:
 
 Display name changed to something else or didn't change at all.

--- a/tests/plugins/link/manual/emailwithatsign.md
+++ b/tests/plugins/link/manual/emailwithatsign.md
@@ -4,26 +4,22 @@
 
 ## Scenario 1:
 
-1. Open link dialog for first link (@CKSource).
+1. Open link dialog for the first link (`@CKSource`).
 1. Click OK.
 
-### Expected:
+  ### Expected:
+  Display text for link didn't change.
 
-Display text for link didn't change.
-
-### Unexpected:
-
-Display text change to link's href.
+  ### Unexpected:
+  Display text changed to link's href.
 
 ## Scenario 2:
 
-1. Open link dialog for second link (Victoria@ckeditor.com).
-2. Change E-mail Address to whatever.
+1. Open link dialog for the second link (`Victoria@ckeditor.com`).
+2. Change `E-mail Address` to something else.
 
-### Expected:
+  ### Expected:
+  Display name changed alongside address.
 
-Display name changed alongside address.
-
-### Unexpected:
-
-Display name changed to something else or didn't change at all.
+  ### Unexpected:
+  Display name changed to something else or didn't change at all.

--- a/tests/plugins/link/manual/emailwithatsign.md
+++ b/tests/plugins/link/manual/emailwithatsign.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, link, 4.13.0, 2027
+@bender-tags: bug, link, 4.13.1, 2027
 @bender-ui: collapsed
 @bender-ckeditor-plugins: link, toolbar, wysiwygarea, sourcearea, basicstyles, undo
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

`[(#2027)](https://github.com/ckeditor/ckeditor-dev/issues/2027): Fix for: Incorrect handling email display text starting with '@'.`

## What changes did you make?

Link plugin was changing email display text to be the same as email address every time it found '@' in display text. This condition was removed.

Closes #2027.