### PR TITLE
Fix for: Copy&Paste on a table cell, creates new table row

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2366,7 +2366,18 @@
 		if ( editor ) {
 			this.sourceEditor = editor;
 
-			this.setData( 'text/html', editor.getSelectedHtml( 1 ) );
+			var selection = editor.getSelection(),
+				ranges = selection.getRanges(),
+				table = ranges.length && ranges[ 0 ]._getTableElement( { table: 1 } ),
+				element = editor.getSelection().getSelectedElement();
+
+			// When element inside cell is copied or dragged with tableselection plugin turned on, it is sometimes
+			// nested in additional table. We want to filter only the content of a cell.
+			if ( editor.plugins.tableselection && table && element && element.$.draggable ) {
+				this.setData( 'text/html', element.$.outerHTML );
+			} else {
+				this.setData( 'text/html', editor.getSelectedHtml( 1 ) );
+			}
 
 			// Without setData( 'text', ... ) on dragstart there is no drop event in Safari.
 			// Also 'text' data is empty as drop to the textarea does not work if we do not put there text.

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2366,16 +2366,17 @@
 		if ( editor ) {
 			this.sourceEditor = editor;
 
-			var selection = editor.getSelection(),
-				ranges = selection.getRanges(),
-				table = ranges.length && ranges[ 0 ]._getTableElement( { table: 1 } ),
-				element = editor.getSelection().getSelectedElement();
+			var selectedCells = editor.getSelectedHtml().find( 'td' ).$,
+				isExactlyOneCellSelected = selectedCells.length == 1;
 
-			// When element inside cell is copied or dragged with tableselection plugin turned on, it is sometimes
-			// nested in additional table. We want to filter only the content of a cell.
-			if ( editor.plugins.tableselection && table && element && element.$.draggable ) {
-				this.setData( 'text/html', element.$.outerHTML );
-			} else {
+			// When copying the cell content using tableselection plugin, editor wants to nest it
+			// in the new table, so actual content must be stripped off.
+			if ( isExactlyOneCellSelected ) {
+				this.setData( 'text/html', selectedCells[ 0 ].innerHTML );
+			}
+			// Get the content in the old way otherwise (including partial selection in table,
+			// selecting more than one cell, and all the normal selections).
+			else {
 				this.setData( 'text/html', editor.getSelectedHtml( 1 ) );
 			}
 

--- a/tests/plugins/tableselection/integrations/clipboard/copypasteimage.html
+++ b/tests/plugins/tableselection/integrations/clipboard/copypasteimage.html
@@ -1,10 +1,161 @@
-<textarea id="before">
+<textarea id="image">
 	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 		<tbody>
 			<tr>
 				<td>[<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px" />]</td>
 			</tr>
 			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="image-partial">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>hello![<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px" />]&nbsp;</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="text">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>[1.1]</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="text-partial">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>[1.1]&nbsp;2.2</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="formatted-text">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>[<em>1.1</em>]</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="formatted-text-partial">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>Hello!&nbsp;[<em>1.1</em>]&nbsp;</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="text-with-image">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>[Hello!<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px" />]</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="link">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>[<a href="https://cksource.com/">https://cksource.com/</a>]</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="list">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>
+					[<ol>
+						<li>dar</li>
+						<li>jar</li>
+						<li>mar</li>
+					</ol>]
+				</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="text-nested-table">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>
+				<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+					<tbody>
+						<tr>
+							<td>[Help me, I am nested!]</td>
+						</tr>
+					</tbody>
+				</table>
+				<p>&nbsp;</p>
+				</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<textarea id="two-cells">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>
+					[start
+				</td>
+				<td>
+					end]
+				</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
 				<td>&nbsp;</td>
 			</tr>
 		</tbody>

--- a/tests/plugins/tableselection/integrations/clipboard/copypasteimage.html
+++ b/tests/plugins/tableselection/integrations/clipboard/copypasteimage.html
@@ -1,0 +1,12 @@
+<textarea id="before">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>[<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px" />]</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>

--- a/tests/plugins/tableselection/integrations/clipboard/copypasteimage.js
+++ b/tests/plugins/tableselection/integrations/clipboard/copypasteimage.js
@@ -1,0 +1,35 @@
+/* bender-tags: tableselection, clipboard */
+/* bender-ckeditor-plugins: undo,tableselection,image */
+/* bender-include: ../../_helpers/tableselection.js */
+
+( function() {
+	'use strict';
+
+	bender.editors = {
+		classic: {},
+		inline: {
+			creator: 'inline'
+		}
+	};
+
+	var tests = {
+		setUp: function() {
+			bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+		},
+
+		// (#3278)
+		'test check if collapse selection is not copied': function( editor, bot ) {
+			var img = '<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px">';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'before' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.areSame( img, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		}
+	};
+
+	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
+
+	bender.test( tests );
+
+} )();

--- a/tests/plugins/tableselection/integrations/clipboard/copypasteimage.js
+++ b/tests/plugins/tableselection/integrations/clipboard/copypasteimage.js
@@ -1,5 +1,5 @@
 /* bender-tags: tableselection, clipboard */
-/* bender-ckeditor-plugins: undo,tableselection,image */
+/* bender-ckeditor-plugins: tableselection,clipboard,image,list,link,basicstyles */
 /* bender-include: ../../_helpers/tableselection.js */
 
 ( function() {
@@ -15,16 +15,120 @@
 	var tests = {
 		setUp: function() {
 			bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+			if ( !CKEDITOR.plugins.clipboard.isCustomCopyCutSupported ) {
+				assert.ignore();
+			}
 		},
 
 		// (#3278)
-		'test check if collapse selection is not copied': function( editor, bot ) {
+		'test copied image is not nested in table': function( editor, bot ) {
 			var img = '<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px">';
 
-			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'before' ).getValue() );
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'image' ).getValue() );
 
 			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
-			assert.areSame( img, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+			assert.beautified.html( img, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied image (partial selection) is not nested in table': function( editor, bot ) {
+			var img = '<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px">';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'image-partial' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( img, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied text is not nested in table': function( editor, bot ) {
+			var text = '1.1';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'text' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied text (partial selection) is not nested in table': function( editor, bot ) {
+			var text = '1.1';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'text-partial' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied formatted text is not nested in table': function( editor, bot ) {
+			var text = '<em>1.1</em>';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'formatted-text' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied formatted text (partial selection) is not nested in table': function( editor, bot ) {
+			var text = '<em>1.1</em>';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'formatted-text-partial' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied text with image is not nested in table': function( editor, bot ) {
+			var text = 'Hello!<img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px">';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'text-with-image' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied link is not nested in table': function( editor, bot ) {
+			var text = '<a href="https://cksource.com/">https://cksource.com/</a>';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'link' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied list is not nested in table': function( editor, bot ) {
+			var text = '<ol><li>dar</li><li>jar</li><li>mar</li></ol>';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'list' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied text in nested table is not nested in table': function( editor, bot ) {
+			var text = 'Help me, I am nested!';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'text-nested-table' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
+		},
+
+		// (#3278)
+		'test copied two cells ARE nested in table': function( editor, bot ) {
+			var text = '<table border="1" cellpadding="1" cellspacing="1" style="width:500px" data-cke-table-faked-selection-table="">' +
+				'<tbody><tr><td class="cke_table-faked-selection">start</td><td class="cke_table-faked-selection">end</td></tr></tbody></table>';
+
+			bot.setHtmlWithSelection( CKEDITOR.document.getById( 'two-cells' ).getValue() );
+
+			editor.editable().fire( 'copy', new CKEDITOR.dom.event( {} ) );
+			assert.beautified.html( text, CKEDITOR.plugins.clipboard.copyCutData.getData( 'text/html' ) );
 		}
 	};
 

--- a/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.html
@@ -1,4 +1,4 @@
-<div id="editor">
+<div id="editor1">
 	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 		<tbody>
 			<tr>
@@ -12,6 +12,43 @@
 	<p>&nbsp;</p>
 </div>
 
+
+<div id="editor2">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td><em>First cell</em></td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+	<p>&nbsp;</p>
+</div>
+
+<div id="editor3">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>
+					<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+						<tbody>
+							<tr>
+								<td><img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px" /></td>
+							</tr>
+						</tbody>
+					</table>
+					<p>&nbsp;</p>
+				</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
 <script>
 	if ( bender.tools.env.mobile ) {
 		bender.ignore();
@@ -19,5 +56,7 @@
 
 	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
 
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor2' );
+	CKEDITOR.replace( 'editor3' );
 </script>

--- a/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.html
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.html
@@ -1,0 +1,23 @@
+<div id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td><img alt="" src="http://cdn.ckeditor.com/4.12.1/full-all/samples/img/logo.svg" style="height:50px; width:172px" /></td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+	<p>&nbsp;</p>
+</div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.md
@@ -1,0 +1,42 @@
+@bender-ui: collapsed
+@bender-tags: bug, 3278, 4.13.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath, image
+
+## Scenario 1:
+
+1. Copy image.
+1. Paste it in the empty cell.
+
+**Expected:**
+
+Image is copied, no rows or different elements are added.
+
+**Unexpected:**
+
+Copying created additional row in table.
+
+## Scenario 2:
+
+1. Fake select the first table cell.
+1. Copy it and paste in the second cell.
+
+**Expected:**
+
+Image is copied and additional row is created.
+
+**Unexpected:**
+
+Additional row didn't appear.
+
+## Scenario 3:
+
+1. Fake select the first table cell.
+1. Copy it and paste after the table.
+
+**Expected:**
+
+New table with image in it appeared.
+
+**Unexpected:**
+
+Only image without new table is pasted.

--- a/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.md
+++ b/tests/plugins/tableselection/manual/integrations/clipboard/copypasteimage.md
@@ -1,42 +1,102 @@
 @bender-ui: collapsed
-@bender-tags: bug, 3278, 4.13.0
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, sourcearea, undo, elementspath, image
+@bender-tags: bug, 4.14.0, 3278
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, clipboard, undo, image, basicstyles
+
+## 1st Editor:
 
 ## Scenario 1:
 
 1. Copy image.
 1. Paste it in the empty cell.
 
-**Expected:**
+### Expected:
 
 Image is copied, no rows or different elements are added.
 
-**Unexpected:**
+### Unexpected:
 
 Copying created additional row in table.
 
 ## Scenario 2:
 
+1. Undo changes.
 1. Fake select the first table cell.
 1. Copy it and paste in the second cell.
 
-**Expected:**
+### Expected:
 
-Image is copied and additional row is created.
+Image is copied, no rows or different elements are added.
 
-**Unexpected:**
+### Unexpected:
 
 Additional row didn't appear.
 
 ## Scenario 3:
 
-1. Fake select the first table cell.
-1. Copy it and paste after the table.
+1. Fake select both cells of table.
+1. Copy them and paste after the table.
 
-**Expected:**
+### Expected:
 
-New table with image in it appeared.
+New table with two cells appeared.
 
-**Unexpected:**
+### Unexpected:
 
 Only image without new table is pasted.
+
+## 2nd Editor:
+
+## Scenario 1:
+
+1. Select whole text in the first cell.
+1. Copy and paste in the second cell.
+
+### Expected:
+
+Formatted text is copied.
+
+### Unexpected:
+
+Text is not formatted.
+
+## Scenario 2:
+
+1. Undo changes.
+1. Fake select the first cell.
+1. Copy and paste in the second cell.
+
+### Expected:
+
+Only formatted text is copied without nesting new table.
+
+### Unexpected:
+
+Text is pasted into nested table.
+
+## Scenario 3:
+
+1. Undo changes.
+1. Copy **some** text from the first cell and paste it in the second one.
+
+### Expected:
+
+Formatted text is copied.
+
+### Unexpected:
+
+Text is not formatted.
+
+## 3rd Editor:
+
+## Scenario 1:
+
+1. Copy image from nested table.
+1. Paste it to another cell.
+
+### Expected:
+
+Image is copied, no rows or different elements are added.
+
+### Unexpected:
+
+Additional row didn't appear.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

`[#972](https://github.com/ckeditor/ckeditor-dev/issues/972): Fixed: Copy&Paste on a [table](https://ckeditor.com/cke4/addon/table) cell, creates new table row.`

## What changes did you make?

`Tableselection` plugin causes copied image to be wrapped into table, so now the content of `dataTransfer` object is filtered in given circumstances.

Closes #972.