### PR TITLE
Implement textColor and bgColor commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 New features:
 
 * [#2583](https://github.com/ckeditor/ckeditor-dev/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
+* [#3748](https://github.com/ckeditor/ckeditor-dev/issues/3748): Improved [Color Button](https://ckeditor.com/cke4/addon/colorbutton) state to reflect selected editor content colors.
 
 Fixed Issues:
 
@@ -14,7 +15,8 @@ Fixed Issues:
 API Changes:
 
 * [#3387](https://github.com/ckeditor/ckeditor-dev/issues/3387): Added the [CKEDITOR.ui.richCombo#select](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-select) method.
-
+* [#3306](https://github.com/ckeditor/ckeditor-dev/issues/3306): Added new commands `textColor` and `bgColor` which applies the selected color choosen by the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) plugin.
+ 
 ## CKEditor 4.13.1
 
 Fixed Issues:

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -105,6 +105,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				style = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ] ),
 				colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
 				colorData = { type: type },
+				defaultColorStyle = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ),
 				panelBlock;
 
 			editor.ui.add( name, CKEDITOR.UI_PANELBUTTON, {
@@ -231,11 +232,9 @@ CKEDITOR.plugins.add( 'colorbutton', {
 						return;
 					}
 
-					var newStyle = data.newStyle,
-						config = editor.config,
-						colorStyleTemplate = config[ 'colorButton_' + type + 'Style' ];
+					var newStyle = data.newStyle;
 
-					editor.removeStyle( new CKEDITOR.style( colorStyleTemplate, { color: 'inherit' } ) );
+					editor.removeStyle( defaultColorStyle );
 
 					editor.focus();
 
@@ -247,19 +246,13 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				}
 			} );
 
-			editor.once( 'instanceReady', function() {
-				var uiElement = editor.ui.get( name ),
-					command = editor.getCommand( commandName );
-
-				if ( !command || !uiElement ) {
+			editor.attachStyleStateChange( defaultColorStyle, function( state ) {
+				if ( editor.readOnly ) {
 					return;
 				}
 
-				if ( uiElement.state !== command.state ) {
-					command.setState( uiElement.state );
-				}
-
-				_registerStateSynchronization( command, uiElement );
+				editor.getCommand( commandName ).setState( state );
+				editor.ui.get( name ).setState( state );
 			} );
 		}
 
@@ -419,15 +412,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 		function normalizeColor( color ) {
 			// Replace 3-character hexadecimal notation with a 6-character hexadecimal notation (#1008).
 			return CKEDITOR.tools.normalizeHex( '#' + CKEDITOR.tools.convertRgbToHex( color || '' ) ).replace( /#/g, '' );
-		}
-
-		function _registerStateSynchronization( command, uiElement ) {
-			// The reverse order is not synchronized as we don't do it anywhere in the editor.
-			command.on( 'state', function() {
-				if ( this.state !== uiElement.getState() ) {
-					uiElement.setState( this.state );
-				}
-			} );
 		}
 	}
 } );

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
@@ -422,19 +422,12 @@ CKEDITOR.plugins.add( 'colorbutton', {
 		}
 
 		function _registerStateSynchronization( command, uiElement ) {
+			// The reverse order is not synchronized as we don't do it anywhere in the editor.
 			command.on( 'state', function() {
 				if ( this.state !== uiElement.getState() ) {
 					uiElement.setState( this.state );
 				}
 			} );
-
-			uiElement.setState = function( state ) {
-				uiElement.constructor.prototype.setState.call( uiElement, state );
-
-				if ( command.state !== state ) {
-					command.setState( state );
-				}
-			};
 		}
 	}
 } );

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -20,7 +20,12 @@ CKEDITOR.plugins.add( 'colorbutton', {
 			lang = editor.lang.colorbutton;
 
 		if ( !CKEDITOR.env.hc ) {
-			addButton( 'TextColor', 'fore', lang.textColorTitle, 10, {
+			addButton( {
+				name: 'TextColor',
+				type: 'fore',
+				commandName: 'textColor',
+				title: lang.textColorTitle,
+				order: 10,
 				contentTransformations: [
 					[
 						{
@@ -40,13 +45,13 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				]
 			} );
 
-			var bgOptions = {},
+			var contentTransformations,
 				normalizeBackground = editor.config.colorButton_normalizeBackground;
 
 			if ( normalizeBackground === undefined || normalizeBackground ) {
 				// If background contains only color, then we want to convert it into background-color so that it's
 				// correctly picked by colorbutton plugin.
-				bgOptions.contentTransformations = [
+				contentTransformations = [
 					[
 						{
 							// Transform span that specify background with color only to background-color.
@@ -80,17 +85,27 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				];
 			}
 
-			addButton( 'BGColor', 'back', lang.bgColorTitle, 20, bgOptions );
+			addButton( {
+				name: 'BGColor',
+				type: 'back',
+				commandName: 'bgColor',
+				title: lang.bgColorTitle,
+				order: 20,
+				contentTransformations: contentTransformations
+			} );
 		}
 
-		function addButton( name, type, title, order, options ) {
-			var style = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ] ),
+		function addButton( options ) {
+			var name = options.name,
+				type = options.type,
+				title = options.title,
+				order = options.order,
+				commandName = options.commandName,
+				contentTransformations = options.contentTransformations || {},
+				style = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ] ),
 				colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
 				colorData = { type: type },
-				panelBlock,
-				commandName = type === 'back' ? 'bgColor' : 'textColor';
-
-			options = options || {};
+				panelBlock;
 
 			editor.ui.add( name, CKEDITOR.UI_PANELBUTTON, {
 				label: title,
@@ -100,7 +115,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				toolbar: 'colors,' + order,
 				allowedContent: style,
 				requiredContent: style,
-				contentTransformations: options.contentTransformations,
+				contentTransformations: contentTransformations,
 
 				panel: {
 					css: CKEDITOR.skin.getPath( 'editor' ),

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -88,7 +88,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
 				colorData = { type: type },
 				panelBlock,
-				commandName = name.slice( 0, 2 ).toLowerCase() + name.slice( 2 );
+				commandName = type === 'back' ? 'bgColor' : 'textColor';
 
 			options = options || {};
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -106,7 +106,9 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
 				colorData = { type: type },
 				defaultColorStyle = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ),
-				panelBlock;
+				panelBlock,
+				uiElement,
+				command;
 
 			editor.ui.add( name, CKEDITOR.UI_PANELBUTTON, {
 				label: title,
@@ -246,13 +248,19 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				}
 			} );
 
+			command = editor.getCommand( commandName );
+			uiElement = editor.ui.get( name );
+
 			editor.attachStyleStateChange( defaultColorStyle, function( state ) {
 				if ( editor.readOnly ) {
 					return;
 				}
 
-				editor.getCommand( commandName ).setState( state );
-				editor.ui.get( name ).setState( state );
+				command.setState( state );
+
+				if ( uiElement ) {
+					uiElement.setState( state );
+				}
 			} );
 		}
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -280,17 +280,16 @@ CKEDITOR.plugins.add( 'colorbutton', {
 						return !( element.is( 'a' ) || element.getElementsByTag( 'a' ).count() ) || isUnstylable( element );
 					};
 
-
 				if ( color == '?' ) {
 					editor.getColorFromDialog( function( color ) {
 						if ( color ) {
-							colorStyle = new CKEDITOR.style( colorStyleTemplate, { color: color } );
+							colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: color } );
 
 							editor.execCommand( commandName, { newStyle: colorStyle } );
 						}
 					}, null, colorData );
 				} else {
-					colorStyle = new CKEDITOR.style( colorStyleTemplate, { color: color && '#' + color } );
+					colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: '#' + color } );
 
 					editor.execCommand( commandName, { newStyle: colorStyle } );
 				}

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -298,7 +298,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				if ( color == '?' ) {
 					editor.getColorFromDialog( function( color ) {
 						if ( color ) {
-							colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: color } );
+							colorStyle = new CKEDITOR.style( colorStyleTemplate, { color: color } );
 
 							editor.execCommand( commandName, { newStyle: colorStyle } );
 						}

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -129,17 +129,13 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				},
 
 				refresh: function( editor, path ) {
-					var newState;
-
 					if ( !defaultColorStyle.checkApplicable( path, editor, editor.activeFilter ) ) {
-						newState = CKEDITOR.TRISTATE_DISABLED;
+						this.setState( CKEDITOR.TRISTATE_DISABLED );
 					} else if ( defaultColorStyle.checkActive( path, editor ) ) {
-						newState = CKEDITOR.TRISTATE_ON;
+						this.setState( CKEDITOR.TRISTATE_ON );
 					} else {
-						newState = CKEDITOR.TRISTATE_OFF;
+						this.setState( CKEDITOR.TRISTATE_OFF );
 					}
-
-					this.setState( newState );
 				}
 			} );
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -106,8 +106,42 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
 				colorData = { type: type },
 				defaultColorStyle = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ),
-				panelBlock,
-				uiElement;
+				panelBlock;
+
+			editor.addCommand( commandName, {
+				contextSensitive: true,
+				exec: function( editor, data ) {
+					if ( editor.readOnly ) {
+						return;
+					}
+
+					var newStyle = data.newStyle;
+
+					editor.removeStyle( defaultColorStyle );
+
+					editor.focus();
+
+					if ( newStyle ) {
+						editor.applyStyle( newStyle );
+					}
+
+					editor.fire( 'saveSnapshot' );
+				},
+
+				refresh: function( editor, path ) {
+					var newState;
+
+					if ( !defaultColorStyle.checkApplicable( path, editor, editor.activeFilter ) ) {
+						newState = CKEDITOR.TRISTATE_DISABLED;
+					} else if ( defaultColorStyle.checkActive( path, editor ) ) {
+						newState = CKEDITOR.TRISTATE_ON;
+					} else {
+						newState = CKEDITOR.TRISTATE_OFF;
+					}
+
+					this.setState( newState );
+				}
+			} );
 
 			editor.ui.add( name, CKEDITOR.UI_PANELBUTTON, {
 				label: title,
@@ -226,49 +260,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 					return automaticColor;
 				}
-			} );
-
-			editor.addCommand( commandName, {
-				contextSensitive: true,
-				exec: function( editor, data ) {
-					if ( editor.readOnly ) {
-						return;
-					}
-
-					var newStyle = data.newStyle;
-
-					editor.removeStyle( defaultColorStyle );
-
-					editor.focus();
-
-					if ( newStyle ) {
-						editor.applyStyle( newStyle );
-					}
-
-					editor.fire( 'saveSnapshot' );
-				},
-
-				refresh: function( editor, path ) {
-					var newState;
-
-					if ( !defaultColorStyle.checkApplicable( path, editor, editor.activeFilter ) ) {
-						newState = CKEDITOR.TRISTATE_DISABLED;
-					} else if ( defaultColorStyle.checkActive( path, editor ) ) {
-						newState = CKEDITOR.TRISTATE_ON;
-					} else {
-						newState = CKEDITOR.TRISTATE_OFF;
-					}
-
-					this.setState( newState );
-
-					if ( uiElement ) {
-						uiElement.setState( newState );
-					}
-				}
-			} );
-
-			editor.on( 'instanceReady', function() {
-				uiElement = editor.ui.get( name );
 			} );
 		}
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -143,7 +143,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				label: title,
 				title: title,
 				command: commandName,
-				modes: { wysiwyg: 1 },
 				editorFocus: 0,
 				toolbar: 'colors,' + order,
 				allowedContent: style,

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -106,9 +106,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
 				colorData = { type: type },
 				defaultColorStyle = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ], { color: 'inherit' } ),
-				panelBlock,
-				uiElement,
-				command;
+				panelBlock;
 
 			editor.ui.add( name, CKEDITOR.UI_PANELBUTTON, {
 				label: title,
@@ -248,19 +246,23 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				}
 			} );
 
-			command = editor.getCommand( commandName );
-			uiElement = editor.ui.get( name );
+			editor.on( 'instanceReady', function() {
+				// Register state synchronization, when editor is fully initialized to have sure that UIElement exists.
+				var command = editor.getCommand( commandName ),
+					uiElement = editor.ui.get( name );
 
-			editor.attachStyleStateChange( defaultColorStyle, function( state ) {
-				if ( editor.readOnly ) {
-					return;
-				}
+				editor.attachStyleStateChange( defaultColorStyle, function( state ) {
+						if ( editor.readOnly ) {
+							return;
+						}
 
-				command.setState( state );
+						command.setState( state );
 
-				if ( uiElement ) {
-					uiElement.setState( state );
-				}
+						if ( uiElement ) {
+							uiElement.setState( state );
+						}
+					}
+				);
 			} );
 		}
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -40,7 +40,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				]
 			} );
 
-			var  bgOptions = {},
+			var bgOptions = {},
 				normalizeBackground = editor.config.colorButton_normalizeBackground;
 
 			if ( normalizeBackground === undefined || normalizeBackground ) {
@@ -178,7 +178,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 								element = element.getParent();
 							}
 
-							currentColor = normalizeColor( element.getComputedStyle( type == 'back' ? 'background-color' : 'color'  ) );
+							currentColor = normalizeColor( element.getComputedStyle( type == 'back' ? 'background-color' : 'color' ) );
 							finalColor = finalColor || currentColor;
 
 							if ( finalColor !== currentColor ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -278,8 +278,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				editor.focus();
 				editor.fire( 'saveSnapshot' );
 
-				var colorStyle,
-					colorStyleTemplate = editor.config[ 'colorButton_' + type + 'Style' ];
+				var colorStyleTemplate = editor.config[ 'colorButton_' + type + 'Style' ];
 
 				colorStyleTemplate.childRule = type == 'back' ?
 					function( element ) {
@@ -294,17 +293,20 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				if ( color == '?' ) {
 					editor.getColorFromDialog( function( color ) {
 						if ( color ) {
-							colorStyle = new CKEDITOR.style( colorStyleTemplate, { color: color } );
-
-							editor.execCommand( commandName, { newStyle: colorStyle } );
+							setColor( color );
 						}
 					}, null, colorData );
 				} else {
-					colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: '#' + color } );
-
-					editor.execCommand( commandName, { newStyle: colorStyle } );
+					setColor( color && '#' + color );
 				}
 			} );
+
+			function setColor( color ) {
+				var colorStyleTemplate = editor.config[ 'colorButton_' + type + 'Style' ],
+					colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: color } );
+
+				editor.execCommand( commandName, { newStyle: colorStyle } );
+			}
 
 			if ( config.colorButton_enableAutomatic !== false ) {
 				// Render the "Automatic" button.

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -293,12 +293,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 				}
 			} );
 
-			function setColor( color ) {
-				var colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: color } );
-
-				editor.execCommand( commandName, { newStyle: colorStyle } );
-			}
-
 			if ( config.colorButton_enableAutomatic !== false ) {
 				// Render the "Automatic" button.
 				output.push( '<a class="cke_colorauto" _cke_focus=1 hidefocus=true' +
@@ -369,6 +363,14 @@ CKEDITOR.plugins.add( 'colorbutton', {
 			output.push( '</tr></table>' );
 
 			return output.join( '' );
+
+			// ---- HELPERS ----
+
+			function setColor( color ) {
+				var colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: color } );
+
+				editor.execCommand( commandName, { newStyle: colorStyle } );
+			}
 		}
 
 		function isUnstylable( ele ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -363,8 +363,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 
 			return output.join( '' );
 
-			// ---- HELPERS ----
-
 			function setColor( color ) {
 				var colorStyle = color && new CKEDITOR.style( colorStyleTemplate, { color: color } );
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -182,12 +182,6 @@ CKEDITOR.plugins.add( 'colorbutton', {
 					keys[ 32 ] = 'click'; // SPACE
 				},
 
-				refresh: function() {
-					if ( !editor.activeFilter.check( style ) ) {
-						this.setState( CKEDITOR.TRISTATE_DISABLED );
-					}
-				},
-
 				// The automatic colorbox should represent the real color (https://dev.ckeditor.com/ticket/6010)
 				onOpen: function() {
 

--- a/plugins/panelbutton/plugin.js
+++ b/plugins/panelbutton/plugin.js
@@ -71,8 +71,9 @@ CKEDITOR.plugins.add( 'panelbutton', {
 				createPanel: function( editor ) {
 					var _ = this._;
 
-					if ( _.panel )
+					if ( _.panel ) {
 						return;
+					}
 
 					var panelDefinition = this._.panelDefinition,
 						panelBlockDefinition = this._.panelDefinition.block,
@@ -83,8 +84,9 @@ CKEDITOR.plugins.add( 'panelbutton', {
 						command = editor.getCommand( this.command );
 
 					panel.onShow = function() {
-						if ( me.className )
+						if ( me.className ) {
 							this.element.addClass( me.className + '_panel' );
+						}
 
 						me.setState( CKEDITOR.TRISTATE_ON );
 
@@ -92,13 +94,15 @@ CKEDITOR.plugins.add( 'panelbutton', {
 
 						me.editorFocus && editor.focus();
 
-						if ( me.onOpen )
+						if ( me.onOpen ) {
 							me.onOpen();
+						}
 					};
 
 					panel.onHide = function( preventOnClose ) {
-						if ( me.className )
+						if ( me.className ) {
 							this.element.getFirst().removeClass( me.className + '_panel' );
+						}
 
 						if ( command ) {
 							me.setStateFromCommand( command );
@@ -108,8 +112,9 @@ CKEDITOR.plugins.add( 'panelbutton', {
 
 						_.on = 0;
 
-						if ( !preventOnClose && me.onClose )
+						if ( !preventOnClose && me.onClose ) {
 							me.onClose();
+						}
 					};
 
 					panel.onEscape = function() {
@@ -117,8 +122,9 @@ CKEDITOR.plugins.add( 'panelbutton', {
 						me.document.getById( _.id ).focus();
 					};
 
-					if ( this.onBlock )
+					if ( this.onBlock ) {
 						this.onBlock( panel, block );
+					}
 
 					block.onHide = function() {
 						_.on = 0;

--- a/plugins/panelbutton/plugin.js
+++ b/plugins/panelbutton/plugin.js
@@ -104,7 +104,8 @@ CKEDITOR.plugins.add( 'panelbutton', {
 							this.element.getFirst().removeClass( me.className + '_panel' );
 						}
 
-						if ( command ) {
+						// Defined `modes` has priority over the command for a backward compatibility (#3727).
+						if ( !me.modes && command ) {
 							me.setStateFromCommand( command );
 						} else {
 							me.setState( me.modes && me.modes[ editor.mode ] ? CKEDITOR.TRISTATE_OFF : CKEDITOR.TRISTATE_DISABLED );
@@ -129,7 +130,8 @@ CKEDITOR.plugins.add( 'panelbutton', {
 					block.onHide = function() {
 						_.on = 0;
 
-						if ( me.command ) {
+						// Defined `modes` has priority over the command for a backward compatibility (#3727).
+						if ( !me.modes && me.command ) {
 							me.setStateFromCommand( command );
 						} else {
 							me.setState( CKEDITOR.TRISTATE_OFF );
@@ -138,7 +140,8 @@ CKEDITOR.plugins.add( 'panelbutton', {
 				},
 
 				render: function( editor, output ) {
-					if ( this.command ) {
+					// Defined `modes` has priority over the command for a backward compatibility (#3727).
+					if ( !this.modes && this.command ) {
 						var me = this;
 
 						editor.getCommand( this.command ).on( 'state', function() {

--- a/plugins/panelbutton/plugin.js
+++ b/plugins/panelbutton/plugin.js
@@ -139,19 +139,6 @@ CKEDITOR.plugins.add( 'panelbutton', {
 					};
 				},
 
-				render: function( editor, output ) {
-					// Defined `modes` has priority over the command for a backward compatibility (#3727).
-					if ( !this.modes && this.command ) {
-						var me = this;
-
-						editor.getCommand( this.command ).on( 'state', function() {
-							me.setStateFromCommand( this );
-						} );
-					}
-
-					return CKEDITOR.ui.button.prototype.render.call( this, editor, output );
-				},
-
 				setStateFromCommand: function( command ) {
 					this.setState( command.state );
 				}

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -49,7 +49,6 @@
 			collapsed = options.collapsed || false,
 			commandName = options.commandName;
 
-
 		editor.execCommand( commandName, { newStyle: newStyle } );
 
 		if ( collapsed ) {

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -463,32 +463,49 @@
 			} );
 		},
 
-		'test should synchronize state between text color command and text color panel': function() {
+		'test should update state of command and ui based on selection': function() {
 			var editor = this.editor,
-				colorPanel = editor.ui.get( 'TextColor' ),
-				command = editor.getCommand( 'textColor' );
+				bgCommand = editor.getCommand( 'bgColor' ),
+				textCommand = editor.getCommand( 'textColor' ),
+				bgUi = editor.ui.get( 'BGColor' ),
+				textUi = editor.ui.get( 'TextColor' );
 
-			command.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after disabling command.' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'Color panel should have disable state.' );
+			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#c0392b">[foo]</span></p>' );
 
-			command.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after off command.' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'Color panel should have off state.' );
-		},
+			assert.areEqual( CKEDITOR.TRISTATE_ON, textCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_ON, textUi.getState() );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgUi.getState() );
 
-		'test should synchronize state between background color command and background color panel': function() {
-			var editor = this.editor,
-				colorPanel = editor.ui.get( 'BGColor' ),
-				command = editor.getCommand( 'bgColor' );
+			bender.tools.selection.setWithHtml( editor, '<p><span style="background-color:#c0392b">[foo]</span></p>' );
 
-			command.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after disabling command.' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'Color panel should have disable state.' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, textCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, textUi.getState() );
+			assert.areEqual( CKEDITOR.TRISTATE_ON, bgCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_ON, bgUi.getState() );
 
-			command.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after off command.' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'Color panel should have off state.' );
+			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#ffffff"><span style="background-color:#c0392b">[foo]</span></span></p>' );
+
+			assert.areEqual( CKEDITOR.TRISTATE_ON, textCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_ON, textUi.getState() );
+			assert.areEqual( CKEDITOR.TRISTATE_ON, bgCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_ON, bgUi.getState() );
+
+			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
+
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, textCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, textUi.getState() );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgUi.getState() );
+
+			editor.setReadOnly();
+
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, textCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, textUi.getState() );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, bgCommand.state );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, bgUi.getState() );
+
+			editor.setReadOnly( false );
 		}
 	} );
 } )();

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -469,23 +469,23 @@
 				colorPanel = editor.ui.get( 'TextColor' ),
 				command = editor.getCommand( 'textColor' );
 
-			assert.areEqual( colorPanel.getState(), command.state, 'should have same initial state' );
+			assert.areEqual( colorPanel.getState(), command.state, 'Should have same initial state.' );
 
 			colorPanel.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after disabling color panel' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'command should have disbled state' );
+			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after disabling color panel.' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'Command should have disbled state.' );
 
 			colorPanel.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after off color panel' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'command should have off state' );
+			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after off color panel.' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'Command should have off state.' );
 
 			command.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after disabling command' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'color panel should have disable state' );
+			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after disabling command.' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'Color panel should have disable state.' );
 
 			command.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after off command' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'color panel should have off state' );
+			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after off command.' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'Color panel should have off state.' );
 		},
 
 		'test should synchronize state between background color command and background color panel': function() {
@@ -493,23 +493,23 @@
 				colorPanel = editor.ui.get( 'BGColor' ),
 				command = editor.getCommand( 'bgColor' );
 
-			assert.areEqual( colorPanel.getState(), command.state, 'should have same initial state' );
+			assert.areEqual( colorPanel.getState(), command.state, 'Should have same initial state.' );
 
 			colorPanel.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after disabling color panel' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'command should have disbled state' );
+			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after disabling color panel.' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'Command should have disbled state.' );
 
 			colorPanel.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after off color panel' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'command should have off state' );
+			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after off color panel.' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'Command should have off state.' );
 
 			command.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after disabling command' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'color panel should have disable state' );
+			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after disabling command.' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'Color panel should have disable state.' );
 
 			command.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after off command' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'color panel should have off state' );
+			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after off command.' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'Color panel should have off state.' );
 		}
 	} );
 } )();

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -38,32 +38,6 @@
 		'</ul>' +
 		'<p>^<u><em><strong>Formatted text.</strong></em></u>$</p>]';
 
-	function getStyleText( style ) {
-		return CKEDITOR.style.getStyleText( style.getDefinition() ).replace( ';', '' );
-	}
-
-	function assertColorCommand( options ) {
-		var expected = options.expected,
-			editor = options.editor,
-			newStyle = options.newStyle,
-			collapsed = options.collapsed || false,
-			commandName = options.commandName;
-
-		editor.execCommand( commandName, { newStyle: newStyle } );
-
-		if ( collapsed ) {
-			editor.insertText( 'ZWS' );
-		}
-
-		assert.isInnerHtmlMatching( expected, editor.editable().getHtml(), {
-			fixStyles: true
-		} );
-	}
-
-	function getFirstColorElement( panel ) {
-		return panel._.panel._.currentBlock.element.findOne( '.cke_colorbox' );
-	}
-
 	bender.test( {
 		tearDown: function() {
 			this.editor.setReadOnly( false );
@@ -510,6 +484,32 @@
 			editor.setReadOnly( false );
 		}
 	} );
+
+	function getStyleText( style ) {
+		return CKEDITOR.style.getStyleText( style.getDefinition() ).replace( ';', '' );
+	}
+
+	function assertColorCommand( options ) {
+		var expected = options.expected,
+			editor = options.editor,
+			newStyle = options.newStyle,
+			collapsed = options.collapsed || false,
+			commandName = options.commandName;
+
+		editor.execCommand( commandName, { newStyle: newStyle } );
+
+		if ( collapsed ) {
+			editor.insertText( 'ZWS' );
+		}
+
+		assert.isInnerHtmlMatching( expected, editor.editable().getHtml(), {
+			fixStyles: true
+		} );
+	}
+
+	function getFirstColorElement( panel ) {
+		return panel._.panel._.currentBlock.element.findOne( '.cke_colorbox' );
+	}
 
 	function assertColorButtonStates( editor, options ) {
 		var bgCommand = editor.getCommand( 'bgColor' ),

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -46,7 +46,6 @@
 		var expected = options.expected,
 			editor = options.editor,
 			newStyle = options.newStyle,
-			message = options.message,
 			collapsed = options.collapsed || false,
 			commandName = options.commandName;
 
@@ -59,7 +58,7 @@
 
 		assert.isInnerHtmlMatching( expected, editor.editable().getHtml(), {
 			fixStyles: true
-		}, message );
+		} );
 	}
 
 	function getFirstColorElement( panel ) {

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -62,6 +62,10 @@
 		}, message );
 	}
 
+	function getFirstColorElement( panel ) {
+		return panel._.panel._.currentBlock.element.findOne( '.cke_colorbox' );
+	}
+
 	bender.test( {
 		tearDown: function() {
 			this.editor.setReadOnly( false );
@@ -413,6 +417,100 @@
 					.replace( /\$/g, '</span>' ),
 				newStyle: RED_BG
 			} );
+		},
+
+		'test color button should exec text color command': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				spy = sinon.spy( editor.getCommand( 'textColor' ), 'exec' );
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			bot.panel( 'TextColor', function( panel ) {
+				try {
+					var firstColorElement = getFirstColorElement( panel );
+
+					firstColorElement.$.click();
+
+					spy.restore();
+
+					sinon.assert.calledOnce( spy );
+					assert.pass();
+				} finally {
+					panel.hide();
+				}
+			} );
+		},
+
+		'test color button should exec background color command': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				spy = sinon.spy( editor.getCommand( 'bgColor' ), 'exec' );
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			bot.panel( 'BGColor', function( panel ) {
+				try {
+					var firstColorElement = getFirstColorElement( panel );
+
+					firstColorElement.$.click();
+
+					spy.restore();
+
+					sinon.assert.calledOnce( spy );
+					assert.pass();
+				} finally {
+					panel.hide();
+				}
+			} );
+		},
+
+		'test should synchronize state between text color command and text color panel': function() {
+			var editor = this.editor,
+				colorPanel = editor.ui.get( 'TextColor' ),
+				command = editor.getCommand( 'textColor' );
+
+			assert.areEqual( colorPanel.getState(), command.state, 'should have same initial state' );
+
+			colorPanel.setState( CKEDITOR.TRISTATE_DISABLED );
+			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after disabling color panel' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'command should have disbled state' );
+
+			colorPanel.setState( CKEDITOR.TRISTATE_OFF );
+			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after off color panel' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'command should have off state' );
+
+			command.setState( CKEDITOR.TRISTATE_DISABLED );
+			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after disabling command' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'color panel should have disable state' );
+
+			command.setState( CKEDITOR.TRISTATE_OFF );
+			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after off command' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'color panel should have off state' );
+		},
+
+		'test should synchronize state between background color command and background color panel': function() {
+			var editor = this.editor,
+				colorPanel = editor.ui.get( 'BGColor' ),
+				command = editor.getCommand( 'bgColor' );
+
+			assert.areEqual( colorPanel.getState(), command.state, 'should have same initial state' );
+
+			colorPanel.setState( CKEDITOR.TRISTATE_DISABLED );
+			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after disabling color panel' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'command should have disbled state' );
+
+			colorPanel.setState( CKEDITOR.TRISTATE_OFF );
+			assert.areEqual( colorPanel.getState(), command.state, 'should have same state after off color panel' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'command should have off state' );
+
+			command.setState( CKEDITOR.TRISTATE_DISABLED );
+			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after disabling command' );
+			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'color panel should have disable state' );
+
+			command.setState( CKEDITOR.TRISTATE_OFF );
+			assert.areEqual( command.state, colorPanel.getState(), 'should have same state after off command' );
+			assert.areEqual( CKEDITOR.TRISTATE_OFF, colorPanel.getState(), 'color panel should have off state' );
 		}
 	} );
 } )();

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -468,16 +468,6 @@
 				colorPanel = editor.ui.get( 'TextColor' ),
 				command = editor.getCommand( 'textColor' );
 
-			assert.areEqual( colorPanel.getState(), command.state, 'Should have same initial state.' );
-
-			colorPanel.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after disabling color panel.' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'Command should have disbled state.' );
-
-			colorPanel.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after off color panel.' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'Command should have off state.' );
-
 			command.setState( CKEDITOR.TRISTATE_DISABLED );
 			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after disabling command.' );
 			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, colorPanel.getState(), 'Color panel should have disable state.' );
@@ -491,16 +481,6 @@
 			var editor = this.editor,
 				colorPanel = editor.ui.get( 'BGColor' ),
 				command = editor.getCommand( 'bgColor' );
-
-			assert.areEqual( colorPanel.getState(), command.state, 'Should have same initial state.' );
-
-			colorPanel.setState( CKEDITOR.TRISTATE_DISABLED );
-			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after disabling color panel.' );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, command.state, 'Command should have disbled state.' );
-
-			colorPanel.setState( CKEDITOR.TRISTATE_OFF );
-			assert.areEqual( colorPanel.getState(), command.state, 'Should have same state after off color panel.' );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, command.state, 'Command should have off state.' );
 
 			command.setState( CKEDITOR.TRISTATE_DISABLED );
 			assert.areEqual( command.state, colorPanel.getState(), 'Should have same state after disabling command.' );

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -1,0 +1,418 @@
+/* bender-tags: colorbuttons */
+/* bender-ckeditor-plugins: colorbutton,toolbar,wysiwygarea,basicstyles,table,list */
+/* bender-ui: collapsed */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	var textColor_style_template = {
+			element: 'span',
+			styles: { 'color': '#(color)' }
+		},
+		bgColor_style_template = {
+			element: 'span',
+			styles: { 'background-color': '#(color)' }
+		},
+		RED_TEXT = new CKEDITOR.style( textColor_style_template, { color: '#FF0000' } ),
+		GREEN_TEXT = new CKEDITOR.style( textColor_style_template, { color: '#00FF00' } ),
+		RED_BG = new CKEDITOR.style( bgColor_style_template, { color: '#FF0000' } ),
+		GREEN_BG = new CKEDITOR.style( bgColor_style_template, { color: '#00FF00' } ),
+		CONTENT_TEMPLATE = '[<p>^test$@</p>' +
+		'<table border="1" cellpadding="1" cellspacing="1" style="width:500px">' +
+			'<tbody>' +
+				'<tr>' +
+					'<td>^one$</td>' +
+					'<td>^two$</td>' +
+				'</tr>' +
+				'<tr>' +
+					'<td>^three$</td>' +
+					'<td>^four$</td>' +
+				'</tr>' +
+			'</tbody>' +
+		'</table>' +
+		'<ul>' +
+			'<li>^item1$</li>' +
+			'<li>^item2$</li>' +
+		'</ul>' +
+		'<p>^<u><em><strong>Formatted text.</strong></em></u>$</p>]';
+
+	function getStyleText( style ) {
+		return CKEDITOR.style.getStyleText( style.getDefinition() ).replace( ';', '' );
+	}
+
+	function assertColorCommand( options ) {
+		var expected = options.expected,
+			editor = options.editor,
+			newStyle = options.newStyle,
+			message = options.message,
+			collapsed = options.collapsed || false,
+			commandName = options.commandName;
+
+
+		editor.execCommand( commandName, { newStyle: newStyle } );
+
+		if ( collapsed ) {
+			editor.insertText( 'ZWS' );
+		}
+
+		assert.isInnerHtmlMatching( expected, editor.editable().getHtml(), {
+			fixStyles: true
+		}, message );
+	}
+
+	bender.test( {
+		tearDown: function() {
+			this.editor.setReadOnly( false );
+		},
+
+		'test should apply text color': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p><span style="' + getStyleText( RED_TEXT ) + '">foo</span>@</p>',
+				newStyle: RED_TEXT
+			} );
+		},
+
+		'test should override existing text color': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( GREEN_TEXT ) + '">{foo}</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p><span style="' + getStyleText( RED_TEXT ) + '">foo</span>@</p>',
+				newStyle: RED_TEXT
+			} );
+		},
+
+		'test should split element with text color command and override only selected fragment': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( RED_TEXT ) + '">fo{o}</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p><span style="' + getStyleText( RED_TEXT ) + '">fo</span><span style="' + getStyleText( GREEN_TEXT ) + '">o</span>@</p>',
+				newStyle: GREEN_TEXT
+			} );
+		},
+
+		'test should remove text color, when newStyle is null': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( GREEN_TEXT ) + '">{foo}</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>foo@</p>',
+				newStyle: null
+			} );
+		},
+
+		'test should add empty span with text color style for collapsed selection': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>f{}oo</p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>f<span style="' + getStyleText( RED_TEXT ) + '">ZWS</span>oo@</p>',
+				newStyle: RED_TEXT,
+				collapsed: true
+			} );
+		},
+
+		'test should remove wrapping color and add empty span with text color style for collapsed selection': function() {
+			// This is bug behaviour, expected value in test should be corrected after fixing #2932.
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( RED_TEXT ) + '">f{}oo</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>f<span style="' + getStyleText( GREEN_TEXT ) + '">ZWS</span>oo@</p>',
+				newStyle: GREEN_TEXT,
+				collapsed: true
+			} );
+		},
+
+		'test should not nest text color': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( RED_TEXT ) + '">f{o}o</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>' +
+						'<span style="' + getStyleText( RED_TEXT ) + '">f</span>' +
+						'<span style="' + getStyleText( GREEN_TEXT ) + '">o</span>' +
+						'<span style="' + getStyleText( RED_TEXT ) + '">o</span>@' +
+					'</p>',
+				newStyle: GREEN_TEXT
+			} );
+		},
+
+		'test should merge text colors into one': function() {
+			// Safari doesn't merge nodes.
+			if ( CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
+
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>' +
+				'<span style="' + getStyleText( RED_TEXT ) + '">f</span>' +
+				'{o}' +
+				'<span style="' + getStyleText( RED_TEXT ) + '">o</span>' +
+			'</p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>' +
+						'<span style="' + getStyleText( RED_TEXT ) + '">foo</span>@' +
+					'</p>',
+				newStyle: RED_TEXT
+			} );
+		},
+
+		'test should be possible to cancel text color command': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			editor.once( 'beforeCommandExec', function( evt ) {
+				if ( evt.data.name === 'textColor' ) {
+					evt.cancel();
+				} else {
+					assert.fail( 'There was called wrong command: ' + evt.data.name );
+				}
+			} );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>foo@</p>',
+				newStyle: RED_TEXT
+			} );
+		},
+
+		'test should not apply new text color when editor is in readonly mode': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			editor.setReadOnly( true );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: '<p>foo@</p>',
+				newStyle: RED_TEXT
+			} );
+		},
+
+		'test should apply text color command to multiple different elements': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, CONTENT_TEMPLATE.replace( /[\^\$@]/g, '' ) );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'textColor',
+				expected: CONTENT_TEMPLATE
+					.replace( /[\[\]]/g, '' )
+					.replace( /\^/g, '<span style="' + getStyleText( RED_TEXT ) + '">' )
+					.replace( /\$/g, '</span>' ),
+				newStyle: RED_TEXT
+			} );
+		},
+
+		'test should apply background color': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p><span style="' + getStyleText( RED_BG ) + '">foo</span>@</p>',
+				newStyle: RED_BG
+			} );
+		},
+
+		'test should override existing background color': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( GREEN_BG ) + '">{foo}</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p><span style="' + getStyleText( RED_BG ) + '">foo</span>@</p>',
+				newStyle: RED_BG
+			} );
+		},
+
+		'test should split element background color command and override only selected fragment': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( RED_BG ) + '">fo{o}</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p><span style="' + getStyleText( RED_BG ) + '">fo</span><span style="' + getStyleText( GREEN_BG ) + '">o</span>@</p>',
+				newStyle: GREEN_BG
+			} );
+		},
+
+		'test should remove background color, when newStyle is null': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( GREEN_BG ) + '">{foo}</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>foo@</p>',
+				newStyle: null
+			} );
+		},
+
+		'test should add empty span with background color style for collapsed selection': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>f{}oo</p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>f<span style="' + getStyleText( RED_BG ) + '">ZWS</span>oo@</p>',
+				newStyle: RED_BG,
+				collapsed: true
+			} );
+		},
+
+		'test should remove wrapping color and add empty span with background color style for collapsed selection': function() {
+			// This is bug behaviour, expected value in test should be corrected after fixing #2932.
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( RED_BG ) + '">f{}oo</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>f<span style="' + getStyleText( GREEN_BG ) + '">ZWS</span>oo@</p>',
+				newStyle: GREEN_BG,
+				collapsed: true
+			} );
+		},
+
+		'test should not nest background color': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="' + getStyleText( RED_BG ) + '">f{o}o</span></p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>' +
+						'<span style="' + getStyleText( RED_BG ) + '">f</span>' +
+						'<span style="' + getStyleText( GREEN_BG ) + '">o</span>' +
+						'<span style="' + getStyleText( RED_BG ) + '">o</span>@' +
+					'</p>',
+				newStyle: GREEN_BG
+			} );
+		},
+
+		'test should merge background colors into one': function() {
+			// Safari doesn't merge nodes.
+			if ( CKEDITOR.env.safari ) {
+				assert.ignore();
+			}
+
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>' +
+				'<span style="' + getStyleText( RED_BG ) + '">f</span>' +
+				'{o}' +
+				'<span style="' + getStyleText( RED_BG ) + '">o</span>' +
+			'</p>' );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>' +
+						'<span style="' + getStyleText( RED_BG ) + '">foo</span>@' +
+					'</p>',
+				newStyle: RED_BG
+			} );
+		},
+
+		'test should be possible to cancel background color command': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			editor.once( 'beforeCommandExec', function( evt ) {
+				if ( evt.data.name === 'bgColor' ) {
+					evt.cancel();
+				} else {
+					assert.fail( 'There was called wrong command: ' + evt.data.name );
+				}
+			} );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>foo@</p>',
+				newStyle: RED_BG
+			} );
+		},
+
+		'test should not apply new background color when editor is in readonly mode': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, '<p>{foo}</p>' );
+
+			editor.setReadOnly( true );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: '<p>foo@</p>',
+				newStyle: RED_BG
+			} );
+		},
+
+		'test should apply background color command to multiple different elements': function() {
+			var editor = this.editor;
+
+			bender.tools.selection.setWithHtml( editor, CONTENT_TEMPLATE.replace( /[\^\$@]/g, '' ) );
+
+			assertColorCommand( {
+				editor: editor,
+				commandName: 'bgColor',
+				expected: CONTENT_TEMPLATE
+					.replace( /[\[\]]/g, '' )
+					.replace( /\^/g, '<span style="' + getStyleText( RED_BG ) + '">' )
+					.replace( /\$/g, '</span>' ),
+				newStyle: RED_BG
+			} );
+		}
+	} );
+} )();

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -464,48 +464,36 @@
 		},
 
 		'test should update state of command and ui based on selection': function() {
-			var editor = this.editor,
-				bgCommand = editor.getCommand( 'bgColor' ),
-				textCommand = editor.getCommand( 'textColor' ),
-				bgUi = editor.ui.get( 'BGColor' ),
-				textUi = editor.ui.get( 'TextColor' );
-
-			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#c0392b">[foo]</span></p>' );
-
-			assert.areEqual( CKEDITOR.TRISTATE_ON, textCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_ON, textUi.getState() );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgUi.getState() );
-
-			bender.tools.selection.setWithHtml( editor, '<p><span style="background-color:#c0392b">[foo]</span></p>' );
-
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, textCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, textUi.getState() );
-			assert.areEqual( CKEDITOR.TRISTATE_ON, bgCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_ON, bgUi.getState() );
-
-			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#ffffff"><span style="background-color:#c0392b">[foo]</span></span></p>' );
-
-			assert.areEqual( CKEDITOR.TRISTATE_ON, textCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_ON, textUi.getState() );
-			assert.areEqual( CKEDITOR.TRISTATE_ON, bgCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_ON, bgUi.getState() );
+			var editor = this.editor;
 
 			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
+			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_OFF );
 
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, textCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, textUi.getState() );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_OFF, bgUi.getState() );
+			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#c0392b">[foo]</span></p>' );
+			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_ON, CKEDITOR.TRISTATE_OFF );
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="background-color:#c0392b">[foo]</span></p>' );
+			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_ON );
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#ffffff"><span style="background-color:#c0392b">[foo]</span></span></p>' );
+			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_ON, CKEDITOR.TRISTATE_ON );
 
 			editor.setReadOnly();
-
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, textCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, textUi.getState() );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, bgCommand.state );
-			assert.areEqual( CKEDITOR.TRISTATE_DISABLED, bgUi.getState() );
+			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_DISABLED, CKEDITOR.TRISTATE_DISABLED );
 
 			editor.setReadOnly( false );
 		}
 	} );
+
+	function assertColorbuttonStates( editor, textColorState, bgColorState ) {
+		var bgCommand = editor.getCommand( 'bgColor' ),
+			textCommand = editor.getCommand( 'textColor' ),
+			bgUi = editor.ui.get( 'BGColor' ),
+			textUi = editor.ui.get( 'TextColor' );
+
+		assert.areEqual( textColorState, textCommand.state );
+		assert.areEqual( textColorState, textUi.getState() );
+		assert.areEqual( bgColorState, bgCommand.state );
+		assert.areEqual( bgColorState, bgUi.getState() );
+	}
 } )();

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -469,7 +469,7 @@
 
 			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
 			bot.fireSelectionChange();
-			assertColorbuttonStates( editor, {
+			assertColorButtonStates( editor, {
 				textColorState: CKEDITOR.TRISTATE_OFF,
 				bgColorState: CKEDITOR.TRISTATE_OFF,
 				message: 'Text OFF, background OFF'
@@ -477,7 +477,7 @@
 
 			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#c0392b">[foo]</span></p>' );
 			bot.fireSelectionChange();
-			assertColorbuttonStates( editor, {
+			assertColorButtonStates( editor, {
 				textColorState: CKEDITOR.TRISTATE_ON,
 				bgColorState: CKEDITOR.TRISTATE_OFF,
 				message: 'Text ON, background OFF'
@@ -485,7 +485,7 @@
 
 			bender.tools.selection.setWithHtml( editor, '<p><span style="background-color:#c0392b">[foo]</span></p>' );
 			bot.fireSelectionChange();
-			assertColorbuttonStates( editor, {
+			assertColorButtonStates( editor, {
 				textColorState: CKEDITOR.TRISTATE_OFF,
 				bgColorState: CKEDITOR.TRISTATE_ON,
 				message: 'Text OFF, background ON'
@@ -493,7 +493,7 @@
 
 			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#ffffff"><span style="background-color:#c0392b">[foo]</span></span></p>' );
 			bot.fireSelectionChange();
-			assertColorbuttonStates( editor, {
+			assertColorButtonStates( editor, {
 				textColorState: CKEDITOR.TRISTATE_ON,
 				bgColorState: CKEDITOR.TRISTATE_ON,
 				message: 'Text ON, background ON'
@@ -501,7 +501,7 @@
 
 			editor.setReadOnly();
 
-			assertColorbuttonStates( editor, {
+			assertColorButtonStates( editor, {
 				textColorState: CKEDITOR.TRISTATE_DISABLED,
 				bgColorState: CKEDITOR.TRISTATE_DISABLED,
 				message: 'Text DISABLED, background DISABLED'
@@ -511,7 +511,7 @@
 		}
 	} );
 
-	function assertColorbuttonStates( editor, options ) {
+	function assertColorButtonStates( editor, options ) {
 		var bgCommand = editor.getCommand( 'bgColor' ),
 			textCommand = editor.getCommand( 'textColor' ),
 			bgUi = editor.ui.get( 'BGColor' ),

--- a/tests/plugins/colorbutton/colorcommand.js
+++ b/tests/plugins/colorbutton/colorcommand.js
@@ -464,36 +464,63 @@
 		},
 
 		'test should update state of command and ui based on selection': function() {
-			var editor = this.editor;
+			var editor = this.editor,
+				bot = this.editorBot;
 
 			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
-			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_OFF );
+			bot.fireSelectionChange();
+			assertColorbuttonStates( editor, {
+				textColorState: CKEDITOR.TRISTATE_OFF,
+				bgColorState: CKEDITOR.TRISTATE_OFF,
+				message: 'Text OFF, background OFF'
+			} );
 
 			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#c0392b">[foo]</span></p>' );
-			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_ON, CKEDITOR.TRISTATE_OFF );
+			bot.fireSelectionChange();
+			assertColorbuttonStates( editor, {
+				textColorState: CKEDITOR.TRISTATE_ON,
+				bgColorState: CKEDITOR.TRISTATE_OFF,
+				message: 'Text ON, background OFF'
+			} );
 
 			bender.tools.selection.setWithHtml( editor, '<p><span style="background-color:#c0392b">[foo]</span></p>' );
-			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_OFF, CKEDITOR.TRISTATE_ON );
+			bot.fireSelectionChange();
+			assertColorbuttonStates( editor, {
+				textColorState: CKEDITOR.TRISTATE_OFF,
+				bgColorState: CKEDITOR.TRISTATE_ON,
+				message: 'Text OFF, background ON'
+			} );
 
 			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#ffffff"><span style="background-color:#c0392b">[foo]</span></span></p>' );
-			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_ON, CKEDITOR.TRISTATE_ON );
+			bot.fireSelectionChange();
+			assertColorbuttonStates( editor, {
+				textColorState: CKEDITOR.TRISTATE_ON,
+				bgColorState: CKEDITOR.TRISTATE_ON,
+				message: 'Text ON, background ON'
+			} );
 
 			editor.setReadOnly();
-			assertColorbuttonStates( editor, CKEDITOR.TRISTATE_DISABLED, CKEDITOR.TRISTATE_DISABLED );
+
+			assertColorbuttonStates( editor, {
+				textColorState: CKEDITOR.TRISTATE_DISABLED,
+				bgColorState: CKEDITOR.TRISTATE_DISABLED,
+				message: 'Text DISABLED, background DISABLED'
+			} );
 
 			editor.setReadOnly( false );
 		}
 	} );
 
-	function assertColorbuttonStates( editor, textColorState, bgColorState ) {
+	function assertColorbuttonStates( editor, options ) {
 		var bgCommand = editor.getCommand( 'bgColor' ),
 			textCommand = editor.getCommand( 'textColor' ),
 			bgUi = editor.ui.get( 'BGColor' ),
-			textUi = editor.ui.get( 'TextColor' );
+			textUi = editor.ui.get( 'TextColor' ),
+			message = options.message;
 
-		assert.areEqual( textColorState, textCommand.state );
-		assert.areEqual( textColorState, textUi.getState() );
-		assert.areEqual( bgColorState, bgCommand.state );
-		assert.areEqual( bgColorState, bgUi.getState() );
+		assert.areEqual( options.textColorState, textCommand.state, message + ' (textColor command)' );
+		assert.areEqual( options.textColorState, textUi.getState(), message + ' (textColor ui)' );
+		assert.areEqual( options.bgColorState, bgCommand.state, message + ' (bgColor command)' );
+		assert.areEqual( options.bgColorState, bgUi.getState(), message + ' (bgColor ui)' );
 	}
 } )();

--- a/tests/plugins/colorbutton/colorcommandnoui.js
+++ b/tests/plugins/colorbutton/colorcommandnoui.js
@@ -1,0 +1,31 @@
+/* bender-tags: colorbuttons */
+/* bender-ckeditor-plugins: colorbutton,toolbar,wysiwygarea */
+/* bender-ui: collapsed */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		name: 'classic',
+		config: {
+			removeButtons: 'TextColor,BGColor',
+			allowedContent: true
+		}
+	};
+
+	bender.test( {
+		'test should not throw error when buttons are not present in the toolbar': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
+
+			bender.tools.selection.setWithHtml( editor, '<p><span style="color:#ffffff"><span style="background-color:#c0392b">[foo]</span></span></p>' );
+
+			// There should be no error after selection change, which triggers editor.attachStyleStateChange()
+			bot.fireSelectionChange();
+
+			// There should be no registered ui element.
+			assert.isUndefined( editor.ui.get( 'TextColor' ) );
+			assert.isUndefined( editor.ui.get( 'BGColor' ) );
+		}
+	} );
+} )();

--- a/tests/plugins/colorbutton/manual/colorcommand.html
+++ b/tests/plugins/colorbutton/manual/colorcommand.html
@@ -1,0 +1,25 @@
+<div id="editor">
+	<p>This is unstyled text.</p>
+
+	<p><span style="color:#c0392b">This text has font color.</span></p>
+
+	<p><span style="background-color:#f39c12">This text has background color.</span></p>
+</div>
+
+<script>
+	var index = 1;
+	CKEDITOR.replace( 'editor', {
+		height: 400,
+		on: {
+			'beforeCommandExec': function( evt ) {
+				if ( evt.data.name === 'textColor' || evt.data.name === 'bgColor' ) {
+					var message = index++ + '. "' + evt.data.name + '" command is executed.';
+					evt.editor.showNotification( message );
+					if ( console ) {
+						console.log( message );
+					}
+				}
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/colorcommand.html
+++ b/tests/plugins/colorbutton/manual/colorcommand.html
@@ -63,7 +63,7 @@
 			message += ' which applies style: "' + styleName +'" with value: "' + styleValue + '".';
 		}
 
-		if ( console ) {
+		if ( window.console ) {
 			console.log( message );
 		}
 

--- a/tests/plugins/colorbutton/manual/colorcommand.html
+++ b/tests/plugins/colorbutton/manual/colorcommand.html
@@ -52,8 +52,7 @@
 	function updateOuterContainer( commandName, newStyle ) {
 		var styleName = commandName === 'textColor' ? 'color' : 'background-color',
 			styleValue,
-			message = index++ + '. "' + commandName + '" command is executed';
-
+			message = index + '. "' + commandName + '" command is executed';
 
 		if ( !newStyle ) {
 			colorIndicator.removeStyle( styleName );
@@ -69,5 +68,7 @@
 		}
 
 		messageElement.setText( message );
+
+		index++;
 	}
 </script>

--- a/tests/plugins/colorbutton/manual/colorcommand.html
+++ b/tests/plugins/colorbutton/manual/colorcommand.html
@@ -1,3 +1,22 @@
+<style>
+	#color-indicator {
+		min-width: 100px;
+		min-height: 60px;
+		box-shadow: 0 0 0 5px yellow;
+		outline: dashed 5px black;
+		padding: 15px;
+	}
+
+	#color-indicator p {
+		margin-top: 25px;
+		margin-left: 25px;
+	}
+
+	#message {
+		padding: 5px;
+		border: 1px solid red;
+	}
+</style>
 <div id="editor">
 	<p>This is unstyled text.</p>
 
@@ -6,20 +25,49 @@
 	<p><span style="background-color:#f39c12">This text has background color.</span></p>
 </div>
 
+<div>
+	<p>There is a color indicator below, which shows color recently applied in the editor.</p>
+	<p id="message">Here will be present information about executed command.</p>
+	<div id="color-indicator">
+		<p><strong>This is a test text to present applied text color in this box.</strong></p>
+	</div>
+</div>
+
 <script>
-	var index = 1;
-	CKEDITOR.replace( 'editor', {
+	var index = 1,
+		colorIndicator = new CKEDITOR.dom.element( document.getElementById( 'color-indicator' ) ),
+		messageElement = new CKEDITOR.dom.element( document.getElementById( 'message' ) );
+
+	var editor = CKEDITOR.replace( 'editor', {
 		height: 400,
 		on: {
 			'beforeCommandExec': function( evt ) {
 				if ( evt.data.name === 'textColor' || evt.data.name === 'bgColor' ) {
-					var message = index++ + '. "' + evt.data.name + '" command is executed.';
-					evt.editor.showNotification( message );
-					if ( console ) {
-						console.log( message );
-					}
+					updateOuterContainer( evt.data.name, evt.data.commandData.newStyle );
 				}
 			}
 		}
 	} );
+
+	function updateOuterContainer( commandName, newStyle ) {
+		var styleName = commandName === 'textColor' ? 'color' : 'background-color',
+			styleValue,
+			message = index++ + '. "' + commandName + '" command is executed';
+
+
+		if ( !newStyle ) {
+			colorIndicator.removeStyle( styleName );
+			message += ' which removes style: "' + styleName +'".';
+		} else {
+			styleValue = newStyle.getDefinition().styles[ styleName ];
+			colorIndicator.setStyle( styleName, styleValue );
+			message += ' which applies style: "' + styleName +'" with value: "' + styleValue + '".';
+		}
+
+		if ( console ) {
+			console.log( message );
+		}
+
+		messageElement.setText( message );
+	}
 </script>

--- a/tests/plugins/colorbutton/manual/colorcommand.md
+++ b/tests/plugins/colorbutton/manual/colorcommand.md
@@ -1,0 +1,13 @@
+@bender-tags: feature, 4.13.0, 3306
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, notification
+@bender-ui: collapsed
+
+1. Try to apply and remove colors from text.
+2. You can create additional elements like list, tables, basicstyles etc. and try to apply colors with them.
+
+### Expected:
+* Each color change shows notification in editor and console, that appropriate command was run.
+
+### Unexpected:
+* Text or background color change is not applied.
+* There is no related notification aboute execution a command.

--- a/tests/plugins/colorbutton/manual/colorcommand.md
+++ b/tests/plugins/colorbutton/manual/colorcommand.md
@@ -1,4 +1,4 @@
-@bender-tags: feature, 4.13.0, 3306
+@bender-tags: feature, 4.14.0, 3306
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, notification
 @bender-ui: collapsed
 

--- a/tests/plugins/colorbutton/manual/colorcommand.md
+++ b/tests/plugins/colorbutton/manual/colorcommand.md
@@ -2,12 +2,13 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, notification
 @bender-ui: collapsed
 
-1. Try to apply and remove colors from text.
+1. Try to apply and remove text and background colors on text.
 2. You can create additional elements like list, tables, basicstyles etc. and try to apply colors with them.
 
 ### Expected:
-* Each color change shows notification in editor and console, that appropriate command was run.
+* Each color change has information in the red box below the editor, about type of the command, and style which is applied or removed.
+* Visual representation in box with black-yellow dashes changes according to last command changes.
 
 ### Unexpected:
 * Text or background color change is not applied.
-* There is no related notification aboute execution a command.
+* There is no related information or visual representation change.

--- a/tests/plugins/colorbutton/manual/colorcommand.md
+++ b/tests/plugins/colorbutton/manual/colorcommand.md
@@ -1,5 +1,5 @@
 @bender-tags: feature, 4.14.0, 3306
-@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, elementspath, htmlwriter
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, elementspath, htmlwriter, undo, colordialog
 @bender-ui: collapsed
 
 1. Try to apply and remove text and background colors on text.

--- a/tests/plugins/colorbutton/manual/colorcommand.md
+++ b/tests/plugins/colorbutton/manual/colorcommand.md
@@ -1,5 +1,5 @@
 @bender-tags: feature, 4.14.0, 3306
-@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, notification
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, elementspath, htmlwriter
 @bender-ui: collapsed
 
 1. Try to apply and remove text and background colors on text.

--- a/tests/plugins/colorbutton/manual/colorcommandwithwidget.html
+++ b/tests/plugins/colorbutton/manual/colorcommandwithwidget.html
@@ -1,0 +1,60 @@
+<style>
+	#read-only {
+		margin-top: 20px;
+		margin-bottom: 20px;
+	}
+</style>
+<button id="read-only">Toggle read-only</button>
+<div id="editor">
+	<p>Lorem ipsum dolor sit <span style="background-color:#f39c12">amet</span>, consectetur adipiscing elit. <span style="color:#f1c40f"><span style="background-color:#8e44ad">Aenean</span></span> dapibus pulvinar commodo. Proin rutrum <span style="color:#27ae60">dapibus</span> turpis ut iaculis. Nam iaculis sed ante vel consequat. Pellentesque facilisis eleifend semper. Nullam sed lectus nunc. Aliquam dapibus vel justo in rhoncus. Etiam placerat feugiat ante, vel fringilla nunc sagittis eget. <span style="color:#c0392b">Aliquam auctor dui at malesuada tempor.</span> Vestibulum ac <span style="background-color:#1abc9c">malesuada massa.</span> Curabitur et justo mattis, porta diam ac, gravida sapien. <span style="background-color:#bdc3c7">Sed aliquet nisl eu leo dignissim</span>, a feugiat lectus dictum. Aenean vel quam sit amet turpis tincidunt tempor. In hac habitasse platea dictumst.</p>
+	<div class="testwidget">
+		<div class="col1"><p> </p></div>
+		<div class="col2"><p> </p></div>
+		<div class="col3"><p> </p></div>
+	</div>
+	<p>Praesent nec malesuada risus, <span style="color:#3498db"><span style="background-color:#f1c40f">ac viverra metus.</span></span> Ut blandit blandit enim non commodo. <span style="color:#ffffff"><span style="background-color:#000000">Curabitur condimentum lectus porttitor</span></span> felis scelerisque pellentesque. Sed scelerisque arcu lorem, ut commodo nunc elementum et. <span style="color:#f39c12">In suscipit odio eu accumsan elementum.</span> Nullam eget ornare enim, blandit aliquet magna. <span style="background-color:#3498db">Praesent euismod risus eget</span> velit faucibus, et mattis leo convallis. <span style="color:#8e44ad">Maecenas nec elementum urna.</span> Pellentesque eget tortor consectetur, <span style="background-color:#e74c3c">venenatis ligula ut,</span> posuere est.</p>
+</div>
+
+<script>
+	CKEDITOR.addCss( '.testwidget {	border: 1px dashed #AAAAFF;	} .col1, .col2, .col3 { border: 1px dashed #AA9090; margin: 5px; }' );
+	CKEDITOR.plugins.add( 'testWidget', {
+		requires: 'widget',
+		button: 'testWidget',
+		init: function( editor ) {
+			editor.widgets.add( 'testWidget', {
+				button: 'testWidget',
+				template: '<div class="testwidget">' +
+						'<div class="col1"></div>' +
+						'<div class="col2"></div>' +
+						'<div class="col3"></div>' +
+					'</div>',
+				editables: {
+					col1: {
+						selector: '.col1',
+						allowedContent: 'p'
+					},
+					col2: {
+						selector: '.col2',
+						allowedContent: 'p;span{color}'
+					},
+					col3: {
+						selector: '.col3'
+					}
+				},
+				upcast: function( element ) {
+					return element.hasClass( 'testwidget' );
+				}
+			} );
+		}
+	} );
+
+	var editor = CKEDITOR.replace( 'editor', {
+		height: 400,
+		allowedContent: true,
+		extraPlugins: 'testWidget'
+	} );
+
+	document.getElementById( 'read-only' ).addEventListener( 'click', function() {
+		editor.setReadOnly( !editor.readOnly );
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/colorcommandwithwidget.html
+++ b/tests/plugins/colorbutton/manual/colorcommandwithwidget.html
@@ -54,7 +54,7 @@
 		extraPlugins: 'testWidget'
 	} );
 
-	document.getElementById( 'read-only' ).addEventListener( 'click', function() {
+	CKEDITOR.document.getById( 'read-only' ).on( 'click', function() {
 		editor.setReadOnly( !editor.readOnly );
 	} );
 </script>

--- a/tests/plugins/colorbutton/manual/colorcommandwithwidget.html
+++ b/tests/plugins/colorbutton/manual/colorcommandwithwidget.html
@@ -8,15 +8,15 @@
 <div id="editor">
 	<p>Lorem ipsum dolor sit <span style="background-color:#f39c12">amet</span>, consectetur adipiscing elit. <span style="color:#f1c40f"><span style="background-color:#8e44ad">Aenean</span></span> dapibus pulvinar commodo. Proin rutrum <span style="color:#27ae60">dapibus</span> turpis ut iaculis. Nam iaculis sed ante vel consequat. Pellentesque facilisis eleifend semper. Nullam sed lectus nunc. Aliquam dapibus vel justo in rhoncus. Etiam placerat feugiat ante, vel fringilla nunc sagittis eget. <span style="color:#c0392b">Aliquam auctor dui at malesuada tempor.</span> Vestibulum ac <span style="background-color:#1abc9c">malesuada massa.</span> Curabitur et justo mattis, porta diam ac, gravida sapien. <span style="background-color:#bdc3c7">Sed aliquet nisl eu leo dignissim</span>, a feugiat lectus dictum. Aenean vel quam sit amet turpis tincidunt tempor. In hac habitasse platea dictumst.</p>
 	<div class="testwidget">
-		<div class="col1"><p> </p></div>
-		<div class="col2"><p> </p></div>
-		<div class="col3"><p> </p></div>
+		<div class="row1"><p> </p></div>
+		<div class="row2"><p> </p></div>
+		<div class="row3"><p> </p></div>
 	</div>
 	<p>Praesent nec malesuada risus, <span style="color:#3498db"><span style="background-color:#f1c40f">ac viverra metus.</span></span> Ut blandit blandit enim non commodo. <span style="color:#ffffff"><span style="background-color:#000000">Curabitur condimentum lectus porttitor</span></span> felis scelerisque pellentesque. Sed scelerisque arcu lorem, ut commodo nunc elementum et. <span style="color:#f39c12">In suscipit odio eu accumsan elementum.</span> Nullam eget ornare enim, blandit aliquet magna. <span style="background-color:#3498db">Praesent euismod risus eget</span> velit faucibus, et mattis leo convallis. <span style="color:#8e44ad">Maecenas nec elementum urna.</span> Pellentesque eget tortor consectetur, <span style="background-color:#e74c3c">venenatis ligula ut,</span> posuere est.</p>
 </div>
 
 <script>
-	CKEDITOR.addCss( '.testwidget {	border: 1px dashed #AAAAFF;	} .col1, .col2, .col3 { border: 1px dashed #AA9090; margin: 5px; }' );
+	CKEDITOR.addCss( '.testwidget {	border: 1px dashed #AAAAFF;	} .row1, .row2, .row3 { border: 1px dashed #AA9090; margin: 5px; }' );
 	CKEDITOR.plugins.add( 'testWidget', {
 		requires: 'widget',
 		button: 'testWidget',
@@ -24,21 +24,21 @@
 			editor.widgets.add( 'testWidget', {
 				button: 'testWidget',
 				template: '<div class="testwidget">' +
-						'<div class="col1"></div>' +
-						'<div class="col2"></div>' +
-						'<div class="col3"></div>' +
+						'<div class="row1"></div>' +
+						'<div class="row2"></div>' +
+						'<div class="row3"></div>' +
 					'</div>',
 				editables: {
-					col1: {
-						selector: '.col1',
+					row1: {
+						selector: '.row1',
 						allowedContent: 'p'
 					},
-					col2: {
-						selector: '.col2',
+					row2: {
+						selector: '.row2',
 						allowedContent: 'p;span{color}'
 					},
-					col3: {
-						selector: '.col3'
+					row3: {
+						selector: '.row3'
 					}
 				},
 				upcast: function( element ) {

--- a/tests/plugins/colorbutton/manual/colorcommandwithwidget.md
+++ b/tests/plugins/colorbutton/manual/colorcommandwithwidget.md
@@ -1,5 +1,5 @@
 @bender-tags: feature, 4.14.0, 3306
-@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, elementspath, htmlwriter
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, elementspath, htmlwriter, undo, colordialog
 @bender-ui: collapsed
 
 ## Test case 1:

--- a/tests/plugins/colorbutton/manual/colorcommandwithwidget.md
+++ b/tests/plugins/colorbutton/manual/colorcommandwithwidget.md
@@ -1,14 +1,30 @@
 @bender-tags: feature, 4.14.0, 3306
-@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, notification
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, elementspath, htmlwriter
 @bender-ui: collapsed
 
-1. Try to apply and remove text and background colors on text.
-2. You can create additional elements like list, tables, basicstyles etc. and try to apply colors with them.
+## Test case 1:
+1. Move caret in different position inside text.
+2. Verify if color buttons change state according to current selection.
+3. Switch to readonly mode
 
 ### Expected:
-* Each color change has information in the red box below the editor, about type of the command, and style which is applied or removed.
-* Visual representation in box with black-yellow dashes changes according to last command changes.
+* Color button state is ON, when color panel is open. Regardless of current selection.
+* When color panel is closed:
+  * Color button state is ON, when selection is inside text with proper style
+  * Color button state is OFF, when selection is outside of text with proper style
+* Color button state is DISABLED, when editor is in readonly mode
 
 ### Unexpected:
-* Text or background color change is not applied.
-* There is no related information or visual representation change.
+* Color button state is not coherent with state in the editor.
+
+## Test case 2:
+1. Move caret to the widget. (If there is no widget add new one with the empty button in the toolbar).
+2. Move caret inside each of 3 rows inside widget and check ui state.
+
+### Expected:
+* in 1st row color buttons are disabled - only paragraph element is allowed
+* in 2nd row textColor button is enbaled and backgroundColor button is disabled - only paragraph and span{color} is allowed
+* in 3rd row both collor buttons are enabled - there is no restriction to the editable content
+
+### Unexpected:
+* Color buttons are enabled in wrong sections

--- a/tests/plugins/colorbutton/manual/colorcommandwithwidget.md
+++ b/tests/plugins/colorbutton/manual/colorcommandwithwidget.md
@@ -1,0 +1,14 @@
+@bender-tags: feature, 4.14.0, 3306
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, basicstyles, table, tableselection, list, sourcearea, notification
+@bender-ui: collapsed
+
+1. Try to apply and remove text and background colors on text.
+2. You can create additional elements like list, tables, basicstyles etc. and try to apply colors with them.
+
+### Expected:
+* Each color change has information in the red box below the editor, about type of the command, and style which is applied or removed.
+* Visual representation in box with black-yellow dashes changes according to last command changes.
+
+### Unexpected:
+* Text or background color change is not applied.
+* There is no related information or visual representation change.

--- a/tests/plugins/panelbutton/command.js
+++ b/tests/plugins/panelbutton/command.js
@@ -13,11 +13,23 @@
 
 			editor.ui.add( 'testPanel', CKEDITOR.UI_PANELBUTTON, {
 				command: 'testCommand',
+				panel: {
+					attributes: {}
+				}
+			} );
+
+			editor.addCommand( 'testCommand2', {
+				exec: function() {}
+			} );
+
+			editor.ui.add( 'testPanel2', CKEDITOR.UI_PANELBUTTON, {
+				command: 'testCommand2',
 				modes: { wysiwyg: 1 },
 				panel: {
 					attributes: {}
 				}
 			} );
+
 		}
 	} );
 
@@ -58,6 +70,21 @@
 			assert.areSame( CKEDITOR.TRISTATE_DISABLED, testPanel.getState(), 'Tristate DISABLED' );
 		},
 
+		'test closed panelbutton should use mode state when is available and not react on command state changes': function() {
+			var editor = this.editor,
+				testPanel = editor.ui.get( 'testPanel2' ),
+				testCommand = editor.getCommand( 'testCommand2' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_OFF );
+			assert.areSame( CKEDITOR.TRISTATE_OFF, testPanel.getState(), 'Tristate OFF (1)' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_ON );
+			assert.areSame( CKEDITOR.TRISTATE_OFF, testPanel.getState(), 'Tristate OFF (2)' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_DISABLED );
+			assert.areSame( CKEDITOR.TRISTATE_OFF, testPanel.getState(), 'Tristate OFF (3)' );
+		},
+
 		'test panelbutton should restore command state after panel hide': function() {
 			var editor = this.editor,
 				bot = this.editorBot,
@@ -70,6 +97,21 @@
 				panel.hide();
 
 				assert.areSame( CKEDITOR.TRISTATE_ON, testPanel.getState(), '"testPanel" should have same state as command after closing it' );
+			} );
+		},
+
+		'test panelbutton should restore state from the modes after panel hide and do not use the command state': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				testPanel = editor.ui.get( 'testPanel2' ),
+				testCommand = editor.getCommand( 'testCommand2' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_ON );
+
+			bot.panel( 'testPanel', function( panel ) {
+				panel.hide();
+
+				assert.areSame( CKEDITOR.TRISTATE_OFF, testPanel.getState(), '"testPanel" should have state obtaiend from the modes not the command' );
 			} );
 		}
 	} );

--- a/tests/plugins/panelbutton/command.js
+++ b/tests/plugins/panelbutton/command.js
@@ -1,0 +1,76 @@
+/* bender-tags: panelbutton, command */
+/* bender-ckeditor-plugins: panelbutton,floatpanel,toolbar,wysiwygarea */
+
+( function() {
+	'use strict';
+
+	CKEDITOR.plugins.add( 'testPlugin', {
+		requires: 'panelbutton,floatpanel',
+		init: function( editor ) {
+			editor.addCommand( 'testCommand', {
+				exec: function() {}
+			} );
+
+			editor.ui.add( 'testPanel', CKEDITOR.UI_PANELBUTTON, {
+				command: 'testCommand',
+				modes: { wysiwyg: 1 },
+				panel: {
+					attributes: {}
+				}
+			} );
+		}
+	} );
+
+	bender.editor = {
+		name: 'classic',
+		config: {
+			extraPlugins: 'testPlugin'
+		}
+	};
+
+	bender.test( {
+		'test panelbutton should have "ON" state when is opened': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				testPanel = editor.ui.get( 'testPanel' ),
+				testCommand = editor.getCommand( 'testCommand' );
+
+			assert.areSame( CKEDITOR.TRISTATE_OFF, testCommand.state, '"testCommand" state should be OFF after initialization' );
+
+			bot.panel( 'testPanel', function( panel ) {
+				assert.areSame( CKEDITOR.TRISTATE_ON, testPanel.getState(), '"testPanel" state should be switched to ON when panel is beeing opened' );
+				panel.hide();
+			} );
+		},
+
+		'test closed panelbutton should have the same state as command': function() {
+			var editor = this.editor,
+				testPanel = editor.ui.get( 'testPanel' ),
+				testCommand = editor.getCommand( 'testCommand' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_OFF );
+			assert.areSame( CKEDITOR.TRISTATE_OFF, testPanel.getState(), 'Tristate OFF' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_ON );
+			assert.areSame( CKEDITOR.TRISTATE_ON, testPanel.getState(), 'Tristate ON' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_DISABLED );
+			assert.areSame( CKEDITOR.TRISTATE_DISABLED, testPanel.getState(), 'Tristate DISABLED' );
+		},
+
+		'test panelbutton should restore command state after panel hide': function() {
+			var editor = this.editor,
+				bot = this.editorBot,
+				testPanel = editor.ui.get( 'testPanel' ),
+				testCommand = editor.getCommand( 'testCommand' );
+
+			testCommand.setState( CKEDITOR.TRISTATE_ON );
+
+			bot.panel( 'testPanel', function( panel ) {
+				panel.hide();
+
+				assert.areSame( CKEDITOR.TRISTATE_ON, testPanel.getState(), '"testPanel" should have same state as command after closing it' );
+			} );
+		}
+	} );
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3306](https://github.com/ckeditor/ckeditor-dev/issues/3306): Added new commands `textColor` and `bgColro` which applies the selected color from color panel.
```

## What changes did you make?

* extract logic which applies color to a command.

Closes #3727
Closes #3748