### PR TITLE
Add support for getModel to iframe dialog

### DIFF
--- a/plugins/iframe/dialogs/iframe.js
+++ b/plugins/iframe/dialogs/iframe.js
@@ -42,6 +42,15 @@
 			title: iframeLang.title,
 			minWidth: 350,
 			minHeight: 260,
+			getModel: function( editor ) {
+				var element = editor.getSelection().getSelectedElement();
+
+				if ( element && element.data( 'cke-real-element-type' ) === 'iframe' ) {
+					return element;
+				}
+
+				return null;
+			},
 			onShow: function() {
 				// Clear previously saved elements.
 				this.fakeImage = this.iframeNode = null;

--- a/tests/plugins/iframe/iframe.js
+++ b/tests/plugins/iframe/iframe.js
@@ -8,6 +8,14 @@ bender.editor = {
 };
 
 bender.test( {
+	tearDown: function() {
+		var dialog = CKEDITOR.dialog.getCurrent();
+
+		if ( dialog ) {
+			dialog.hide();
+		}
+	},
+
 	'test create iframe': function() {
 		var bot = this.editorBot;
 		bot.dialog( 'iframe', function( dialog ) {
@@ -38,6 +46,37 @@ bender.test( {
 			dialog.getButton( 'ok' ).click();
 
 			assert.areEqual( '<iframe frameborder="0" scrolling="no" src="http://cksource.com" width="400"></iframe>', bot.getData( true ) );
+		} );
+	},
+
+	// (#2423)
+	'test dialog model during iframe creation': function() {
+		var bot = this.editorBot,
+			editor = this.editor;
+
+		bot.setData( '', function() {
+			bot.dialog( 'iframe', function( dialog ) {
+				assert.isNull( dialog.getModel( editor ) );
+				assert.areEqual( CKEDITOR.dialog.CREATION_MODE, dialog.getMode( editor ) );
+			} );
+		} );
+	},
+
+	// (#2423)
+	'test dialog model with existing iframe': function() {
+		var bot = this.editorBot,
+			editor = this.editor,
+			iframeHtml = '<iframe frameborder="0" scrolling="no" src="http://ckeditor.com" width="100%"></iframe>';
+
+		bot.setData( iframeHtml, function() {
+			bot.dialog( 'iframe', function( dialog ) {
+				var iframe = editor.editable().findOne( '.cke_iframe' );
+
+				editor.getSelection().selectElement( iframe );
+
+				assert.areEqual( iframe, dialog.getModel( editor ) );
+				assert.areEqual( CKEDITOR.dialog.EDITING_MODE, dialog.getMode( editor ) );
+			} );
 		} );
 	}
 } );

--- a/tests/plugins/iframe/manual/editingmode.html
+++ b/tests/plugins/iframe/manual/editingmode.html
@@ -1,0 +1,5 @@
+<div id="editor"></div>
+
+<script>
+	dialogTools.initDialogEditingModeTest( CKEDITOR.replace( 'editor' ) );
+</script>

--- a/tests/plugins/iframe/manual/editingmode.md
+++ b/tests/plugins/iframe/manual/editingmode.md
@@ -1,0 +1,31 @@
+@bender-include: ../../dialog/manual/_helpers/tools.js
+@bender-tags: dialog, 4.13.0, 2423, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, iframe, toolbar
+
+**NOTE:** For modern browsers you will see "real" HTML in **expected** results instead of `[element HTML]` string.
+
+1. Click `iframe` button.
+2. Verify status above the editor.
+
+## Expected
+
+Dialog name: **iframe** in **editor** editor.
+
+Dialog is in **creation** mode.
+
+Currently editing: null
+
+---
+
+3. Insert `example.com` `iframe` URL and click `OK`.
+4. Double click `iframe` to open dialog again.
+5. Verify status above the editor.
+
+## Expected
+
+Dialog name: **iframe** in **editor** editor.
+
+Dialog is in **editing** mode.
+
+Currently editing: `[element HTML]`


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix/new feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

None, as it's part of unreleased feature.

## What changes did you make?

I've added missing support for model API to `iframe` dialog (basically copied it from `flash` one).

Closes #3442.
