### PR TITLE
Fix for incorrect getSelectedAnchor result

### DIFF
--- a/plugins/link/dialogs/anchor.js
+++ b/plugins/link/dialogs/anchor.js
@@ -25,6 +25,11 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 		range.shrink( CKEDITOR.SHRINK_ELEMENT );
 		element = range.getEnclosedNode();
 
+		// If selection is inside text, get its parent element (#3437).
+		if ( element && element.type === CKEDITOR.NODE_TEXT ) {
+			element = element.getParent();
+		}
+
 		if ( element && element.type === CKEDITOR.NODE_ELEMENT &&
 			( element.data( 'cke-real-element-type' ) === 'anchor' || element.is( 'a' ) ) ) {
 			return element;

--- a/tests/plugins/link/anchor.js
+++ b/tests/plugins/link/anchor.js
@@ -51,6 +51,26 @@
 
 				wait();
 			} );
+		},
+
+		// (#3437)
+		'test getModel when selection is inside anchor\'s text': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
+
+			bot.setData( '<p><a id="test" name="test">Foobar</a></p>', function() {
+				var range = editor.createRange(),
+					anchor = editor.editable().findOne( '#test' ),
+					textNode = anchor.getChild( 0 );
+
+				range.selectNodeContents( textNode );
+				range.select();
+
+				bot.dialog( 'anchor', function( dialog ) {
+					assert.areSame( 'test', dialog.getValueOf( 'info', 'txtName' ) );
+					assert.areSame( anchor, dialog.getModel( editor ) );
+				} );
+			} );
 		}
 	} );
 }() );

--- a/tests/plugins/link/anchor.js
+++ b/tests/plugins/link/anchor.js
@@ -7,6 +7,14 @@
 	bender.editor = {};
 
 	bender.test( {
+		tearDown: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+
+			if ( dialog ) {
+				dialog.hide();
+			}
+		},
+
 		// #476
 		'test editing anchor': function() {
 			var editor = this.editor,
@@ -39,7 +47,7 @@
 				range.selectNodeContents( editor.editable().findOne( '[data-cke-real-element-type=anchor]' ) );
 				range.select();
 
-				editor.on( 'dialogShow', function( evt ) {
+				editor.once( 'dialogShow', function( evt ) {
 					resume( function() {
 						assert.areSame( evt.data._.name, 'anchor', 'Anchor dialog has been opened.' );
 					} );

--- a/tests/plugins/link/manual/anchorselection.html
+++ b/tests/plugins/link/manual/anchorselection.html
@@ -1,0 +1,39 @@
+<style>
+#result {
+	font-size: 36px;
+}
+.found {
+	color: green;
+}
+.notfound {
+	color: red;
+}
+</style>
+<p id="result">Open dialog first</p>
+<div id="editor">
+	<p><a id="test" name="test">Foobar</a></p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			dialogShow: function( evt ) {
+				var editor = evt.editor,
+					expected = editor.editable().findOne( '#test' ),
+					actual = evt.data.getModel( editor ),
+					result = CKEDITOR.document.getById( 'result' );
+
+				result.setHtml( expected.equals( actual ) ? 'FOUND!' : 'NOT FOUND!' );
+				result.addClass( expected.equals( actual ) ? 'found' : 'notfound' );
+			},
+
+			dialogHide: function( evt ) {
+				var result = CKEDITOR.document.getById( 'result' );
+
+				result.setHtml( 'Open dialog first' );
+				result.removeClass( 'found' );
+				result.removeClass( 'notfound' );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/link/manual/anchorselection.md
+++ b/tests/plugins/link/manual/anchorselection.md
@@ -1,0 +1,16 @@
+@bender-tags: link, 4.13.0, 3437, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: link,toolbar,wysiwygarea
+
+1. Double click text inside anchor.
+
+## Expected
+
+* Dialog shown with `test` value.
+* Green "FOUND!" text above the editor.
+
+## Unexpected
+
+* Dialog is not shown.
+* Dialog is shown without appropriate data.
+* There is red "NOT FOUND!" text above the editor.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3437](https://github.com/ckeditor/ckeditor4/issues/3437): [Safari] Fixed: Can't get selected anchor when selection is in anchor's text.
```

## What changes did you make?

I've added additional mechanism to fetch tex't parent element if selection is inside the text.

Closes #3437.
