### PR TITLE
Fix broken paste in iOS 13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@ Fixed Issues:
 * [#14613](https://dev.ckeditor.com/ticket/14613): Fixed: Race condition when loading plugins for an already destroyed editor instance throws an error.
 * [#2257](https://github.com/ckeditor/ckeditor-dev/issues/2257): Fixed: The editor throws an exception when destroyed shortly after it was created.
 * [#3115](https://github.com/ckeditor/ckeditor-dev/issues/3115): Fixed: Destroying the editor during the initialization throws an error.
+* [#3354](https://github.com/ckeditor/ckeditor4/issues/3354): [iOS] Fixed: Pasting no longer works on iOS version 13.
 
 API Changes:
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1634,7 +1634,7 @@
 	CKEDITOR.plugins.clipboard = {
 		/**
 		 * True if the environment allows to set data on copy or cut manually. This value is false in IE, because this browser
-		 * shows the security dialog window when the script tries to set clipboard data and on iOS, because custom data is
+		 * shows the security dialog window when the script tries to set clipboard data and on older iOS, because custom data is
 		 * not saved to clipboard there.
 		 *
 		 * @since 4.5.0

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1740,8 +1740,12 @@
 			}
 
 			// Safari fixed clipboard in 10.1 (https://bugs.webkit.org/show_bug.cgi?id=19893) (https://dev.ckeditor.com/ticket/16982).
-			// However iOS version still doesn't work well enough (https://bugs.webkit.org/show_bug.cgi?id=19893#c34).
 			if ( CKEDITOR.env.safari && CKEDITOR.env.version >= 603 && !CKEDITOR.env.iOS ) {
+				return true;
+			}
+
+			// Issue doesn't occur any longer in new iOS version (https://bugs.webkit.org/show_bug.cgi?id=19893#c34).
+			if ( CKEDITOR.env.iOS && CKEDITOR.env.version >= 605 ) {
 				return true;
 			}
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1641,7 +1641,18 @@
 		 * @readonly
 		 * @property {Boolean}
 		 */
-		isCustomCopyCutSupported: ( !CKEDITOR.env.ie || CKEDITOR.env.version >= 16 ) && !CKEDITOR.env.iOS,
+		isCustomCopyCutSupported: ( function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 ) {
+				return false;
+			}
+
+			// There might be lower version supported as well. However, we don't have possibility to test it. (#3354)
+			if ( CKEDITOR.env.iOS && CKEDITOR.env.version < 605 ) {
+				return false;
+			}
+
+			return true;
+		} )(),
 
 		/**
 		 * True if the environment supports MIME types and custom data types in dataTransfer/cliboardData getData/setData methods.

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1634,8 +1634,8 @@
 	CKEDITOR.plugins.clipboard = {
 		/**
 		 * True if the environment allows to set data on copy or cut manually. This value is false in IE, because this browser
-		 * shows the security dialog window when the script tries to set clipboard data and on older iOS, because custom data is
-		 * not saved to clipboard there.
+		 * shows the security dialog window when the script tries to set clipboard data and on older iOS (below version 13),
+		 * because custom data is not saved to clipboard there.
 		 *
 		 * @since 4.5.0
 		 * @readonly
@@ -1646,7 +1646,7 @@
 				return false;
 			}
 
-			// There might be lower version supported as well. However, we don't have possibility to test it. (#3354)
+			// There might be lower version supported as well. However, we don't have possibility to test it (#3354).
 			if ( CKEDITOR.env.iOS && CKEDITOR.env.version < 605 ) {
 				return false;
 			}
@@ -1744,7 +1744,7 @@
 				return true;
 			}
 
-			// Issue doesn't occur any longer in new iOS version (https://bugs.webkit.org/show_bug.cgi?id=19893#c34).
+			// Issue doesn't occur any longer in new iOS version (https://bugs.webkit.org/show_bug.cgi?id=19893#c34) (#3354).
 			if ( CKEDITOR.env.iOS && CKEDITOR.env.version >= 605 ) {
 				return true;
 			}

--- a/tests/plugins/clipboard/manual/customtypes.md
+++ b/tests/plugins/clipboard/manual/customtypes.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, feature, 468
+@bender-tags: 4.13.0, 4.8.0, feature, 468, 3354
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image2, list, elementspath, clipboard, link
 
 ## Custom types

--- a/tests/plugins/clipboard/manual/customtypesasync.md
+++ b/tests/plugins/clipboard/manual/customtypesasync.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.8.0, bug, #1223
+@bender-tags: 4.13.0, 4.8.0, bug, #1223, 3354
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image2, list, elementspath, clipboard, link
 
 ## Custom types

--- a/tests/plugins/clipboard/paste.js
+++ b/tests/plugins/clipboard/paste.js
@@ -49,8 +49,7 @@
 		} );
 	}
 
-	var trustySafari = CKEDITOR.env.safari && CKEDITOR.env.version >= 603 && !CKEDITOR.env.iOS,
-		trustyEdge = CKEDITOR.env.edge && CKEDITOR.env.version >= 16;
+	var trustyEdge = CKEDITOR.env.edge && CKEDITOR.env.version >= 16;
 
 	bender.test( {
 		setUp: function() {
@@ -1376,7 +1375,7 @@
 		},
 
 		'test canClipboardApiBeTrusted in Safari': function() {
-			if ( !trustySafari ) {
+			if ( !CKEDITOR.env.safari ) {
 				assert.ignore();
 			}
 
@@ -1471,7 +1470,7 @@
 		},
 
 		'test canClipboardApiBeTrusted on other browser': function() {
-			if ( CKEDITOR.env.chrome || CKEDITOR.env.gecko || trustySafari || trustyEdge ) {
+			if ( CKEDITOR.env.chrome || CKEDITOR.env.gecko || CKEDITOR.env.safari || trustyEdge ) {
 				assert.ignore();
 			}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#3354](https://github.com/ckeditor/ckeditor4/issues/3354) Fix: Broken paste in iOS 13.

```

## What changes did you make?

Mark current iOS Safari version as supported for custom copy/cut and mark it as trusted browsers. This flags generally change the way how we treat pasted and copied data:
https://github.com/ckeditor/ckeditor4/blob/98cae96bbe874496a63cdedd0dd9a8f869e3a0b3/plugins/clipboard/plugin.js#L2249-L2271
It looks like a bug which is reported here: https://bugs.webkit.org/show_bug.cgi?id=19893#c34 no longer occur in iOS Safari.
The current version of Safari supports custom data types applied in data transfer.

As tests were already there covering those features I just simple activate them. I also re-activate manual tests.

Closes #3354 