### PR TITLE
Add link protocol field customization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
     * [#3118](https://github.com/ckeditor/ckeditor-dev/issues/3118): Selecting a paragraph with triple-click and applying heading applies heading only to selected paragraph.
     * [#3161](https://github.com/ckeditor/ckeditor-dev/issues/3161): Double click on a `span` element containing one word only creates correct selection including clicked `span` only.
 * [#3359](https://github.com/ckeditor/ckeditor-dev/issues/3359): Improved [dialog](https://ckeditor.com/cke4/addon/dialog) positioning and behaviour when browser window is resized, dialog resized or moved.
+* [#2227](https://github.com/ckeditor/ckeditor-dev/issues/2227): Added [`config.linkDefaultProtocol`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-linkDefaultProtocol) configuration option that allows setting default URL protocol for [Link](https://ckeditor.com/cke4/addon/link) plugin dialog.
 
 Fixed Issues:
 

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -280,12 +280,11 @@
 								[ 'news://\u200E', 'news://' ],
 								[ linkLang.other, '' ]
 							],
+							'default': editor.config.link_defaultProtocol,
 							setup: function( data ) {
-								var protocol = data.url && data.url.protocol;
-
-								protocol = protocol !== undefined ? protocol : editor.config.link_defaultProtocol;
-
-								this.setValue( protocol );
+								if ( data.url ) {
+									this.setValue( data.url.protocol || '' );
+								}
 							},
 							commit: function( data ) {
 								if ( !data.url )

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -280,7 +280,7 @@
 								[ 'news://\u200E', 'news://' ],
 								[ linkLang.other, '' ]
 							],
-							'default': editor.config.link_defaultProtocol,
+							'default': editor.config.linkDefaultProtocol,
 							setup: function( data ) {
 								if ( data.url ) {
 									this.setValue( data.url.protocol || '' );

--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -272,7 +272,6 @@
 							id: 'protocol',
 							type: 'select',
 							label: commonLang.protocol,
-							'default': 'http://',
 							items: [
 								// Force 'ltr' for protocol names in BIDI. (https://dev.ckeditor.com/ticket/5433)
 								[ 'http://\u200E', 'http://' ],
@@ -282,8 +281,11 @@
 								[ linkLang.other, '' ]
 							],
 							setup: function( data ) {
-								if ( data.url )
-									this.setValue( data.url.protocol || '' );
+								var protocol = data.url && data.url.protocol;
+
+								protocol = protocol !== undefined ? protocol : editor.config.link_defaultProtocol;
+
+								this.setValue( protocol );
 							},
 							commit: function( data ) {
 								if ( !data.url )

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -900,11 +900,23 @@
 		/**
 		 * Default URL protocol used for link dialog.
 		 *
+		 * Available values are:
+		 *
+		 * * `'http://'`
+		 * * `'https://'`
+		 * * `'ftp://'`
+		 * * `'news://'`
+		 * * `''` - empty string for `<other>` option
+		 *
+		 * ```javascript
+		 * config.linkDefaultProtocol = 'https://';
+		 * ```
+		 *
 		 * @cfg {String}
 		 * @member CKEDITOR.config
 		 * @since 4.13.0
 		 */
-		linkDefaultProtocol: 'http://',
+		linkDefaultProtocol: 'http://'
 
 		/**
 		 * Whether JavaScript code is allowed as a `href` attribute in an anchor tag.

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -904,7 +904,7 @@
 		 * @member CKEDITOR.config
 		 * @since 4.13.0
 		 */
-		link_defaultProtocol: 'http://',
+		linkDefaultProtocol: 'http://',
 
 		/**
 		 * Whether JavaScript code is allowed as a `href` attribute in an anchor tag.

--- a/plugins/link/plugin.js
+++ b/plugins/link/plugin.js
@@ -895,7 +895,16 @@
 		 * @cfg {Boolean} [linkShowTargetTab=true]
 		 * @member CKEDITOR.config
 		 */
-		linkShowTargetTab: true
+		linkShowTargetTab: true,
+
+		/**
+		 * Default URL protocol used for link dialog.
+		 *
+		 * @cfg {String}
+		 * @member CKEDITOR.config
+		 * @since 4.13.0
+		 */
+		link_defaultProtocol: 'http://',
 
 		/**
 		 * Whether JavaScript code is allowed as a `href` attribute in an anchor tag.

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -22,6 +22,12 @@
 			config: {
 				linkDefaultProtocol: 'https://'
 			}
+		},
+
+		otherProtocol: {
+			config: {
+				linkDefaultProtocol: ''
+			}
 		}
 	};
 
@@ -641,7 +647,17 @@
 			bot.dialog( 'link', function( dialog ) {
 				assert.areEqual( 'https://', dialog.getContentElement( 'info', 'protocol' ).getValue() );
 				dialog.hide();
-			} )
+			} );
+		},
+
+		// (#2227)
+		'test other URL protocol': function() {
+			var bot = this.editorBots.otherProtocol;
+
+			bot.dialog( 'link', function( dialog ) {
+				assert.areEqual( '', dialog.getContentElement( 'info', 'protocol' ).getValue() );
+				dialog.hide();
+			} );
 		}
 	} );
 

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -17,6 +17,11 @@
 				linkPhoneRegExp: /^[0-9]{9}$/,
 				linkPhoneMsg: 'Invalid number'
 			}
+		},
+		customProtocol: {
+			config: {
+				link_defaultProtocol: 'https://'
+			}
 		}
 	};
 
@@ -627,7 +632,17 @@
 
 		'test email address with "?" in domain': assertEmail( 'mailto:?ck?editor@cksou?rce.com' ),
 
-		'test email address with "?" and arguments': assertEmail( 'mailto:ck?editor@cksource.com?subject=cke4&amp;body=hello' )
+		'test email address with "?" and arguments': assertEmail( 'mailto:ck?editor@cksource.com?subject=cke4&amp;body=hello' ),
+
+		// (#2227)
+		'test custom URL protocol': function() {
+			var bot = this.editorBots.customProtocol;
+
+			bot.dialog( 'link', function( dialog ) {
+				assert.areEqual( 'https://', dialog.getContentElement( 'info', 'protocol' ).getValue() );
+				dialog.hide();
+			} )
+		}
 	} );
 
 	function assertEmail( link ) {

--- a/tests/plugins/link/link.js
+++ b/tests/plugins/link/link.js
@@ -20,7 +20,7 @@
 		},
 		customProtocol: {
 			config: {
-				link_defaultProtocol: 'https://'
+				linkDefaultProtocol: 'https://'
 			}
 		}
 	};

--- a/tests/plugins/link/manual/protocol.html
+++ b/tests/plugins/link/manual/protocol.html
@@ -1,0 +1,7 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		link_defaultProtocol: 'https://'
+	} );
+</script>

--- a/tests/plugins/link/manual/protocol.html
+++ b/tests/plugins/link/manual/protocol.html
@@ -1,7 +1,15 @@
-<div id="editor"></div>
+<h2>First editor</h2>
+<div id="editor1"></div>
+
+<h2>Second editor</h2>
+<div id="editor2"</div>
 
 <script>
-	CKEDITOR.replace( 'editor', {
+	CKEDITOR.replace( 'editor1', {
+		link_defaultProtocol: 'https://'
+	} );
+
+	CKEDITOR.replace( 'editor2', {
 		link_defaultProtocol: 'https://'
 	} );
 </script>

--- a/tests/plugins/link/manual/protocol.html
+++ b/tests/plugins/link/manual/protocol.html
@@ -6,10 +6,10 @@
 
 <script>
 	CKEDITOR.replace( 'editor1', {
-		link_defaultProtocol: 'https://'
+		linkDefaultProtocol: 'https://'
 	} );
 
 	CKEDITOR.replace( 'editor2', {
-		link_defaultProtocol: 'https://'
+		linkDefaultProtocol: 'https://'
 	} );
 </script>

--- a/tests/plugins/link/manual/protocol.md
+++ b/tests/plugins/link/manual/protocol.md
@@ -2,7 +2,7 @@
 @bender-ckeditor-plugins: link, toolbar, wysiwygarea
 @bender-ui: collapsed
 
-1. Click link button.
+1. Click link button in the first editor.
 
 **Expected:** Protocol set to `https://`.
 
@@ -12,3 +12,5 @@
 5. Double click inserted link to open dialog.
 
 **Expected**: Link protocol remains `http://`.
+
+6. Repeat 1-5 test steps with the second editor using `<other>` protocol instead of `http://`.

--- a/tests/plugins/link/manual/protocol.md
+++ b/tests/plugins/link/manual/protocol.md
@@ -1,0 +1,14 @@
+@bender-tags: feature, link, 2227, 4.13.0
+@bender-ckeditor-plugins: link, toolbar, wysiwygarea
+@bender-ui: collapsed
+
+1. Click link button.
+
+**Expected:** Protocol set to `https://`.
+
+2. Change protocol into `http://`.
+3. Fill URL field with `foo`.
+4. Click `OK`.
+5. Double click inserted link to open dialog.
+
+**Expected**: Link protocol remains `http://`.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
[#2227](https://github.com/ckeditor/ckeditor-dev/issues/2227): Added [`config.link_defaultProcotol`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-link_defaultProtocol) configuration option that allows setting default URL protocol for [Link](https://ckeditor.com/cke4/addon/link) plugin dialog.
```

## What changes did you make?

Closes #2227
