### PR TITLE
Add support for d&d multiple widgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ New features:
 * [#3748](https://github.com/ckeditor/ckeditor4/issues/3748): Improved [Color Button](https://ckeditor.com/cke4/addon/colorbutton) state to reflect selected editor content colors.
 * [#3661](https://github.com/ckeditor/ckeditor4/issues/3661): Improved [Print](https://ckeditor.com/cke4/addon/print) plugin to respect styling rendered by the [Preview](https://ckeditor.com/cke4/addon/preview) plugin.
 * [#3547](https://github.com/ckeditor/ckeditor4/issues/3547): Active [dialog](https://ckeditor.com/cke4/addon/dialog) tab has now `aria-selected="true"` attribute.
+* [#3441](https://github.com/ckeditor/ckeditor4/issues/3441): Improved [`widget.getClipboardHtml`] support for dragging and dropping multiple [Widgets](https://ckeditor.com/cke4/addon/widget).
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ New features:
 * [#3748](https://github.com/ckeditor/ckeditor4/issues/3748): Improved [Color Button](https://ckeditor.com/cke4/addon/colorbutton) state to reflect selected editor content colors.
 * [#3661](https://github.com/ckeditor/ckeditor4/issues/3661): Improved [Print](https://ckeditor.com/cke4/addon/print) plugin to respect styling rendered by the [Preview](https://ckeditor.com/cke4/addon/preview) plugin.
 * [#3547](https://github.com/ckeditor/ckeditor4/issues/3547): Active [dialog](https://ckeditor.com/cke4/addon/dialog) tab has now `aria-selected="true"` attribute.
-* [#3441](https://github.com/ckeditor/ckeditor4/issues/3441): Improved [`widget.getClipboardHtml`] support for dragging and dropping multiple [Widgets](https://ckeditor.com/cke4/addon/widget).
+* [#3441](https://github.com/ckeditor/ckeditor4/issues/3441): Improved [`widget.getClipboardHtml`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html#method-getClipboardHtml) support for dragging and dropping multiple [Widgets](https://ckeditor.com/cke4/addon/widget).
 
 Fixed Issues:
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2613,6 +2613,21 @@
 			editor.widgets.destroy( sourceWidget, true );
 		} );
 
+		// Add support for dropping selection containing more than widget itself
+		// or more than one widget (#3441).
+		editor.on( 'drop', function( evt ) {
+			var dataTransfer = evt.data.dataTransfer,
+				id = dataTransfer.getData( 'cke/widget-id' ),
+				transferType = dataTransfer.getTransferType( editor );
+
+			if ( id !== '' || ( editor.widgets.selected.length > 0 &&
+				transferType != CKEDITOR.DATA_TRANSFER_INTERNAL ) ) {
+				return;
+			}
+
+			evt.data.dataTransfer.setData( 'text/html', getClipboardHtml( editor ) );
+		} );
+
 		editor.on( 'contentDom', function() {
 			var editable = editor.editable();
 
@@ -3406,21 +3421,7 @@
 			bookmarks = editor.getSelection().createBookmarks( true );
 		}
 
-		copyBin.handle( getClipboardHtml() );
-
-		function getClipboardHtml() {
-			var selectedHtml = editor.getSelectedHtml( true );
-
-			if ( editor.widgets.focused ) {
-				return editor.widgets.focused.getClipboardHtml();
-			}
-
-			editor.once( 'toDataFormat', function( evt ) {
-				evt.data.widgetsCopy = true;
-			}, null, null, -1 );
-
-			return editor.dataProcessor.toDataFormat( selectedHtml );
-		}
+		copyBin.handle( getClipboardHtml( editor ) );
 
 		function handleCut() {
 			if ( focused ) {
@@ -3472,6 +3473,20 @@
 			this.editor.forceNextSelectionCheck();
 			this.editor.selectionChange( 1 );
 		}
+	}
+
+	function getClipboardHtml( editor ) {
+		var selectedHtml = editor.getSelectedHtml( true );
+
+		if ( editor.widgets.focused ) {
+			return editor.widgets.focused.getClipboardHtml();
+		}
+
+		editor.once( 'toDataFormat', function( evt ) {
+			evt.data.widgetsCopy = true;
+		}, null, null, -1 );
+
+		return editor.dataProcessor.toDataFormat( selectedHtml );
 	}
 
 	function setupWidget( widget, widgetDef ) {

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2590,7 +2590,14 @@
 				return;
 			}
 
-			if ( id === '' || transferType != CKEDITOR.DATA_TRANSFER_INTERNAL ) {
+			if ( transferType != CKEDITOR.DATA_TRANSFER_INTERNAL ) {
+				return;
+			}
+
+			// Add support for dropping selection containing more than widget itself
+			// or more than one widget (#3441).
+			if ( !id && editor.widgets.selected.length > 0 ) {
+				evt.data.dataTransfer.setData( 'text/html', getClipboardHtml( editor ) );
 				return;
 			}
 
@@ -2611,21 +2618,6 @@
 
 			evt.data.dataTransfer.setData( 'text/html', sourceWidget.getClipboardHtml() );
 			editor.widgets.destroy( sourceWidget, true );
-		} );
-
-		// Add support for dropping selection containing more than widget itself
-		// or more than one widget (#3441).
-		editor.on( 'drop', function( evt ) {
-			var dataTransfer = evt.data.dataTransfer,
-				id = dataTransfer.getData( 'cke/widget-id' ),
-				transferType = dataTransfer.getTransferType( editor );
-
-			if ( id !== '' || ( editor.widgets.selected.length > 0 &&
-				transferType != CKEDITOR.DATA_TRANSFER_INTERNAL ) ) {
-				return;
-			}
-
-			evt.data.dataTransfer.setData( 'text/html', getClipboardHtml( editor ) );
 		} );
 
 		editor.on( 'contentDom', function() {

--- a/tests/plugins/widget/dnd.js
+++ b/tests/plugins/widget/dnd.js
@@ -54,11 +54,12 @@
 	var getWidgetById = widgetTestsTools.getWidgetById,
 		assertRelations = lineutilsTestsTools.assertRelations;
 
-	function dragstart( editor, evt, widget ) {
-		var dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor );
+	function dragstart( editor, evt, widgetOrNode ) {
+		var dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor ),
+			dragTarget = widgetOrNode.dragHandlerContainer ? widgetOrNode.dragHandlerContainer.findOne( 'img' ) : widgetOrNode;
 
-		// Use realistic target which is the drag handler.
-		evt.setTarget( widget.dragHandlerContainer.findOne( 'img' ) );
+		// Use realistic target which is the drag handler or the element.
+		evt.setTarget( dragTarget );
 
 		dropTarget.fire( 'dragstart', evt );
 	}
@@ -76,11 +77,12 @@
 		dropTarget.fire( 'drop', evt );
 	}
 
-	function dragend( editor, evt, widget ) {
-		var dropTarget = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? editor.editable() : editor.document;
+	function dragend( editor, evt, widgetOrNode ) {
+		var dropTarget = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? editor.editable() : editor.document,
+			dragTarget = widgetOrNode.dragHandlerContainer ? widgetOrNode.dragHandlerContainer.findOne( 'img' ) : widgetOrNode;
 
-		// Use realistic target which is the drag handler.
-		evt.setTarget( widget.dragHandlerContainer.findOne( 'img' ) );
+		// Use realistic target which is the drag handler or the element.
+		evt.setTarget( dragTarget );
 
 		dropTarget.fire( 'dragend', evt );
 	}
@@ -291,7 +293,7 @@
 		},
 
 		// (#3138)
-		'test drag and drop with shadowed clipboard html': function() {
+		'test drag and drop with shadowed clipboard html (single widget)': function() {
 			var editor = this.editor;
 
 			this.editorBot.setData( '<p><span data-widget="testwidget5" id="w1">foo</span></p>', function() {
@@ -319,6 +321,62 @@
 					drop( editor, evt.data, range );
 
 					dragend( editor, evt.data, widget );
+				} );
+			} );
+		},
+
+		// (#3441)
+		'test drag and drop with shadowed clipboard html (multiple widgets)': function() {
+			if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+				assert.ignore();
+			}
+
+			var editor = this.editor,
+				dragHtml = '<p>Lorem <span data-widget="testwidget5" id="w1">foo</span> ipsum <span data-widget="testwidget5" id="w2">bar</span> dolor</p>',
+				initialHtml = dragHtml + '<p>Drop zone</p>';
+
+			this.editorBot.setData( initialHtml, function() {
+				var evt = { data: bender.tools.mockDropEvent() },
+					dragRange = editor.createRange(),
+					dropRange = editor.createRange();
+
+				editor.resetUndo();
+				editor.focus();
+
+				bender.tools.resumeAfter( editor, 'afterPaste', function() {
+					var expectedRegex = /<p>Dr<\/p><p>Lorem<\/p><p>foobar<\/p><p>ipsum<\/p><p>foobar<\/p><p>dolor<\/p>(<p>\s*?<\/p>)<p>op zone<\/p>/,
+						undoManager = editor.undoManager;
+
+					assert.isTrue( undoManager.undoable(), 'dnd is undoable' );
+					assert.isMatching( expectedRegex, editor.getData(), 'Editor data' );
+
+					undoManager.undo();
+
+					assert.areSame( initialHtml, editor.getData(), 'Editor content afer undo' );
+					assert.isFalse( undoManager.undoable(), 'dnd after undo is not undoable' );
+				} );
+
+				// Ensure async.
+				wait( function() {
+					var editable = editor.editable(),
+						paragraphs = editable.find( 'p' ).toArray(),
+						dragTarget = paragraphs[ 0 ].getChild( 1 ),
+						dropTarget = paragraphs[ 1 ].getChild( 0 );
+
+					dragRange.selectNodeContents( paragraphs[ 0 ] );
+					dragRange.select();
+
+					dragstart( editor, evt.data, dragTarget );
+
+					CKEDITOR.plugins.clipboard.initDragDataTransfer( evt );
+					evt.data.dataTransfer.setData( 'text/html', dragHtml );
+
+					dropRange.setStart( dropTarget, 2 );
+					evt.data.testRange = dropRange;
+
+					drop( editor, evt.data, dropRange );
+
+					dragend( editor, evt.data, dragTarget );
 				} );
 			} );
 		},

--- a/tests/plugins/widget/dnd.js
+++ b/tests/plugins/widget/dnd.js
@@ -336,9 +336,7 @@
 				initialHtml = dragHtml + '<p>Drop zone</p>';
 
 			this.editorBot.setData( initialHtml, function() {
-				var evt = { data: bender.tools.mockDropEvent() },
-					dragRange = editor.createRange(),
-					dropRange = editor.createRange();
+				var evt = { data: bender.tools.mockDropEvent() };
 
 				editor.resetUndo();
 				editor.focus();
@@ -361,7 +359,9 @@
 					var editable = editor.editable(),
 						paragraphs = editable.find( 'p' ).toArray(),
 						dragTarget = paragraphs[ 0 ].getChild( 1 ),
-						dropTarget = paragraphs[ 1 ].getChild( 0 );
+						dropTarget = paragraphs[ 1 ].getChild( 0 ),
+						dragRange = editor.createRange(),
+						dropRange = editor.createRange();
 
 					dragRange.selectNodeContents( paragraphs[ 0 ] );
 					dragRange.select();

--- a/tests/plugins/widget/dnd.js
+++ b/tests/plugins/widget/dnd.js
@@ -56,7 +56,7 @@
 
 	function dragstart( editor, evt, widgetOrNode ) {
 		var dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor ),
-			dragTarget = widgetOrNode.dragHandlerContainer ? widgetOrNode.dragHandlerContainer.findOne( 'img' ) : widgetOrNode;
+			dragTarget = getDragEventTarget( widgetOrNode );
 
 		// Use realistic target which is the drag handler or the element.
 		evt.setTarget( dragTarget );
@@ -79,12 +79,20 @@
 
 	function dragend( editor, evt, widgetOrNode ) {
 		var dropTarget = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? editor.editable() : editor.document,
-			dragTarget = widgetOrNode.dragHandlerContainer ? widgetOrNode.dragHandlerContainer.findOne( 'img' ) : widgetOrNode;
+			dragTarget = getDragEventTarget( widgetOrNode );
 
 		// Use realistic target which is the drag handler or the element.
 		evt.setTarget( dragTarget );
 
 		dropTarget.fire( 'dragend', evt );
+	}
+
+	function getDragEventTarget( widgetOrNode ) {
+		if ( !widgetOrNode.dragHandlerContainer ) {
+			return widgetOrNode;
+		}
+
+		return widgetOrNode.dragHandlerContainer.findOne( 'img' );
 	}
 
 	bender.test( {

--- a/tests/plugins/widget/dnd.js
+++ b/tests/plugins/widget/dnd.js
@@ -1,6 +1,6 @@
 /* bender-tags: widgetcore */
 /* bender-ckeditor-plugins: widget,undo,clipboard */
-/* bender-ckeditor-remove-plugins: tableselection */
+/* bender-ckeditor-remove-plugins: tableselection,pastefromlibreoffice */
 /* bender-include: _helpers/tools.js */
 /* global widgetTestsTools, lineutilsTestsTools */
 
@@ -350,7 +350,7 @@
 				editor.focus();
 
 				bender.tools.resumeAfter( editor, 'afterPaste', function() {
-					var expectedRegex = /<p>Dr<\/p><p>Lorem<\/p><p>foobar<\/p><p>ipsum<\/p><p>foobar<\/p><p>dolor<\/p>(<p>\s*?<\/p>)<p>op zone<\/p>/,
+					var expectedRegex = /<p>Dr<\/p><p>Lorem<\/p><p>foobar<\/p><p>ipsum<\/p><p>foobar<\/p><p>dolor<\/p>(<p>(\s|&nbsp;)*?<\/p>)<p>op zone<\/p>/,
 						undoManager = editor.undoManager;
 
 					assert.isTrue( undoManager.undoable(), 'dnd is undoable' );

--- a/tests/plugins/widget/manual/clipboardhtmldnd.html
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.html
@@ -1,29 +1,17 @@
 <div id="editor">
-	<p>Adipisicing corporis rem repellendus vel mollitia vero?</p>
+	<p>Drop zone</p>
+	<p>[Start here</p>
 	<div data-widget="customwidget">Widget</div>
 	<p>Consectetur dolores voluptatibus illo ipsam eveniet?</p>
-	<div data-widget="customwidget">Widget</div>
-	<p>Lorem ipsum dolor sit amet.</p>
 	<div data-widget="customnestedwidget">
 		<p>Widget</p>
 		<div class="ned">
 			<div data-widget="customwidget">Nested widget</div>
 		</div>
 	</div>
-	<p>Many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many,</p>
-	<p>many</p>
-	<p>lines to test scrollhack for IE.</p>
+	<p>end here].</p>
+	<p>Some [[inline widget]], too!</p>
+	<p>Drop zone</p>
 </div>
 
 <script>
@@ -34,7 +22,8 @@
 	CKEDITOR.replace( 'editor', {
 		extraAllowedContent: 'span',
 		extraPlugins: 'customwidget',
-		allowedContent: true
+		allowedContent: true,
+		height: 500
 	} );
 
 	CKEDITOR.plugins.add( 'customwidget', {

--- a/tests/plugins/widget/manual/clipboardhtmldnd.html
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.html
@@ -1,0 +1,71 @@
+<div id="editor">
+	<p>Adipisicing corporis rem repellendus vel mollitia vero?</p>
+	<div data-widget="customwidget">Widget</div>
+	<p>Consectetur dolores voluptatibus illo ipsam eveniet?</p>
+	<div data-widget="customwidget">Widget</div>
+	<p>Lorem ipsum dolor sit amet.</p>
+	<div data-widget="customnestedwidget">
+		<p>Widget</p>
+		<div class="ned">
+			<div data-widget="customwidget">Nested widget</div>
+		</div>
+	</div>
+	<p>Many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many,</p>
+	<p>many</p>
+	<p>lines to test scrollhack for IE.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'span',
+		extraPlugins: 'customwidget',
+		allowedContent: true
+	} );
+
+	CKEDITOR.plugins.add( 'customwidget', {
+		requires: 'widget',
+		allowedContent: 'div(copied)',
+
+		init: function ( editor )	{
+			var counter = 0;
+
+			editor.widgets.add( 'customwidget', {
+				button: 'Add widget',
+				template: '<div>Widget</div>',
+
+				getClipboardHtml: getClipboardHtml
+			} );
+
+			editor.widgets.add( 'customnestedwidget', {
+				button: 'Add nested widget',
+				template: '<div><p>Widget</p><div class="ned"><div data-widget="customwidget">Nested widget</div></div></div>',
+				getClipboardHtml: getClipboardHtml,
+
+				editables: {
+					ned: '.ned'
+				}
+			} );
+
+			function getClipboardHtml() {
+				counter++;
+
+				return '<div data-widget="' + this.name + '">Widget copied ' + counter + ' times!</div>';
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/widget/manual/clipboardhtmldnd.html
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.html
@@ -1,3 +1,4 @@
+<button type="button" id="reset">Reset</button>
 <div id="editor">
 	<p>Drop zone</p>
 	<p>[Start here</p>
@@ -10,11 +11,12 @@
 		</div>
 	</div>
 	<p>end here].</p>
-	<p>Some [[inline widget]], too!</p>
 	<p>Drop zone</p>
 </div>
 
 <script>
+	// IEs does not have proper support for setting clipboard data.
+	// Additionally support for d&d in Edge is too buggy to be able to handle this test.
 	if ( CKEDITOR.env.ie ) {
 		bender.ignore();
 	}
@@ -23,7 +25,16 @@
 		extraAllowedContent: 'span',
 		extraPlugins: 'customwidget',
 		allowedContent: true,
-		height: 500
+		height: 500,
+		on: {
+			pluginsLoaded: function( evt ) {
+				var editor = evt.editor;
+
+				CKEDITOR.document.getById( 'reset' ).on( 'click', function() {
+					editor.undoManager.reset();
+				} );
+			}
+		}
 	} );
 
 	CKEDITOR.plugins.add( 'customwidget', {
@@ -31,8 +42,6 @@
 		allowedContent: 'div(copied)',
 
 		init: function ( editor )	{
-			var counter = 0;
-
 			editor.widgets.add( 'customwidget', {
 				button: 'Add widget',
 				template: '<div>Widget</div>',
@@ -51,9 +60,11 @@
 			} );
 
 			function getClipboardHtml() {
-				counter++;
+				var counter = Number( this.data.counter ) || 0,
+					serializedData = encodeURIComponent( JSON.stringify( { counter: ++counter } ) );
 
-				return '<div data-widget="' + this.name + '">Widget copied ' + counter + ' times!</div>';
+				return '<div data-widget="' + this.name + '" data-cke-widget-data="' + serializedData + '">' +
+					'Widget dragged and dropped ' + counter + ' times!</div>';
 			}
 		}
 	} );

--- a/tests/plugins/widget/manual/clipboardhtmldnd.html
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.html
@@ -31,7 +31,7 @@
 				var editor = evt.editor;
 
 				CKEDITOR.document.getById( 'reset' ).on( 'click', function() {
-					editor.undoManager.reset();
+					editor.resetUndo();
 				} );
 			}
 		}

--- a/tests/plugins/widget/manual/clipboardhtmldnd.md
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.md
@@ -1,18 +1,16 @@
 @bender-tags: 4.14.0, feature, 3441
 @bender-ui: collapsed
-@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
+@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar, placeholder
 
-**NOTE:** It's expected that if you paste the same copied content multiple times, widget copy counter won't change. Counter changes only during `copy`, `cut` and `drop` operations. Please also note that the counter is the same for every widget instance.
-
-1. Manipulate the content by dragging and droping, both with one widget and content containing more than one widget.
+1. Select content inside the editor according to the instructions inside it. Drop the selected content into one of drop zones.
 
 	## Expected
 
-	After each operation manipulated widget's content changes into `Widget copied X times!` where `X` changes after every operation.
+	After dropping widgets' content changes into `Widget copied X times!` where `X` changes after every drop. Note: the same counter is used for all widgets!
 
 	## Unexpected
 
-	Widget message doesn't change.
+	Widgets' content doesn't change.
 2. Check if undo is working correctly after performing operations (you can use the button above the editor to reset undo stack)
 
 	## Expected
@@ -22,7 +20,3 @@
 	## Unexpected
 
 	Operations are broken into several steps.
-
-### Additional check for IE
-
-Check if selection is still visible on screen after dragging and dropping.

--- a/tests/plugins/widget/manual/clipboardhtmldnd.md
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.md
@@ -1,0 +1,28 @@
+@bender-tags: 4.14.0, feature, 3441
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
+
+**NOTE:** It's expected that if you paste the same copied content multiple times, widget copy counter won't change. Counter changes only during `copy`, `cut` and `drop` operations. Please also note that the counter is the same for every widget instance.
+
+1. Manipulate the content by dragging and droping, both with one widget and content containing more than one widget.
+
+	## Expected
+
+	After each operation manipulated widget's content changes into `Widget copied X times!` where `X` changes after every operation.
+
+	## Unexpected
+
+	Widget message doesn't change.
+2. Check if undo is working correctly after performing operations (you can use the button above the editor to reset undo stack)
+
+	## Expected
+
+	Every operation is atomic, it does not create unnecessary, intermediate steps.
+
+	## Unexpected
+
+	Operations are broken into several steps.
+
+### Additional check for IE
+
+Check if selection is still visible on screen after dragging and dropping.

--- a/tests/plugins/widget/manual/clipboardhtmldnd.md
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.md
@@ -6,7 +6,7 @@
 
 	## Expected
 
-	After dropping widgets' content changes into `Widget copied X times!` where `X` changes after every drop. Note: the same counter is used for all widgets!
+	After dropping widgets' content changes into `Widget dragged and dropped X times!` where `X` changes after every drop.
 
 	## Unexpected
 

--- a/tests/plugins/widget/manual/clipboardhtmldnd.md
+++ b/tests/plugins/widget/manual/clipboardhtmldnd.md
@@ -1,6 +1,6 @@
 @bender-tags: 4.14.0, feature, 3441
 @bender-ui: collapsed
-@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar, placeholder
+@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
 
 1. Select content inside the editor according to the instructions inside it. Drop the selected content into one of drop zones.
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#3441](https://github.com/ckeditor/ckeditor4/issues/3441) Added support for dragging and dropping multiple [widgets](https://ckeditor.com/cke4/addon/widget).
```

## What changes did you make?

I've added additional `drop` handler, which fires only if there are more than one widget in the selection or there is something else alongside the widget (e.g. text).

Unfortunately this feature does not work in IE, as it does not support custom MIME types in `DataTransfer`, and in Edge, due to #1850.

Closes #3441.
