### PR TITLE
Fix for: editor.setData breaks shift+arrow selection behavior

### DIFF
--- a/core/selection/optimization.js
+++ b/core/selection/optimization.js
@@ -21,12 +21,18 @@
 			preventOptimization = false;
 		} );
 
-		editor.on( 'instanceReady', function() {
-			this.editable().on( 'keydown', function( evt ) {
+		editor.on( 'contentDom', function() {
+			var editable = editor.editable();
+
+			if ( !editable ) {
+				return;
+			}
+
+			editable.attachListener( editable, 'keydown', function( evt ) {
 				this._.shiftPressed = evt.data.$.shiftKey;
 			}, this );
 
-			this.editable().on( 'keyup', function( evt ) {
+			editable.attachListener( editable, 'keyup', function( evt ) {
 				this._.shiftPressed = evt.data.$.shiftKey;
 			}, this );
 		} );

--- a/tests/core/selection/manual/optimization.html
+++ b/tests/core/selection/manual/optimization.html
@@ -1,4 +1,47 @@
-<div id="editor">
+<h2>Iframe editor</h2>
+<div id="editor1">
+	<ul>
+		<li>Foo bar</li>
+		<li><strong>Foo</strong>
+			<ol>
+				<li>Bar</li>
+				<li><img alt="" src="../../../_assets/lena.jpg" style="height:50px; width:50px"/></li>
+				<li>Bar baz
+					<ol>
+						<li><strong>Baz</strong></li>
+						<li>Baz&nbsp;<strong><img alt="" src="../../../_assets/lena.jpg"
+												  style="font-weight:400; height:50px; width:50px"/></strong></li>
+						<li>Baz</li>
+					</ol>
+				</li>
+			</ol>
+		</li>
+	</ul>
+	<div>This is div</div>
+	<p>Text&nbsp;<img alt="" src="../../../_assets/lena.jpg" style="height:50px; width:50px"/></p>
+	<table border="1" cellspacing="1" cellpadding="1" style="width:500px">
+		<tbody>
+		<tr>
+			<td>Foo<br/>Bar</td>
+			<td>Bar</td>
+		</tr>
+		<tr>
+			<td><strong>Bar</strong></td>
+			<td><img alt="" src="../../../_assets/lena.jpg" style="height:50px; width:50px"/></td>
+		</tr>
+		<tr>
+			<td><img alt="" src="../../../_assets/lena.jpg" style="height:50px; width:50px"/></td>
+			<td><strong>Bar</strong><br/>Baz</td>
+		</tr>
+		</tbody>
+	</table>
+	<p>This is paragraph</p>
+	<p>This is paragraph</p>
+	<p><img alt="" src="../../../_assets/lena.jpg" style="height:50px; width:50px"/></p>
+</div>
+
+<h2>Divarea editor</h2>
+<div id="editor2">
 	<ul>
 		<li>Foo bar</li>
 		<li><strong>Foo</strong>
@@ -44,8 +87,14 @@
 		bender.ignore();
 	}
 
-	CKEDITOR.replace( 'editor', {
+	CKEDITOR.replace( 'editor1', {
 		removePlugins: 'tableselection',
+		height: 800
+	} );
+
+	CKEDITOR.replace( 'editor2', {
+		removePlugins: 'tableselection',
+		extraPlugins: 'divarea',
 		height: 800
 	} );
 </script>

--- a/tests/core/selection/manual/optimization.md
+++ b/tests/core/selection/manual/optimization.md
@@ -1,8 +1,10 @@
-@bender-tags: selection, 4.13.0, bug, 3161, 3175
+@bender-tags: selection, 4.13.0, bug, 3161, 3175, 3493
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo, div, table, image, basicstyles, format
 
-Play around with selection to check if there are no weird behaviours.
+Play around with selection in both editors to check if there are no weird behaviours.
+
+Switch to `source view` during testing few times to see if it doesn't affect the way selection works.
 
 Check different ways to manipulate selection:
 - Collapsed and non-collapsed selection with mouse

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -102,7 +102,27 @@
 				assertEditorHtml();
 				editor._.shiftPressed = false;
 			}
-		} )
+		} ),
+
+		'test selection optimization key listeners after setData() with keydown': function( editor, bot ) {
+			editor._.shiftPressed = null;
+
+			bot.setData( '<p>Foo</p><p><strong>bar</strong> baz</p>', function() {
+				bot.editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { shiftKey: true } ) );
+
+				assert.isTrue( editor._.shiftPressed );
+			} );
+		},
+
+		'test selection optimization key listeners after setData() with keyup': function( editor, bot ) {
+			editor._.shiftPressed = null;
+
+			bot.setData( '<p>Foo</p><p><strong>bar</strong> baz</p>', function() {
+				bot.editor.editable().fire( 'keyup', new CKEDITOR.dom.event( { shiftKey: false } ) );
+
+				assert.isFalse( editor._.shiftPressed );
+			} );
+		}
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -104,6 +104,7 @@
 			}
 		} ),
 
+		// (#3493)
 		'test selection optimization key listeners after setData() with keydown': function( editor, bot ) {
 			editor._.shiftPressed = null;
 
@@ -114,6 +115,7 @@
 			} );
 		},
 
+		// (#3493)
 		'test selection optimization key listeners after setData() with keyup': function( editor, bot ) {
 			editor._.shiftPressed = null;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

None, since it is a bugfix for a new feature.

## What changes did you make?

It turns out that after `setData()` call or switching to `source mode` or using `new page` button, new editable is created (AFAIU for Iframe editor only), and thus listeners attached to editable on `editor#instanceReady` event are no longer valid. Attaching listener to editable should be done on `contentDom` event which is fired every time new editable is used.

Closes #3493.
