### PR TITLE
Add additonal check for lastSel existence

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -814,8 +814,10 @@
 				// On Webkit&Gecko (#1113) we use focusout which is fired more often than blur. I.e. it will also be
 				// fired when nested editable is blurred.
 				editable.attachListener( editable, CKEDITOR.env.webkit || CKEDITOR.env.gecko ? 'focusout' : 'blur', function() {
+					var isFakeOrSingleSelection = lastSel && ( lastSel.isFake || lastSel.getRanges() < 2 );
+
 					// Ignore cases that doesn't produce issue in Firefox (#3136).
-					if ( CKEDITOR.env.gecko && !isInline && ( lastSel.isFake || lastSel.getRanges() < 2 ) ) {
+					if ( CKEDITOR.env.gecko && !isInline && isFakeOrSingleSelection ) {
 						return;
 					}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

No changelog entry is needed.

## What changes did you make?

I've added additional check if `lastSel` is set. The only situation, in which is not set, is in http://tests.ckeditor.test:1030/tests/core/editable/insertelement where `CKEDITOR.dom.selection.prototype` is overridden.

Closes #3408.
