### PR TITLE
Add "select" method to rich combo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ Fixed Issues:
 
 * [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) with form input elements loses focus during typing.
 
+API Changes:
+
+* [#3387](https://github.com/ckeditor/ckeditor-dev/issues/3387): Added the [CKEDITOR.ui.richCombo#select](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-select) method.
+
 ## CKEditor 4.13.1
 
 Fixed Issues:

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -120,7 +120,9 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * to this button will be appended to.
 			 */
 			render: function( editor, output ) {
-				var env = CKEDITOR.env;
+				var env = CKEDITOR.env,
+					instance,
+					selLocked;
 
 				var id = 'cke_' + this.id;
 				var clickFn = CKEDITOR.tools.addFunction( function( el ) {
@@ -133,7 +135,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 				}, this );
 
 				var combo = this;
-				var instance = {
+
+				instance = {
 					id: id,
 					combo: this,
 					focus: function() {
@@ -215,7 +218,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 					instance.onfocus && instance.onfocus();
 				} );
 
-				var selLocked = 0;
+				selLocked = 0;
 
 				// For clean up
 				instance.keyDownFn = keyDownFn;

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -402,21 +402,26 @@ CKEDITOR.plugins.add( 'richcombo', {
 			},
 
 			/**
-			 * Method expects that options object is provided with richcombo definitiont. Options should contain a key-value pairs mapping,
-			 * where key from mapping is a richcombo's value used to set its state and value from mapping is an entity related to it.
-			 * Most commonly as values will be stored CKEDITOR.styles definitions.
-			 * Callback function is used as a filter, which is run with each value as an argument, until it returns true. When matching value from mapping
-			 * is found, then related key is used to set up richcombo's value.
-			 * Function returns true if state of richcombo was set and false when matching wasn't found.
+			 * This method expects that the options object is provided with the richcombo definition. Options should contain a key-value pairs
+			 * mapping, where key from mapping is a richcombo's value used to set its state and value from mapping is an entity related to it.
+			 * Most commonly as this entity is stored {@link CKEDITOR.styles} definitions.
 			 *
-			 * @param {Function} callback function should return true if found matching element
-			 * @param {*} callback.value single element which is compared by this callback
+			 * The callback function is used as a filter, which is run with each entity as an argument until it returns the `true`.
+			 * When a matching entity is found, then the related key is used to set up the richcombo's value.
+			 *
+			 * The select method returns the `true` when matching is found and the value of a richcombo is set. The `false` is returned
+			 * when matching is not found. In case that richcombo already has set searching value `true` is returned as well.
+			 *
+			 * @since 4.13.0
+			 * @param {Function} callback function should return `true` if found matching element
+			 * @param {*} callback.value single entity which is compared by this callback
+			 * @returns {Boolean} Information if there is found matching and the value is set
 			 */
 			select: function( callback ) {
 				var property;
 
 				if ( !this.options || typeof this.options !== 'object' ) {
-					return;
+					return false;
 				}
 
 				for ( property in this.options ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -240,6 +240,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 				if ( this.onRender )
 					this.onRender();
 
+				this._.editor = editor;
+
 				return instance;
 			},
 
@@ -417,15 +419,15 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @param {*} callback.value single entity which is compared by this callback
 			 */
 			select: function( callback ) {
-				var property;
+				var value;
 
-				if ( typeof this.options !== 'object' ) {
-					return;
+				if ( CKEDITOR.tools.isEmpty( this._.items ) ) {
+					this.createPanel( this._.editor );
 				}
 
-				for ( property in this.options ) {
-					if ( callback( this.options[ property ] ) ) {
-						this.setValue( property );
+				for ( value in this._.items ) {
+					if ( callback( this._.items[ value ] ) ) {
+						this.setValue( value );
 						return;
 					}
 				}

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -419,7 +419,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			select: function( callback ) {
 				var property;
 
-				if ( !this.options || typeof this.options !== 'object' ) {
+				if ( typeof this.options !== 'object' ) {
 					return;
 				}
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -412,29 +412,23 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * The callback function is used as a filter, which is run with each entity as an argument until it returns the `true`.
 			 * When a matching entity is found, then the related key is used to set up the richcombo's value.
 			 *
-			 * The select method returns the `true` when matching is found and the value of a richcombo is set. The `false` is returned
-			 * when matching is not found. In case that richcombo already has set searching value `true` is returned as well.
-			 *
 			 * @since 4.13.0
 			 * @param {Function} callback function should return `true` if found matching element
 			 * @param {*} callback.value single entity which is compared by this callback
-			 * @returns {Boolean} Information if there is found matching and the value is set
 			 */
 			select: function( callback ) {
 				var property;
 
 				if ( !this.options || typeof this.options !== 'object' ) {
-					return false;
+					return;
 				}
 
 				for ( property in this.options ) {
 					if ( callback( this.options[ property ] ) ) {
 						this.setValue( property );
-						return true;
+						return;
 					}
 				}
-
-				return false;
 			}
 		},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -407,30 +407,34 @@ CKEDITOR.plugins.add( 'richcombo', {
 			},
 
 			/**
-			 * This method expects that the options object is provided with the richcombo definition. Options should contain a key-value pairs
-			 * mapping, where key from mapping is a richcombo's value used to set its state and value from mapping is an entity related to it.
-			 * Most commonly as this entity is stored {@link CKEDITOR.styles} definitions.
+			 * Selects richcombo item based on the first matching result from the given filter function.
+			 * Filter function takes an object as an argumnet with `value` and `text` fields. Values of those
+			 * fields match to argument passed in `CKEDITOR.ui.richcombo.add` method.
 			 *
-			 * The callback function is used as a filter, which is run with each entity as an argument until it returns the `true`.
-			 * When a matching entity is found, then the related key is used to set up the richcombo's value.
-			 *
-			 * @since 4.13.0
+			 * @since 4.14.0
 			 * @param {Function} callback function should return `true` if found matching element
-			 * @param {*} callback.value single entity which is compared by this callback
+			 * @param {*} callback.item object containing value and text fields which are compared by this callback
 			 */
 			select: function( callback ) {
-				var value;
-
 				if ( CKEDITOR.tools.isEmpty( this._.items ) ) {
 					this.createPanel( this._.editor );
 				}
 
-				for ( value in this._.items ) {
-					if ( callback( this._.items[ value ] ) ) {
-						this.setValue( value );
-						return;
+				this.select = function( callback ) {
+					var value;
+
+					for ( value in this._.items ) {
+						if ( callback( {
+							value: value,
+							text: this._.items[ value ]
+						} ) ) {
+							this.setValue( value );
+							return;
+						}
 					}
-				}
+				};
+
+				this.select( callback );
 			}
 		},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -240,8 +240,6 @@ CKEDITOR.plugins.add( 'richcombo', {
 				if ( this.onRender )
 					this.onRender();
 
-				this._.editor = editor;
-
 				return instance;
 			},
 
@@ -346,6 +344,13 @@ CKEDITOR.plugins.add( 'richcombo', {
 				this._.list.showAll();
 			},
 
+			/**
+			 * Adds entry displayed inside richcombo panel.
+			 *
+			 * @param {String} value
+			 * @param {String} html
+			 * @param {String} text
+			 */
 			add: function( value, html, text ) {
 				this._.items[ value ] = text || value;
 				this._.list.add( value, html, text );
@@ -409,32 +414,36 @@ CKEDITOR.plugins.add( 'richcombo', {
 			/**
 			 * Selects richcombo item based on the first matching result from the given filter function.
 			 * Filter function takes an object as an argumnet with `value` and `text` fields. Values of those
-			 * fields match to argument passed in `CKEDITOR.ui.richcombo.add` method.
+			 * fields match to argument passed in {@link #add} method.
+			 * In order to obtain correct result by this method, it's required to open or initialize the richcombo panel.
+			 *
+			 * 	var richCombo = editor.ui.get( 'Font' );
+			 *
+			 * 	// Required, when 'richcombo' was never open in given editor instance.
+			 * 	richCombo.createPanel( editor );
+			 *
+			 * 	richCombo.select( function( item ) {
+			 * 		return item.value === 'Tahoma' || item.text === 'Tahoma';
+			 * 	} );
 			 *
 			 * @since 4.14.0
 			 * @param {Function} callback function should return `true` if found matching element
-			 * @param {*} callback.item object containing value and text fields which are compared by this callback
+			 * @param {Object} callback.item object containing `value` and `text` fields which are compared by this callback
 			 */
 			select: function( callback ) {
 				if ( CKEDITOR.tools.isEmpty( this._.items ) ) {
-					this.createPanel( this._.editor );
+					return;
 				}
 
-				this.select = function( callback ) {
-					var value;
-
-					for ( value in this._.items ) {
-						if ( callback( {
-							value: value,
-							text: this._.items[ value ]
-						} ) ) {
-							this.setValue( value );
-							return;
-						}
+				for ( var value in this._.items ) {
+					if ( callback( {
+						value: value,
+						text: this._.items[ value ]
+					} ) ) {
+						this.setValue( value );
+						return;
 					}
-				};
-
-				this.select( callback );
+				}
 			}
 		},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -413,10 +413,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 
 			/**
 			 * Selects richcombo item based on the first matching result from the given filter function.
-			 * Filter function takes an object as an argumnet with `value` and `text` fields. Values of those
-			 * fields match to argument passed in {@link #add} method.
+			 * Filter function takes an object as an argument with `value` and `text` fields. Values of those
+			 * fields match to arguments passed in {@link #add} method.
 			 * In order to obtain correct result by this method, it's required to open or initialize the richcombo panel.
 			 *
+			 * ```javascript
 			 * 	var richCombo = editor.ui.get( 'Font' );
 			 *
 			 * 	// Required, when 'richcombo' was never open in given editor instance.
@@ -425,10 +426,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * 	richCombo.select( function( item ) {
 			 * 		return item.value === 'Tahoma' || item.text === 'Tahoma';
 			 * 	} );
+			 * ```
 			 *
 			 * @since 4.14.0
-			 * @param {Function} callback function should return `true` if found matching element
-			 * @param {Object} callback.item object containing `value` and `text` fields which are compared by this callback
+			 * @param {Function} callback Function should return `true` if found matching element.
+			 * @param {Object} callback.item Object containing `value` and `text` fields which are compared by this callback.
 			 */
 			select: function( callback ) {
 				if ( CKEDITOR.tools.isEmpty( this._.items ) ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -399,6 +399,34 @@ CKEDITOR.plugins.add( 'richcombo', {
 					listener.removeListener();
 				} );
 				this._.listeners = [];
+			},
+
+			/**
+			 * Method expects that options object is provided with richcombo definitiont. Options should contain a key-value pairs mapping,
+			 * where key from mapping is a richcombo's value used to set its state and value from mapping is an entity related to it.
+			 * Most commonly as values will be stored CKEDITOR.styles definitions.
+			 * Callback function is used as a filter, which is run with each value as an argument, until it returns true. When matching value from mapping
+			 * is found, then related key is used to set up richcombo's value.
+			 * Function returns true if state of richcombo was set and false when matching wasn't found.
+			 *
+			 * @param {Function} callback function should return true if found matching element
+			 * @param {*} callback.value single element which is compared by this callback
+			 */
+			select: function( callback ) {
+				var property;
+
+				if ( !this.options || typeof this.options !== 'object' ) {
+					return;
+				}
+
+				for ( property in this.options ) {
+					if ( callback( this.options[ property ] ) ) {
+						this.setValue( property );
+						return true;
+					}
+				}
+
+				return false;
 			}
 		},
 

--- a/tests/plugins/richcombo/manual/select.html
+++ b/tests/plugins/richcombo/manual/select.html
@@ -42,8 +42,8 @@
 	} );
 
 	function setComboValue( value ) {
-		combo.select( function( option ) {
-			return option === value;
+		combo.select( function( item ) {
+			return item.value === value;
 		} );
 	}
 

--- a/tests/plugins/richcombo/manual/select.html
+++ b/tests/plugins/richcombo/manual/select.html
@@ -1,5 +1,5 @@
 <h2>Classic editor</h2>
-<div id="classic">
+<div id="editor">
 	<p>I'm CKEditor 4 instance.</p>
 </div>
 <button onClick="setComboValue( 'one' )" >one</button>
@@ -7,41 +7,36 @@
 <button onClick="setComboValue( 'three' )" >three</button>
 
 <script>
-	var combo;
-	CKEDITOR.replace( 'classic', {
-		toolbar: [ [ 'custom_richcombo' ] ],
-		on: {
-			'pluginsLoaded': function( evt ) {
-				var editor = evt.editor,
-					items = {
-						'one': 'one',
-						'two': 'two',
-						'three': 'three'
-					}
-
-				editor.ui.addRichCombo( 'custom_richcombo', {
-					panel: {
-						css: [],
-						multiSelect: false
-					},
-					init: function() {
-						for ( var key in items ) {
-							this.add( key, items[ key ] );
+	var editor = CKEDITOR.replace( 'editor', {
+			toolbar: [ [ 'custom_richcombo' ] ],
+			on: {
+				'pluginsLoaded': function( evt ) {
+					var editor = evt.editor,
+						items = {
+							'one': 'one',
+							'two': 'two',
+							'three': 'three'
 						}
-					},
-					onClick: function() {},
-					onRender: function() {}
-				} );
-			},
-			'instanceReady': function( evt ) {
-				var editor = evt.editor;
 
-				combo = editor.ui.get( 'custom_richcombo' );
+					editor.ui.addRichCombo( 'custom_richcombo', {
+						panel: {
+							css: [],
+							multiSelect: false
+						},
+						init: function() {
+							for ( var key in items ) {
+								this.add( key, items[ key ] );
+							}
+						},
+						onClick: function() {},
+						onRender: function() {}
+					} );
+				}
 			}
-		}
-	} );
+		} );
 
 	function setComboValue( value ) {
+		var combo = editor.ui.get( 'custom_richcombo' );
 		combo.select( function( item ) {
 			return item.value === value;
 		} );

--- a/tests/plugins/richcombo/manual/select.html
+++ b/tests/plugins/richcombo/manual/select.html
@@ -37,6 +37,11 @@
 
 	function setComboValue( value ) {
 		var combo = editor.ui.get( 'custom_richcombo' );
+
+		if ( CKEDITOR.tools.isEmpty( combo._.items ) ) {
+			combo.createPanel( editor );
+		}
+
 		combo.select( function( item ) {
 			return item.value === value;
 		} );

--- a/tests/plugins/richcombo/manual/select.html
+++ b/tests/plugins/richcombo/manual/select.html
@@ -13,7 +13,7 @@
 		on: {
 			'pluginsLoaded': function( evt ) {
 				var editor = evt.editor,
-					options = {
+					items = {
 						'one': 'one',
 						'two': 'two',
 						'three': 'three'
@@ -24,10 +24,9 @@
 						css: [],
 						multiSelect: false
 					},
-					options: options,
 					init: function() {
-						for ( var key in options ) {
-							this.add( key, options[ key ] );
+						for ( var key in items ) {
+							this.add( key, items[ key ] );
 						}
 					},
 					onClick: function() {},
@@ -38,8 +37,6 @@
 				var editor = evt.editor;
 
 				combo = editor.ui.get( 'custom_richcombo' );
-
-				combo.createPanel( editor );
 			}
 		}
 	} );

--- a/tests/plugins/richcombo/manual/select.html
+++ b/tests/plugins/richcombo/manual/select.html
@@ -43,7 +43,7 @@
 		}
 
 		combo.select( function( item ) {
-			return item.value === value;
+			return item.value === value && item.text === value;
 		} );
 	}
 

--- a/tests/plugins/richcombo/manual/select.html
+++ b/tests/plugins/richcombo/manual/select.html
@@ -1,0 +1,53 @@
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>I'm CKEditor 4 instance.</p>
+</div>
+<button onClick="setComboValue( 'one' )" >one</button>
+<button onClick="setComboValue( 'two' )" >two</button>
+<button onClick="setComboValue( 'three' )" >three</button>
+
+<script>
+	var combo;
+	CKEDITOR.replace( 'classic', {
+		toolbar: [ [ 'custom_richcombo' ] ],
+		on: {
+			'pluginsLoaded': function( evt ) {
+				var editor = evt.editor,
+					options = {
+						'one': 'one',
+						'two': 'two',
+						'three': 'three'
+					}
+
+				editor.ui.addRichCombo( 'custom_richcombo', {
+					panel: {
+						css: [],
+						multiSelect: false
+					},
+					options: options,
+					init: function() {
+						for ( var key in options ) {
+							this.add( key, options[ key ] );
+						}
+					},
+					onClick: function() {},
+					onRender: function() {}
+				} );
+			},
+			'instanceReady': function( evt ) {
+				var editor = evt.editor;
+
+				combo = editor.ui.get( 'custom_richcombo' );
+
+				combo.createPanel( editor );
+			}
+		}
+	} );
+
+	function setComboValue( value ) {
+		combo.select( function( option ) {
+			return option === value;
+		} );
+	}
+
+</script>

--- a/tests/plugins/richcombo/manual/select.md
+++ b/tests/plugins/richcombo/manual/select.md
@@ -1,0 +1,16 @@
+@bender-ui: collapsed
+@bender-tags: 3387, 4.13.0, feature
+@bender-ckeditor-plugins: wysiwygarea, richcombo, toolbar
+
+## Procedure
+
+1. Click into buttons 'one', 'two', 'three'.
+2. Check how rich combo reacts on those buttons.
+
+### Expected result:
+
+The rich combo reflects the status of the clicked button.
+
+### Unexpected result
+
+The rich combo doesn't change.

--- a/tests/plugins/richcombo/manual/select.md
+++ b/tests/plugins/richcombo/manual/select.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 3387, 4.13.0, feature
+@bender-tags: 3387, 4.14.0, feature
 @bender-ckeditor-plugins: wysiwygarea, richcombo, toolbar
 
 ## Procedure

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -4,17 +4,49 @@
 var customCls = 'my_combo';
 bender.editor = {
 	config: {
-		toolbar: [ [ 'custom_combo' ] ],
+		toolbar: [ [ 'custom_combo', 'custom_combo_with_options' ] ],
 		on: {
 			pluginsLoaded: function( evt ) {
-				var ed = evt.editor;
+				var ed = evt.editor,
+					options = {
+						'one': {
+							style: 'one'
+						},
+						'two': {
+							style: 'two'
+						},
+						'three': {
+							style: 'three'
+						}
+					};
+
 				ed.ui.addRichCombo( 'custom_combo', {
 					className: customCls,
 					panel: {
 						css: [],
 						multiSelect: false
 					},
-					init: function() {},
+					init: function() {
+						for ( var key in options ) {
+							this.add( key, options[ key ].style );
+						}
+					},
+					onClick: function() {},
+					onRender: function() {}
+				} );
+
+				ed.ui.addRichCombo( 'custom_combo_with_options', {
+					className: customCls,
+					panel: {
+						css: [],
+						multiSelect: false
+					},
+					options: options,
+					init: function() {
+						for ( var key in options ) {
+							this.add( key, options[ key ].style );
+						}
+					},
 					onClick: function() {},
 					onRender: function() {}
 				} );
@@ -75,5 +107,42 @@ bender.test( {
 		spy.restore();
 
 		assert.areSame( 0, spy.callCount, 'rich combo was no opened' );
+	},
+
+	// (#3387)
+	'test richcombo.select() should select proper value in combo': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo_with_options' );
+
+		combo.createPanel( editor );
+
+		combo.setValue( 'one' );
+		assert.areEqual( 'one', combo.getValue() );
+
+		combo.select( function( option ) {
+			return option.style === 'three';
+		} );
+		assert.areEqual( 'three', combo.getValue() );
+
+		combo.select( function( option ) {
+			return option.style === 'three';
+		} );
+		assert.areEqual( 'three', combo.getValue() );
+	},
+
+	// (#3387)
+	'test richcombo.select() should do nothing for combo without options': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo' );
+
+		combo.createPanel( editor );
+
+		combo.setValue( 'one' );
+		assert.areEqual( 'one', combo.getValue() );
+
+		combo.select( function( option ) {
+			return option.style === 'three';
+		} );
+		assert.areEqual( 'one', combo.getValue() );
 	}
 } );

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -8,16 +8,10 @@ bender.editor = {
 		on: {
 			pluginsLoaded: function( evt ) {
 				var ed = evt.editor,
-					options = {
-						'one': {
-							style: 'one'
-						},
-						'two': {
-							style: 'two'
-						},
-						'three': {
-							style: 'three'
-						}
+					items = {
+						'one': 'ONE',
+						'two': 'TWO',
+						'three': 'THREE'
 					};
 
 				ed.ui.addRichCombo( 'custom_combo', {
@@ -26,11 +20,7 @@ bender.editor = {
 						css: [],
 						multiSelect: false
 					},
-					init: function() {
-						for ( var key in options ) {
-							this.add( key, options[ key ].style );
-						}
-					},
+					init: function() {},
 					onClick: function() {},
 					onRender: function() {}
 				} );
@@ -41,10 +31,9 @@ bender.editor = {
 						css: [],
 						multiSelect: false
 					},
-					options: options,
 					init: function() {
-						for ( var key in options ) {
-							this.add( key, options[ key ].style );
+						for ( var key in items ) {
+							this.add( key, '<span style="color:red">' + key + '</span>', items[ key ] );
 						}
 					},
 					onClick: function() {},
@@ -114,20 +103,18 @@ bender.test( {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo_with_options' );
 
-		combo.createPanel( editor );
-
 		combo.setValue( 'one' );
 		assert.areEqual( 'one', combo.getValue() );
 
-		combo.select( function( option ) {
-			return option.style === 'three';
+		combo.select( function( item ) {
+			return item.value === 'three';
 		} );
 		assert.areEqual( 'three', combo.getValue() );
 
-		combo.select( function( option ) {
-			return option.style === 'three';
+		combo.select( function( item ) {
+			return item.text === 'TWO';
 		} );
-		assert.areEqual( 'three', combo.getValue() );
+		assert.areEqual( 'two', combo.getValue() );
 	},
 
 	// (#3387)
@@ -135,13 +122,11 @@ bender.test( {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo' );
 
-		combo.createPanel( editor );
-
 		combo.setValue( 'one' );
 		assert.areEqual( 'one', combo.getValue() );
 
 		combo.select( function( option ) {
-			return option.style === 'three';
+			return option.value === 'three';
 		} );
 		assert.areEqual( 'one', combo.getValue() );
 	}

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -103,6 +103,8 @@ bender.test( {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo_with_options' );
 
+		combo.createPanel( editor );
+
 		combo.setValue( 'one' );
 		assert.areEqual( 'one', combo.getValue() );
 
@@ -121,6 +123,8 @@ bender.test( {
 	'test richcombo.select() should do nothing for combo without options': function() {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo' );
+
+		combo.createPanel( editor );
 
 		combo.setValue( 'one' );
 		assert.areEqual( 'one', combo.getValue() );


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
[#3387](https://github.com/ckeditor/ckeditor-dev/issues/3387): Added the [CKEDITOR.ui.richCombo#select](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-select) method.
```

## What changes did you make?

Add new method in richcombo to select proper value based on a callback function. 

Closes: #3387