### PR TITLE
Add reference about the old parameter 'internal' parameter in 'setData()' method

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -1117,9 +1117,9 @@
 		 * @param {Function} [options.callback] Function to be called after `setData` is completed (on {@link #dataReady}).
 		 * @param {Boolean} [options.noSnapshot=false] If set to `true`, it will prevent recording an undo snapshot.
 		 * Introduced in CKEditor 4.4.2.
-		 * @param {Boolean} [internal=false] Old equivalent of `options.internal=false`. This parameter is only available
-		 * to provide backward compatibility in calls with `data, callback, internal` parameters. It is recommended to use
-		 * `data, [options]` parameters instead.
+		 * @param {Boolean} [internal=false] Old equivalent of `options.internal` parameter. It is only available
+		 * to provide backwards compatibility for calls with `data, callback, internal` parameters.
+		 * It is recommended to use `options.internal` parameter instead.
 		 */
 		setData: function( data, options, internal ) {
 			var fireSnapshot = true,

--- a/core/editor.js
+++ b/core/editor.js
@@ -1117,6 +1117,9 @@
 		 * @param {Function} [options.callback] Function to be called after `setData` is completed (on {@link #dataReady}).
 		 * @param {Boolean} [options.noSnapshot=false] If set to `true`, it will prevent recording an undo snapshot.
 		 * Introduced in CKEditor 4.4.2.
+		 * @param {Boolean} [internal=false] Old equivalent of `options.internal=false`. This parameter is only available
+		 * to provide backward compatibility in calls with `data, callback, internal` parameters. It is recommended to use
+		 * `data, [options]` parameters instead.
 		 */
 		setData: function( data, options, internal ) {
 			var fireSnapshot = true,


### PR DESCRIPTION
## What is the purpose of this pull request?

To fix inconsistent API Docs about `setData()` method. 
It was caused by maintaining backward compatibility, as mentioned above: https://github.com/ckeditor/ckeditor4/blob/52ec0b185b005611368b3eccd59275ba4294526a/core/editor.js#L1106-L1108 Still, as using `internal` parameter is valid, I added reference to it.

Closes #3417.