### PR TITLE
Add support for new dialog model API for image buttons

### DIFF
--- a/plugins/image/dialogs/image.js
+++ b/plugins/image/dialogs/image.js
@@ -278,9 +278,12 @@
 				minWidth: ( CKEDITOR.skinName || editor.config.skin ) == 'moono-lisa' ? 500 : 420,
 				minHeight: 360,
 				getModel: function( editor ) {
-					var element = editor.getSelection().getSelectedElement();
+					var element = editor.getSelection().getSelectedElement(),
+						isImage = element && element.getName() === 'img',
+						isImageInput = element && element.getName() === 'input' &&
+							element.getAttribute( 'type' ) === 'image';
 
-					if ( element && element.getName() === 'img' ) {
+					if ( isImage ||isImageInput ) {
 						return element;
 					}
 

--- a/tests/plugins/forms/imagebutton.js
+++ b/tests/plugins/forms/imagebutton.js
@@ -1,4 +1,4 @@
-/* bender-tags: editor,dialog */
+/* bender-tags: editor,dialog,2423 */
 /* bender-ckeditor-plugins: dialog,image,button,forms,htmlwriter,toolbar */
 /* bender-include: _helpers/tools.js */
 
@@ -17,7 +17,6 @@
 			}
 		},
 
-		// (#2423)
 		'test dialog model during imagebutton creation': function() {
 			var bot = this.editorBot,
 				editor = this.editor;
@@ -30,7 +29,6 @@
 			} );
 		},
 
-		// (#2423)
 		'test dialog model with existing imagebutton': function() {
 			var bot = this.editorBot,
 				editor = this.editor;

--- a/tests/plugins/forms/imagebutton.js
+++ b/tests/plugins/forms/imagebutton.js
@@ -1,0 +1,51 @@
+/* bender-tags: editor,dialog */
+/* bender-ckeditor-plugins: dialog,image,button,forms,htmlwriter,toolbar */
+/* bender-include: _helpers/tools.js */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	bender.test( {
+
+		tearDown: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+
+			if ( dialog ) {
+				dialog.hide();
+			}
+		},
+
+		// (#2423)
+		'test dialog model during imagebutton creation': function() {
+			var bot = this.editorBot,
+				editor = this.editor;
+
+			bot.setData( '', function() {
+				bot.dialog( 'imagebutton', function( dialog ) {
+					assert.isNull( dialog.getModel( editor ) );
+					assert.areEqual( CKEDITOR.dialog.CREATION_MODE, dialog.getMode( editor ) );
+				} );
+			} );
+		},
+
+		// (#2423)
+		'test dialog model with existing imagebutton': function() {
+			var bot = this.editorBot,
+				editor = this.editor;
+
+			bot.setData( '<input type="image" src="test" alt="alt" value="click me" />', function() {
+				bot.dialog( 'imagebutton', function( dialog ) {
+					var button = editor.editable().findOne( 'input' );
+
+					editor.getSelection().selectElement( button );
+
+					assert.areEqual( button, dialog.getModel( editor ) );
+					assert.areEqual( CKEDITOR.dialog.EDITING_MODE, dialog.getMode( editor ) );
+				} );
+			} );
+		}
+	} );
+
+} )();

--- a/tests/plugins/forms/manual/editingmode.md
+++ b/tests/plugins/forms/manual/editingmode.md
@@ -1,7 +1,7 @@
 @bender-include: ../../dialog/manual/_helpers/tools.js
 @bender-tags: dialog, 4.13.0, 2423, feature
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, forms, toolbar
+@bender-ckeditor-plugins: wysiwygarea, forms, image, toolbar
 
 **NOTE:** For modern browsers you will see "real" HTML in **expected** results instead of `[element HTML]` string.
 
@@ -41,4 +41,5 @@ Currently editing: `[element HTML]`
 * `textarea`
 * `select`
 * `button`
+* `imagebutton`
 * `hiddenfield`


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix/new feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

No changelog entry, as it's fix for yet unreleased feature.

## What changes did you make?

That was a little tricky one. We missed it during development, because `imagebutton` is available only when `image` plugin is used and it uses `image`'s dialog. I've updated `image`'s `getModel()` to fetch also `input[type=image]`.

Closes #3436.
