### PR TITLE
Fix for menu items with double quotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#3415](https://github.com/ckeditor/ckeditor4/issues/3415): [Firefox] Fixed: Pasting individual list elements fails. Thanks to [Jack Wickham](https://github.com/jackwickham)!
+* [#3413](https://github.com/ckeditor/ckeditor4/issues/3413): Fixed: Menu items with labels containing double quotes are rendered incorrectly.
 
 ## CKEditor 4.13
 

--- a/plugins/menu/plugin.js
+++ b/plugins/menu/plugin.js
@@ -88,7 +88,7 @@ CKEDITOR.plugins.add( 'menu', {
 		' _cke_focus=1' +
 		' hidefocus="true"' +
 		' role="{role}"' +
-		' aria-label="{label}"' +
+		' aria-label="{attrLabel}"' +
 		' aria-describedby="{id}_description"' +
 		' aria-haspopup="{hasPopup}"' +
 		' aria-disabled="{disabled}"' +
@@ -540,28 +540,32 @@ CKEDITOR.plugins.add( 'menu', {
 					}
 				}
 
-				var params = {
-					id: id,
-					name: this.name,
-					iconName: iconName,
-					label: this.label,
-					cls: this.className || '',
-					state: stateName,
-					hasPopup: hasSubMenu ? 'true' : 'false',
-					disabled: state == CKEDITOR.TRISTATE_DISABLED,
-					title: this.label + ( shortcut ? ' (' + shortcut.display + ')' : '' ),
-					ariaShortcut: shortcut ? editor.lang.common.keyboardShortcut + ' ' + shortcut.aria : '',
-					href: 'javascript:void(\'' + ( this.label || '' ).replace( "'" + '' ) + '\')', // jshint ignore:line
-					hoverFn: menu._.itemOverFn,
-					moveOutFn: menu._.itemOutFn,
-					clickFn: menu._.itemClickFn,
-					index: index,
-					iconStyle: CKEDITOR.skin.getIconStyle( iconName, ( this.editor.lang.dir == 'rtl' ), iconName == this.icon ? null : this.icon, this.iconOffset ),
-					shortcutHtml: shortcut ? menuShortcutTpl.output( { shortcut: shortcut.display } ) : '',
-					arrowHtml: hasSubMenu ? menuArrowTpl.output( { label: arrowLabel } ) : '',
-					role: this.role ? this.role : 'menuitem',
-					ariaChecked: ariaChecked
-				};
+				// We must escape label for use inside attributes to not close them
+				// too early by using double quotes inside label (#3413).
+				var attrLabel = CKEDITOR.tools.htmlEncodeAttr( this.label ),
+					params = {
+						id: id,
+						name: this.name,
+						iconName: iconName,
+						label: this.label,
+						attrLabel: attrLabel,
+						cls: this.className || '',
+						state: stateName,
+						hasPopup: hasSubMenu ? 'true' : 'false',
+						disabled: state == CKEDITOR.TRISTATE_DISABLED,
+						title: attrLabel + ( shortcut ? ' (' + shortcut.display + ')' : '' ),
+						ariaShortcut: shortcut ? editor.lang.common.keyboardShortcut + ' ' + shortcut.aria : '',
+						href: 'javascript:void(\'' + ( attrLabel || '' ).replace( "'" + '' ) + '\')', // jshint ignore:line
+						hoverFn: menu._.itemOverFn,
+						moveOutFn: menu._.itemOutFn,
+						clickFn: menu._.itemClickFn,
+						index: index,
+						iconStyle: CKEDITOR.skin.getIconStyle( iconName, ( this.editor.lang.dir == 'rtl' ), iconName == this.icon ? null : this.icon, this.iconOffset ),
+						shortcutHtml: shortcut ? menuShortcutTpl.output( { shortcut: shortcut.display } ) : '',
+						arrowHtml: hasSubMenu ? menuArrowTpl.output( { label: arrowLabel } ) : '',
+						role: this.role ? this.role : 'menuitem',
+						ariaChecked: ariaChecked
+					};
 
 				menuItemTpl.output( params, output );
 			}

--- a/tests/plugins/menu/manual/quotes.html
+++ b/tests/plugins/menu/manual/quotes.html
@@ -1,0 +1,33 @@
+<div id="editor">
+	<p>Foo</p>
+	<p>Bar</p>
+</div>
+
+<script>
+CKEDITOR.replace( 'editor', {
+	plugins: 'wysiwygarea,toolbar,contextmenu,clipboard,menubutton',
+	toolbar: [ [ 'Menubutton' ] ],
+	on: {
+		pluginsLoaded: function( evt ) {
+			var editor = evt.editor;
+
+			editor.addMenuItem( 'paste', {
+				label: 'Custom "Item" Foo<suggestion>Bar<suggestion>',
+				command: 'paste',
+				group: 'clipboard',
+				order: 0
+			} );
+
+			editor.ui.add( 'Menubutton', CKEDITOR.UI_MENUBUTTON, {
+				label: 'Menu button',
+				icon: 'paste',
+				onMenu: function() {
+					return {
+						paste: CKEDITOR.TRISTATE_OFF
+					};
+				}
+			} );
+		}
+	}
+} );
+</script>

--- a/tests/plugins/menu/manual/quotes.md
+++ b/tests/plugins/menu/manual/quotes.md
@@ -1,0 +1,22 @@
+@bender-tags: bug, 4.13.0, 3413
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,contextmenu,clipboard,menubutton
+
+1. Right click any of words in the editor.
+
+	## Expected
+
+	Context menu looks normal, the option is working.
+
+	## Unexpected
+
+	Instead of the option, there is dump of its internal HTML.
+2. Open menu button in the toolbar.
+
+	## Expected
+
+	Open menu looks normal, the option are working.
+
+	## Unexpected
+
+	Instead of the option, there is dump of its internal HTML.

--- a/tests/plugins/menu/manual/quotes.md
+++ b/tests/plugins/menu/manual/quotes.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.13.0, 3413
+@bender-tags: bug, 4.13.1, 3413
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar,contextmenu,clipboard,menubutton
 

--- a/tests/plugins/menu/menu.js
+++ b/tests/plugins/menu/menu.js
@@ -62,6 +62,92 @@
 				menu.hide();
 				assert.areSame( 0, spy.callCount, 'item command was not fired' );
 			} );
+		},
+
+		// (#3413)
+		'test context menu with item containing double quotes': function() {
+			var label = 'Custom "Item" Foo<suggestion>Bar<suggestion>';
+
+			bender.editorBot.create( {
+				name: 'editor_quotes-contextmenu',
+				config: {
+					plugins: 'wysiwygarea,contextmenu',
+					on: {
+						pluginsLoaded: function( evt ) {
+							var editor = evt.editor;
+
+							editor.addMenuGroup( 'testGroup' );
+							editor.addMenuItem( 'test', {
+								label: label,
+								group: 'testGroup',
+								order: 0
+							} );
+
+							editor.contextMenu.addListener( function() {
+								return {
+									test: CKEDITOR.TRISTATE_OFF
+								};
+							} );
+						}
+					}
+				}
+			}, function( bot ) {
+				bot.contextmenu( function( menu ) {
+					assertMenuItemAttrs( menu, label );
+				} );
+			} );
+		},
+
+		// (#3413)
+		'test menubutton with item containing double quotes': function() {
+			var label = 'Custom "Item" Foo<suggestion>Bar<suggestion>';
+
+			bender.editorBot.create( {
+				name: 'editor_quotes-menubutton',
+				config: {
+					plugins: 'wysiwygarea,toolbar,menubutton',
+					toolbar: [ [ 'Menubutton' ] ],
+					on: {
+						pluginsLoaded: function( evt ) {
+							var editor = evt.editor;
+
+							editor.addMenuGroup( 'testGroup' );
+							editor.addMenuItem( 'test', {
+								label: label,
+								group: 'testGroup',
+								order: 0
+							} );
+
+							editor.ui.add( 'Menubutton', CKEDITOR.UI_MENUBUTTON, {
+								label: 'Menu button',
+								onMenu: function() {
+									return {
+										test: CKEDITOR.TRISTATE_OFF
+									};
+								}
+							} );
+						}
+					}
+				}
+			}, function( bot ) {
+				bot.menu( 'Menubutton', function( menu ) {
+					assertMenuItemAttrs( menu, label );
+				} );
+			} );
 		}
 	} );
 } )();
+
+function assertMenuItemAttrs( menu, label ) {
+	var html = [],
+		encoded = CKEDITOR.tools.htmlEncodeAttr( label ),
+		ariaLabelRegex = new RegExp( 'aria-label="' + encoded + '"' ),
+		titleRegex = new RegExp( 'title="' + encoded + '"' ),
+		hrefRegex = new RegExp( 'href="javascript:void\\(\'' + encoded + '\'\\)"' );
+
+	menu.items[ 0 ].render( menu, 0, html );
+
+	assert.isMatching( ariaLabelRegex, html[ 0 ] );
+	assert.isMatching( titleRegex, html[ 0 ] );
+	assert.isMatching( hrefRegex, html[ 0 ] );
+}


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#3413](https://github.com/ckeditor/ckeditor4/issues/3413): Fixed: Menu items with labels containing double quotes are rendered incorrectly.
```

## What changes did you make?

I've enabled encoding of HTML attributes via `CKEDITOR.tools.htmlEncodeAttr` for labels that are used inside attributes.

Closes #3413.
