### PR TITLE
WIP: Ticket-3336 enable reversal of context menu switching

### DIFF
--- a/plugins/contextmenu/plugin.js
+++ b/plugins/contextmenu/plugin.js
@@ -48,7 +48,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 				 * @param {Boolean} [nativeContextMenuOnCtrl] Whether to open native context menu if the
 				 * <kbd>Ctrl</kbd> key is held on opening the context menu. See {@link CKEDITOR.config#browserContextMenuOnCtrl}.
 				 */
-				addTarget: function( element, nativeContextMenuOnCtrl ) {
+				addTarget: function( element, contextMenuSwitchingEnabled, nativeContextMenuOnByDefault) {
 					var holdCtrlKey,
 						keystrokeActive;
 
@@ -59,8 +59,14 @@ CKEDITOR.plugins.add( 'contextmenu', {
 								// which make this property unreliable. (https://dev.ckeditor.com/ticket/4826)
 								( CKEDITOR.env.webkit ? holdCtrlKey : ( CKEDITOR.env.mac ? domEvent.$.metaKey : domEvent.$.ctrlKey ) );
 
-						if ( nativeContextMenuOnCtrl && isCtrlKeyDown ) {
-							return;
+						if ( contextMenuSwitchingEnabled ) {
+							if ( nativeContextMenuOnByDefault && !isCtrlKeyDown ) {
+								return;
+							}
+
+							if ( !nativeContextMenuOnByDefault  && isCtrlKeyDown ) {
+								return;
+							}
 						}
 
 						// Cancel the browser context menu.
@@ -163,7 +169,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 		var contextMenu = editor.contextMenu = new CKEDITOR.plugins.contextMenu( editor );
 
 		editor.on( 'contentDom', function() {
-			contextMenu.addTarget( editor.editable(), editor.config.browserContextMenuOnCtrl !== false );
+			contextMenu.addTarget( editor.editable(), editor.config.contextMenuSwitchingEnabled !== false ,editor.config.nativeContextMenuOnByDefault == false );
 		} );
 
 		editor.addCommand( 'contextMenu', {


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature / -->

## Does your PR contain necessary tests?

Work in progress: tests not added yet. 

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

Add an additional configuration option for the context menu plugin.
Allowing the reversal of which context menu is shown when. 

E.g
right-click = browser context menu
ctrl right-click = CKeditor context menu

## What changes did you make?

Added an extra parameter to the context menu plugin and use it to switch what context menu is shown by default.