### PR TITLE
Set correct focus on tab in dialog when is clicked

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ Fixed Issues:
 * [#3586](https://github.com/ckeditor/ckeditor4/issues/3586): Fixed: Content pasted from Excel is not correctly recognised by [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
 * [#3585](https://github.com/ckeditor/ckeditor4/issues/3585): [Firefox] Fixed: Excel content is pasted as an image.
 * [#3625](https://github.com/ckeditor/ckeditor4/issues/3625): [Firefox] Fixed: PowerPoint content is pasted as an image.
+* [#3474](https://github.com/ckeditor/ckeditor4/issues/3474): Fixed: Incorrect focus order after any tab in the [dialog](https://ckeditor.com/cke4/addon/dialog) was clicked.
+* [#3689](https://github.com/ckeditor/ckeditor4/issues/3689): Fixed: Cannot change [dialog](https://ckeditor.com/cke4/addon/dialog) tabs with keyboard arrows after focusing any tab with a mouse click.
 
 API Changes:
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -656,11 +656,10 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				var id = target.$.id;
 				this.selectPage( id.substring( 4, id.lastIndexOf( '_' ) ) );
 
-				if ( this._.tabBarMode ) {
-					this._.tabBarMode = false;
-					this._.currentFocusIndex = -1;
-					changeFocus( 1 );
-				}
+				this._.currentFocusIndex = -1;
+				changeFocus();
+				this._.tabBarMode = true;
+
 				evt.data.preventDefault();
 			}
 		}, this );

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -62,6 +62,8 @@ CKEDITOR.DIALOG_STATE_IDLE = 1;
 CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 ( function() {
+	'use strict';
+
 	var cssLength = CKEDITOR.tools.cssLength,
 		defaultDialogDefinition,
 		currentCover;

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -64,6 +64,12 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 ( function() {
 	var cssLength = CKEDITOR.tools.cssLength;
 
+	function focusActiveTab( dialog ) {
+		dialog._.tabBarMode = true;
+		dialog._.tabs[ dialog._.currentTabId ][ 0 ].focus();
+		dialog._.currentFocusIndex = -1;
+	}
+
 	function isTabVisible( tabId ) {
 		return !!this._.tabs[ tabId ][ 0 ].$.offsetHeight;
 	}
@@ -508,9 +514,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				processed = 1;
 			} else if ( keystroke == CKEDITOR.ALT + 121 && !me._.tabBarMode && me.getPageCount() > 1 ) {
 				// Alt-F10 puts focus into the current tab item in the tab bar.
-				me._.tabBarMode = true;
-				me._.tabs[ me._.currentTabId ][ 0 ].focus();
-				me._.currentFocusIndex = -1;
+				focusActiveTab( me );
 				processed = 1;
 			} else if ( CKEDITOR.tools.indexOf( arrowKeys, keystroke ) != -1 && me._.tabBarMode ) {
 				// Array with key codes that activate previous tab.
@@ -656,9 +660,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				var id = target.$.id;
 				this.selectPage( id.substring( 4, id.lastIndexOf( '_' ) ) );
 
-				this._.currentFocusIndex = -1;
-				changeFocus();
-				this._.tabBarMode = true;
+				focusActiveTab( this );
 
 				evt.data.preventDefault();
 			}

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -189,6 +189,29 @@
 			tc.wait();
 		},
 
+		asyncDialog: function( dialogName ) {
+			var editor = this.editor;
+
+			return new CKEDITOR.tools.promise( function( resolve, reject ) {
+
+				editor.on( 'dialogShow', function( event ) {
+					var dialog = event.data;
+
+					event.removeListener();
+
+					CKEDITOR.tools.setTimeout( function() {
+						resolve( dialog );
+					}, 0 );
+				} );
+
+				CKEDITOR.tools.setTimeout( function() {
+					reject();
+				}, 5000 );
+
+				editor.execCommand( dialogName );
+			} );
+		},
+
 		getData: function( fixHtml, compatHtml ) {
 			var data = this.editor.getData();
 

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -194,7 +194,10 @@
 
 			return new CKEDITOR.tools.promise( function( resolve, reject ) {
 				var resolveTimeout,
-					rejectTimeout;
+					rejectTimeout,
+					// IE 11 requires some delay to fully show up and initialize dialog. From testing it looks like 10ms is enough,
+					// however, the value is increased 5 times to have safe overhead.
+					resolveDelay = CKEDITOR.env.ie && CKEDITOR.env.version === 11 ? 50 : 0;
 
 				editor.on( 'dialogShow', function( event ) {
 					var dialog = event.data;
@@ -206,7 +209,7 @@
 							window.clearTimeout( rejectTimeout );
 						}
 						resolve( dialog );
-					}, 0 );
+					}, resolveDelay );
 				} );
 
 				rejectTimeout = CKEDITOR.tools.setTimeout( function() {

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -193,18 +193,28 @@
 			var editor = this.editor;
 
 			return new CKEDITOR.tools.promise( function( resolve, reject ) {
+				var resolveTimeout,
+					rejectTimeout;
 
 				editor.on( 'dialogShow', function( event ) {
 					var dialog = event.data;
 
 					event.removeListener();
 
-					CKEDITOR.tools.setTimeout( function() {
+					resolveTimeout = CKEDITOR.tools.setTimeout( function() {
+						if ( rejectTimeout !== undefined ) {
+							window.clearTimeout( rejectTimeout );
+						}
 						resolve( dialog );
 					}, 0 );
 				} );
 
-				CKEDITOR.tools.setTimeout( function() {
+				rejectTimeout = CKEDITOR.tools.setTimeout( function() {
+					// Technically resolveTimeout should always be undefined. However there is slight chance, that showing dialog will be executed,
+					// and resolveTimeout will be created, but already pass 5 seconds and rejectTimeout will be already waiting in event loop.
+					if ( resolveTimeout !== undefined ) {
+						window.clearTimeout( resolveTimeout );
+					}
 					reject( new Error( 'There was no "dialogShow" event for last 5 seconds.' ) );
 				}, 5000 );
 

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -205,7 +205,7 @@
 				} );
 
 				CKEDITOR.tools.setTimeout( function() {
-					reject();
+					reject( new Error( 'There was no "dialogShow" event for last 5 seconds.' ) );
 				}, 5000 );
 
 				editor.execCommand( dialogName );

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -213,8 +213,8 @@
 				} );
 
 				rejectTimeout = CKEDITOR.tools.setTimeout( function() {
-					// Technically resolveTimeout should always be undefined. However there is slight chance, that showing dialog will be executed,
-					// and resolveTimeout will be created, but already pass 5 seconds and rejectTimeout will be already waiting in event loop.
+					// Generally resolveTimeout should always be undefined. However, there is slight chance, that showing dialog will be executed slower.
+					// So the resolveTimeout will be created with much delay. If that delay will be almost exact 5 seconds, then rejectTimeout will be first in the event loop.
 					if ( resolveTimeout !== undefined ) {
 						window.clearTimeout( resolveTimeout );
 					}

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -196,7 +196,7 @@
 				var resolveTimeout,
 					rejectTimeout,
 					// IE 11 requires some delay to fully show up and initialize dialog. From testing it looks like 10ms is enough,
-					// however, the value is increased 5 times to have safe overhead.
+					// however, the value is increased 5 times to have safe margin.
 					resolveDelay = CKEDITOR.env.ie && CKEDITOR.env.version === 11 ? 50 : 0;
 
 				editor.on( 'dialogShow', function( event ) {
@@ -218,7 +218,7 @@
 					if ( resolveTimeout !== undefined ) {
 						window.clearTimeout( resolveTimeout );
 					}
-					reject( new Error( 'There was no "dialogShow" event for last 5 seconds.' ) );
+					reject( new Error( 'There was no "dialogShow" event for at least 5 seconds.' ) );
 				}, 5000 );
 
 				editor.execCommand( dialogName );

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -213,8 +213,6 @@
 				} );
 
 				rejectTimeout = CKEDITOR.tools.setTimeout( function() {
-					// Generally resolveTimeout should always be undefined. However, there is slight chance, that showing dialog will be executed slower.
-					// So the resolveTimeout will be created with much delay. If that delay will be almost exact 5 seconds, then rejectTimeout will be first in the event loop.
 					if ( resolveTimeout !== undefined ) {
 						window.clearTimeout( resolveTimeout );
 					}

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -359,7 +359,18 @@
 					changeFocus( dialog, options );
 				} );
 			};
+		},
+
+		addPredefinedDialogsToEditor: function( editor ) {
+			CKEDITOR.dialog.add( 'singlePageDialog', this.definitions.singlePage );
+			CKEDITOR.dialog.add( 'multiPageDialog', this.definitions.multiPage );
+			CKEDITOR.dialog.add( 'hiddenPageDialog', this.definitions.hiddenPage );
+
+			editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialog' ) );
+			editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialog' ) );
+			editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialog' ) );
 		}
+
 	};
 
 	window.dialogTools = dialogTools;

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -13,7 +13,7 @@
 			}, null, null, 100000 );
 		} );
 
-		// Applug listening tofocus change on elements in dialog
+		// Apply listening to focus change on elements in dialog.
 		CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
 			item.on( 'focus', function() {
 				dialog.fire( 'focus:change' );

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -27,7 +27,7 @@
 	// 2. passing `options.elementId` and `options.tab` moves focus with `CKEDITOR.dom.element.focus()` on element found with options values
 	// 3. passing `options.buttonName` moves focus to "OK" or "Cancel" buttons by execution of `CKEDITOR.dom.element.focus()` on this element
 	// 4. passing `options.key` fires "keydown" event on dialog._.element with a specified keyCode. It simulates moving focus with a keyboard.
-	//   There might be also added key modifiers "shift" or "alt"
+	//    There might be also added key modifiers "shift" or "alt"
 	//
 	// In case of passing invalid options option, function throws a descriptive error.
 	function changeFocus( dialog, options ) {

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -1,0 +1,324 @@
+( function() {
+	'use strict';
+
+	// Flag indicates if safety timout for promise should be enabled.
+	var hasRejects = true;
+
+	// Function extends dialog with a new event which executes a `focus:change` event, when tab or element on focusList gain a focus
+	// This general approach helps to finish promises when focus is changed inside dialog.
+	function onLoadHandler( evt ) {
+		var dialog = evt.sender;
+
+		// Apply listening to focus change on tabs in dialog
+		CKEDITOR.tools.array.forEach( CKEDITOR.tools.object.values( dialog._.tabs ), function( item ) {
+			item[ 0 ].on( 'focus', function() {
+				dialog.fire( 'focus:change' );
+			}, null, null, 100000 );
+		} );
+
+		// Applug listening tofocus change on elements in dialog
+		CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
+			item.on( 'focus', function() {
+				dialog.fire( 'focus:change' );
+			}, null, null, 100000 );
+		} );
+	}
+
+	// Function generates specific event ( based on config ), which have to result with focus change in dialog.
+	function focusChanger( dialog, config ) {
+		var element;
+
+		if ( config.direction === 'next' ) {
+			dialog.changeFocus( 1 );
+			return;
+		}
+
+		if ( config.direction === 'previous' ) {
+			dialog.changeFocus( -1 );
+			return;
+		}
+
+		if ( config.elementId && config.tab ) {
+			element = dialog.getContentElement( config.tab, config.elementId ).getInputElement();
+			element.focus();
+			return;
+		}
+
+		if ( config.buttonName ) {
+			element = dialog.getButton( config.buttonName ).getInputElement();
+			element.focus();
+			return;
+		}
+
+		if ( config.key ) {
+			dialog._.element.fire( 'keydown', new CKEDITOR.dom.event( {
+				keyCode: config.key,
+				shiftKey: config.shiftKey ? true : false,
+				altKey: config.altKey ? true : false
+			} ) );
+			return;
+		}
+
+		throw new Error( 'Invalid focus config: ' + JSON.stringify( config ) );
+	}
+
+
+	var dialogTools = {
+		// Dialog definitions used in test cases.
+		definitions: {
+			singlePage: function() {
+				return {
+					title: 'Single page dialog',
+					contents: [
+						{
+							id: 'sp-test1',
+							elements: [
+								{
+									type: 'text',
+									id: 'sp-input1',
+									label: 'input 1'
+								},
+								{
+									type: 'text',
+									id: 'sp-input2',
+									label: 'input 2'
+								},
+								{
+									type: 'text',
+									id: 'sp-input3',
+									label: 'input 3'
+								}
+							]
+						}
+					],
+					onLoad: onLoadHandler
+				};
+			},
+			multiPage: function() {
+				return {
+					title: 'Mult page dialog',
+					contents: [
+						{
+							id: 'mp-test1',
+							label: 'MP 1',
+							elements: [
+								{
+									type: 'text',
+									id: 'mp-input11',
+									label: 'input 11'
+								},
+								{
+									type: 'text',
+									id: 'mp-input12',
+									label: 'input 12'
+								},
+								{
+									type: 'text',
+									id: 'mp-input13',
+									label: 'input 13'
+								}
+							]
+						},
+						{
+							id: 'mp-test2',
+							label: 'MP 2',
+							elements: [
+								{
+									type: 'text',
+									id: 'mp-input21',
+									label: 'input 21'
+								}
+							]
+						},
+						{
+							id: 'mp-test3',
+							label: 'MP 3',
+							elements: [
+								{
+									type: 'text',
+									id: 'mp-input31',
+									label: 'input 31'
+								},
+								{
+									type: 'text',
+									id: 'mp-input32',
+									label: 'input 32'
+								},
+								{
+									type: 'text',
+									id: 'mp-input33',
+									label: 'input 33'
+								},
+								{
+									type: 'text',
+									id: 'mp-input34',
+									label: 'input 34'
+								},
+								{
+									type: 'text',
+									id: 'mp-input35',
+									label: 'input 35'
+								}
+							]
+						}
+					],
+					onLoad: onLoadHandler
+				};
+			},
+			hiddenPage: function() {
+				return {
+					title: 'Hidden page dialog',
+					contents: [
+						{
+							id: 'hp-test1',
+							label: 'HP 1',
+							elements: [
+								{
+									type: 'text',
+									id: 'hp-input11',
+									label: 'input 11'
+								},
+								{
+									type: 'text',
+									id: 'hp-input12',
+									label: 'input 12'
+								},
+								{
+									type: 'text',
+									id: 'hp-input13',
+									label: 'input 13'
+								}
+							]
+						},
+						{
+							id: 'hp-test2',
+							label: 'HP 2',
+							elements: [
+								{
+									type: 'text',
+									id: 'hp-input21',
+									label: 'input 21',
+									requiredContent: 'fakeElement'
+								},
+								{
+									type: 'text',
+									id: 'hp-input22',
+									label: 'input 22'
+								},
+								{
+									type: 'text',
+									id: 'hp-input23',
+									label: 'input 23',
+									requiredContent: 'fakeElement'
+								}
+							]
+						},
+						{
+							id: 'hp-test3',
+							label: 'HP 3',
+							requiredContent: 'fakeElement',
+							elements: [
+								{
+									type: 'text',
+									id: 'hp-input31',
+									label: 'input 31'
+								},
+								{
+									type: 'text',
+									id: 'hp-input32',
+									label: 'input 32'
+								},
+								{
+									type: 'text',
+									id: 'hp-input33',
+									label: 'input 33'
+								},
+								{
+									type: 'text',
+									id: 'hp-input34',
+									label: 'input 34'
+								},
+								{
+									type: 'text',
+									id: 'hp-input35',
+									label: 'input 35'
+								}
+							]
+						},
+						{
+							id: 'hp-test4',
+							label: 'HP 4',
+							elements: [
+								{
+									type: 'text',
+									id: 'hp-input41',
+									label: 'input 41'
+								}
+							]
+						}
+					],
+					onLoad: onLoadHandler
+				};
+			}
+		},
+
+		// Assert for checking dialog elements and buttons.
+		// config.buttonName {String} 'ok' or 'cancel'
+		// config.tab {String} ID of a tabe in dialog
+		// config.elementId {String} ID of an element on a given tab page
+		assertFocusedElement: function( config ) {
+			return function( dialog ) {
+				var actualFocusedElement = dialog._.focusList[ dialog._.currentFocusIndex ];
+				var expectedFocusedElement;
+
+				if ( config.buttonName ) {
+					expectedFocusedElement = dialog.getButton( config.buttonName );
+				} else {
+					expectedFocusedElement = dialog.getContentElement( config.tab, config.elementId );
+				}
+
+				assert.areEqual( expectedFocusedElement, actualFocusedElement,
+					'Element: "' + expectedFocusedElement.id + '" should be equal to currently focused element: "' + actualFocusedElement.id + '".' );
+				return dialog;
+			};
+		},
+
+		// Assert to check focus on tab elements in dialog
+		// tabName {String} ID of a tab
+		assertFocusedTab: function( tabName ) {
+			return function( dialog ) {
+				assert.areEqual( -1, dialog._.currentFocusIndex );
+				assert.areEqual( tabName, dialog._.currentTabId );
+
+				return dialog;
+			};
+		},
+
+		// Provides a thenable function which preserved proper config in a closure.
+		// The idea is to wrap function which change focus (focusChanger) with a promise. Then wait until dialog generate
+		// a `focus:change` event which should exist because of execution of onLoadHandler.
+		// There is additional safety mechanism which rejects promise after 5 seconds without focus change. It might be disabled with
+		// `hasRejects` flag.
+		focusElement: function( config ) {
+			return function( dialog ) {
+				return new CKEDITOR.tools.promise( function( resolve, reject ) {
+					dialog.once( 'focus:change', function() {
+						CKEDITOR.tools.setTimeout( function() {
+							resolve( dialog );
+						} );
+					} );
+
+					if ( hasRejects ) {
+						CKEDITOR.tools.setTimeout( function() {
+							reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
+						}, 5000 );
+					}
+
+					focusChanger( dialog, config );
+				} );
+			};
+		}
+	};
+
+	window.dialogTools = dialogTools;
+} )();

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	// Function extends dialog with a new event (`focusChange`) which is executed, when tab or element on `focusList` gains focus.
-	// This generic approach helps to resolve promises, when focus was changed intenrally by the dialog itself.
+	// This generic approach helps to resolve promises, when focus was changed internally by the dialog.
 	function onLoadHandler( evt ) {
 		var dialog = evt.sender;
 
@@ -21,13 +21,13 @@
 		} );
 	}
 
-	// Function changes focused element or fires event, which tirggers focus change in the dialog, based on provided options.
+	// Function changes focused element or fires event which triggers focus change in the dialog, based on provided options.
 	//
-	// It supports few possibilities, which interact with dialog in a different way:
+	// It supports few possibilities to interact with a dialog in a different way:
 	// 1. Passing `options.direction` moves focus with dialog method `changeFocus`.
 	// 2. Passing `options.elementId` and `options.tab` moves focus with `CKEDITOR.dom.element.focus()` method to found element.
 	// 3. Passing `options.buttonName` moves focus to "OK" or "Cancel" buttons with `CKEDITOR.dom.element.focus()` method.
-	// 4. Passing `options.key` fires `keydown` event on dialog._.element with a specified `keyCode`. It simulates moving focus
+	// 4. Passing `options.key` fires `keydown` event on `dialog._.element` with a specified `keyCode`. It simulates moving focus
 	// with a keyboard. It also supports key modifiers: `shift` or `alt`.
 	//
 	// Function returns true if it triggered focus change. In case of passing invalid options argument, function throws a descriptive error.
@@ -296,8 +296,8 @@
 			}
 		},
 
-		// Assert checking dialog focused element or button.
-		// It requires either `buttonName` or combintation of `tab` and `elementId` input options.
+		// Asserts dialog focused element or button.
+		// It requires either `buttonName` or combination of `tab` and `elementId` input options.
 		//
 		// @param options
 		// @param {String} [options.buttonName] Button name from dialog footer, usually 'ok' or 'cancel'.
@@ -325,7 +325,7 @@
 			};
 		},
 
-		// Assert checking dialog focused tab.
+		// Asserts dialog focused tab.
 		//
 		// @param {String} tab The tab ID.
 		assertFocusedTab: function( tab ) {
@@ -337,10 +337,14 @@
 			};
 		},
 
-		// Provides a thenable function which preserved proper options in a closure.
-		// The idea is to wrap function which change focus with a promise. Then wait until dialog generate
-		// a `focusChange` event which should be fired because of execution of onLoadHandler.
-		// There is additional safety switch which rejects promise after 5 seconds without focus change.
+		// Provides a thenable/chainable function which returns "dialog changing focus" promise when called.
+		//
+		// The idea is to wrap a function which changes focus into a promise. The promise resolves when dialog generates
+		// a `focusChange` event. There is an additional safety switch which rejects promise after 5 seconds without focus change.
+		//
+		// @param {Object} options See private `changeFocus` function for available options.
+		// @returns {Function} Function which accepts dialog parameter and returns promise object. The returned promise
+		// changes dialog focused based on provided initial options. When focus change fails, the Promise is rejected after 5 seconds.
 		focusElement: function( options ) {
 			return function( dialog ) {
 				return new CKEDITOR.tools.promise( function( resolve, reject ) {
@@ -349,7 +353,7 @@
 
 					dialog.once( 'focusChange', function() {
 						// Keep the event asynchronous to make sure that all changes related to focus change
-						// on a given element or tab were  already prcoessed.
+						// on a given element or tab were already processed.
 						resolveTimeout = CKEDITOR.tools.setTimeout( function() {
 							if ( rejectTimeout !== undefined ) {
 								window.clearTimeout( rejectTimeout );
@@ -358,7 +362,7 @@
 						} );
 					} );
 
-					// Safety switch to finish promise in case of lack of focus change in dialog.
+					// Safety switch to reject a promise in case of lack of focus change in the dialog.
 					rejectTimeout = CKEDITOR.tools.setTimeout( function() {
 						if ( resolveTimeout !== undefined ) {
 							window.clearTimeout( resolveTimeout );
@@ -371,7 +375,9 @@
 			};
 		},
 
-		// Setup test dialogs on given editor instance.
+		// Setups test dialogs on a given editor instance.
+		//
+		// @param {CKEDITOR.editor} editor
 		addPredefinedDialogsToEditor: function( editor ) {
 			CKEDITOR.dialog.add( 'singlePageDialog', this.definitions.singlePage );
 			CKEDITOR.dialog.add( 'multiPageDialog', this.definitions.multiPage );

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -23,48 +23,53 @@
 
 	// Function generates event, based on passed config, which changes focus in the dialog.
 	// It supports few possibilities, which interact with dialog in a different way.
-	// * passing `config.direction` moves focus with dialog method `changeFocus`
-	// * passing `config.elementId` and `config.tab` moves focus with `CKEDITOR.dom.element.focus()` on element found with config values
-	// * passing `config.buttonName` moves focus to "OK" or "Cancel" buttons by execution of `CKEDITOR.dom.element.focus()` on this element
-	// * passing `config.key` fires "keydown" event on dialog._.element with a specified keyCode. It simulates moving focus with a keyboard.
-	//   There might be also added key modifiers such as "shift", "ctrl", "alt"
+	// 1. passing `config.direction` moves focus with dialog method `changeFocus`
+	// 2. passing `config.elementId` and `config.tab` moves focus with `CKEDITOR.dom.element.focus()` on element found with config values
+	// 3. passing `config.buttonName` moves focus to "OK" or "Cancel" buttons by execution of `CKEDITOR.dom.element.focus()` on this element
+	// 4. passing `config.key` fires "keydown" event on dialog._.element with a specified keyCode. It simulates moving focus with a keyboard.
+	//   There might be also added key modifiers "shift" or "alt"
 	//
 	// In case of passing invalid config option, function throws a descriptive error.
 	function changeFocus( dialog, config ) {
 		var element;
 
+		if ( !( dialog instanceof CKEDITOR.dialog ) ) {
+			throw new Error( 'Passed "dialog" argument is not an instance of the CKEDITOR.dialog.' );
+		}
+
 		if ( config.direction === 'next' ) {
+			// 1.
 			dialog.changeFocus( 1 );
-			return;
-		}
-
-		if ( config.direction === 'previous' ) {
+		} else if ( config.direction === 'previous' ) {
+			// 1.
 			dialog.changeFocus( -1 );
-			return;
-		}
-
-		if ( config.elementId && config.tab ) {
-			element = dialog.getContentElement( config.tab, config.elementId ).getInputElement();
-			element.focus();
-			return;
-		}
-
-		if ( config.buttonName ) {
-			element = dialog.getButton( config.buttonName ).getInputElement();
-			element.focus();
-			return;
-		}
-
-		if ( config.key ) {
+		} else if ( config.key ) {
+			if ( typeof config.key !== 'number' ) {
+				throw new Error( 'Invalid focus config. "config.key" should be a number: ' + JSON.stringify( config ) );
+			}
+			// 4.
 			dialog._.element.fire( 'keydown', new CKEDITOR.dom.event( {
 				keyCode: config.key,
 				shiftKey: config.shiftKey ? true : false,
 				altKey: config.altKey ? true : false
 			} ) );
-			return;
-		}
+		} else {
+			if ( config.elementId && config.tab ) {
+				// 2.
+				element = dialog.getContentElement( config.tab, config.elementId ).getInputElement();
+			} else if ( config.buttonName ) {
+				// 3.
+				element = dialog.getButton( config.buttonName ).getInputElement();
+			} else {
+				throw new Error( 'Invalid focus config. There is no valid "Object.key": ' + JSON.stringify( config ) );
+			}
 
-		throw new Error( 'Invalid focus config: ' + JSON.stringify( config ) );
+			if ( element ) {
+				element.focus();
+			} else {
+				throw new Error( 'Invalid focus config. DOM element cannot be found based on the config: ' + JSON.stringify( config ) );
+			}
+		}
 	}
 
 
@@ -84,12 +89,14 @@
 									label: 'input 1'
 								},
 								{
-									type: 'text',
+									type: 'select',
 									id: 'sp-input2',
-									label: 'input 2'
+									label: 'input 2',
+									items: [ [ 'A' ], [ 'B' ], [ 'C' ], [ 'D' ] ],
+									'default': 'C'
 								},
 								{
-									type: 'text',
+									type: 'checkbox',
 									id: 'sp-input3',
 									label: 'input 3'
 								}
@@ -108,12 +115,14 @@
 							label: 'MP 1',
 							elements: [
 								{
-									type: 'text',
+									type: 'select',
 									id: 'mp-input11',
-									label: 'input 11'
+									label: 'input 11',
+									items: [ [ 'A' ], [ 'B' ], [ 'C' ], [ 'D' ] ],
+									'default': 'C'
 								},
 								{
-									type: 'text',
+									type: 'button',
 									id: 'mp-input12',
 									label: 'input 12'
 								},
@@ -129,9 +138,11 @@
 							label: 'MP 2',
 							elements: [
 								{
-									type: 'text',
+									type: 'select',
 									id: 'mp-input21',
-									label: 'input 21'
+									label: 'input 21',
+									items: [ [ 'X' ], [ 'Y' ], [ 'Z' ] ],
+									'default': 'Y'
 								}
 							]
 						},
@@ -140,12 +151,12 @@
 							label: 'MP 3',
 							elements: [
 								{
-									type: 'text',
+									type: 'checkbox',
 									id: 'mp-input31',
 									label: 'input 31'
 								},
 								{
-									type: 'text',
+									type: 'button',
 									id: 'mp-input32',
 									label: 'input 32'
 								},
@@ -155,14 +166,16 @@
 									label: 'input 33'
 								},
 								{
-									type: 'text',
+									type: 'textarea',
 									id: 'mp-input34',
 									label: 'input 34'
 								},
 								{
-									type: 'text',
+									type: 'select',
 									id: 'mp-input35',
-									label: 'input 35'
+									label: 'input 35',
+									items: [ [ '111' ], [ '222' ], [ '333' ] ],
+									'default': '111'
 								}
 							]
 						}
@@ -184,14 +197,16 @@
 									label: 'input 11'
 								},
 								{
-									type: 'text',
+									type: 'textarea',
 									id: 'hp-input12',
 									label: 'input 12'
 								},
 								{
-									type: 'text',
+									type: 'select',
 									id: 'hp-input13',
-									label: 'input 13'
+									label: 'input 13',
+									items: [ [ 'A' ], [ 'B' ], [ 'C' ] ],
+									'default': 'C'
 								}
 							]
 						},
@@ -200,18 +215,20 @@
 							label: 'HP 2',
 							elements: [
 								{
-									type: 'text',
+									type: 'button',
 									id: 'hp-input21',
 									label: 'input 21',
 									requiredContent: 'fakeElement' // This input element should be hidden.
 								},
 								{
-									type: 'text',
+									type: 'select',
 									id: 'hp-input22',
-									label: 'input 22'
+									label: 'input 22',
+									items: [ [ 'A' ], [ 'B' ], [ 'C' ] ],
+									'default': 'C'
 								},
 								{
-									type: 'text',
+									type: 'textarea',
 									id: 'hp-input23',
 									label: 'input 23',
 									requiredContent: 'fakeElement' // This input element should be hidden.
@@ -224,22 +241,24 @@
 							requiredContent: 'fakeElement', // Entire tab should be hidden.
 							elements: [
 								{
-									type: 'text',
+									type: 'button',
 									id: 'hp-input31',
 									label: 'input 31'
 								},
 								{
-									type: 'text',
+									type: 'checkbox',
 									id: 'hp-input32',
 									label: 'input 32'
 								},
 								{
-									type: 'text',
+									type: 'select',
 									id: 'hp-input33',
-									label: 'input 33'
+									label: 'input 33',
+									items: [ [ '111' ], [ '222' ], [ '333' ] ],
+									'default': '111'
 								},
 								{
-									type: 'text',
+									type: 'textarea',
 									id: 'hp-input34',
 									label: 'input 34'
 								},
@@ -255,7 +274,7 @@
 							label: 'HP 4',
 							elements: [
 								{
-									type: 'text',
+									type: 'button',
 									id: 'hp-input41',
 									label: 'input 41'
 								}

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -21,9 +21,16 @@
 		} );
 	}
 
-	// Function generates specific event ( based on config ), which have to change focus in dialog.
-	// For example pressing a `TAB` key should move focus to the next ocusable element.
-	function focusChanger( dialog, config ) {
+	// Function generates event, based on passed config, which changes focus in the dialog.
+	// It supports few possibilities, which interact with dialog in a different way.
+	// * passing `config.direction` moves focus with dialog method `changeFocus`
+	// * passing `config.elementId` and `config.tab` moves focus with `CKEDITOR.dom.element.focus()` on element found with config values
+	// * passing `config.buttonName` moves focus to "OK" or "Cancel" buttons by execution of `CKEDITOR.dom.element.focus()` on this element
+	// * passing `config.key` fires "keydown" event on dialog._.element with a specified keyCode. It simulates moving focus with a keyboard.
+	//   There might be also added key modifiers such as "shift", "ctrl", "alt"
+	//
+	// In case of passing invalid config option, function throws a descriptive error.
+	function changeFocus( dialog, config ) {
 		var element;
 
 		if ( config.direction === 'next' ) {
@@ -293,7 +300,7 @@
 		},
 
 		// Provides a thenable function which preserved proper config in a closure.
-		// The idea is to wrap function which change focus (focusChanger) with a promise. Then wait until dialog generate
+		// The idea is to wrap function which change focus with a promise. Then wait until dialog generate
 		// a `focusChange` event which should be fired because of execution of onLoadHandler.
 		// There is additional safety switch which rejects promise after 5 seconds without focus change.
 		focusElement: function( config ) {
@@ -312,7 +319,7 @@
 						reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
 					}, 5000 );
 
-					focusChanger( dialog, config );
+					changeFocus( dialog, config );
 				} );
 			};
 		}

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -21,53 +21,53 @@
 		} );
 	}
 
-	// Function generates event, based on passed config, which changes focus in the dialog.
+	// Function generates event, based on passed options, which changes focus in the dialog.
 	// It supports few possibilities, which interact with dialog in a different way.
-	// 1. passing `config.direction` moves focus with dialog method `changeFocus`
-	// 2. passing `config.elementId` and `config.tab` moves focus with `CKEDITOR.dom.element.focus()` on element found with config values
-	// 3. passing `config.buttonName` moves focus to "OK" or "Cancel" buttons by execution of `CKEDITOR.dom.element.focus()` on this element
-	// 4. passing `config.key` fires "keydown" event on dialog._.element with a specified keyCode. It simulates moving focus with a keyboard.
+	// 1. passing `options.direction` moves focus with dialog method `changeFocus`
+	// 2. passing `options.elementId` and `options.tab` moves focus with `CKEDITOR.dom.element.focus()` on element found with options values
+	// 3. passing `options.buttonName` moves focus to "OK" or "Cancel" buttons by execution of `CKEDITOR.dom.element.focus()` on this element
+	// 4. passing `options.key` fires "keydown" event on dialog._.element with a specified keyCode. It simulates moving focus with a keyboard.
 	//   There might be also added key modifiers "shift" or "alt"
 	//
-	// In case of passing invalid config option, function throws a descriptive error.
-	function changeFocus( dialog, config ) {
+	// In case of passing invalid options option, function throws a descriptive error.
+	function changeFocus( dialog, options ) {
 		var element;
 
 		if ( !( dialog instanceof CKEDITOR.dialog ) ) {
 			throw new Error( 'Passed "dialog" argument is not an instance of the CKEDITOR.dialog.' );
 		}
 
-		if ( config.direction === 'next' ) {
+		if ( options.direction === 'next' ) {
 			// 1.
 			dialog.changeFocus( 1 );
-		} else if ( config.direction === 'previous' ) {
+		} else if ( options.direction === 'previous' ) {
 			// 1.
 			dialog.changeFocus( -1 );
-		} else if ( config.key ) {
-			if ( typeof config.key !== 'number' ) {
-				throw new Error( 'Invalid focus config. "config.key" should be a number: ' + JSON.stringify( config ) );
+		} else if ( options.key ) {
+			if ( typeof options.key !== 'number' ) {
+				throw new Error( 'Invalid focus options. "options.key" should be a number: ' + JSON.stringify( options ) );
 			}
 			// 4.
 			dialog._.element.fire( 'keydown', new CKEDITOR.dom.event( {
-				keyCode: config.key,
-				shiftKey: config.shiftKey ? true : false,
-				altKey: config.altKey ? true : false
+				keyCode: options.key,
+				shiftKey: options.shiftKey ? true : false,
+				altKey: options.altKey ? true : false
 			} ) );
 		} else {
-			if ( config.elementId && config.tab ) {
+			if ( options.elementId && options.tab ) {
 				// 2.
-				element = dialog.getContentElement( config.tab, config.elementId ).getInputElement();
-			} else if ( config.buttonName ) {
+				element = dialog.getContentElement( options.tab, options.elementId ).getInputElement();
+			} else if ( options.buttonName ) {
 				// 3.
-				element = dialog.getButton( config.buttonName ).getInputElement();
+				element = dialog.getButton( options.buttonName ).getInputElement();
 			} else {
-				throw new Error( 'Invalid focus config. There is no valid "Object.key": ' + JSON.stringify( config ) );
+				throw new Error( 'Invalid focus options. There is no valid "Object.key": ' + JSON.stringify( options ) );
 			}
 
 			if ( element ) {
 				element.focus();
 			} else {
-				throw new Error( 'Invalid focus config. DOM element cannot be found based on the config: ' + JSON.stringify( config ) );
+				throw new Error( 'Invalid focus options. DOM element cannot be found based on the options: ' + JSON.stringify( options ) );
 			}
 		}
 	}
@@ -327,11 +327,11 @@
 			};
 		},
 
-		// Provides a thenable function which preserved proper config in a closure.
+		// Provides a thenable function which preserved proper options in a closure.
 		// The idea is to wrap function which change focus with a promise. Then wait until dialog generate
 		// a `focusChange` event which should be fired because of execution of onLoadHandler.
 		// There is additional safety switch which rejects promise after 5 seconds without focus change.
-		focusElement: function( config ) {
+		focusElement: function( options ) {
 			return function( dialog ) {
 				return new CKEDITOR.tools.promise( function( resolve, reject ) {
 					var resolveTimeout,
@@ -356,7 +356,7 @@
 						reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
 					}, 5000 );
 
-					changeFocus( dialog, config );
+					changeFocus( dialog, options );
 				} );
 			};
 		}

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -287,28 +287,37 @@
 		},
 
 		// Assert for checking dialog elements and buttons.
-		// config.buttonName {String} 'ok' or 'cancel'
-		// config.tab {String} the ID of a tab in the dialog
-		// config.elementId {String} the ID of an element on a given tab page
-		assertFocusedElement: function( config ) {
+		// Requires either `buttonName` or combintation of `tab` and `elementId` input options.
+		//
+		// @param options
+		// @param {String} [options.buttonName] represent name of the button from dialog footer, usually 'ok' or 'cancel'
+		// @param {String} [options.tab] the ID of a tab in the dialog
+		// @param {String} [options.elementId] the ID of an element on a given tab page
+		assertFocusedElement: function( options ) {
 			return function( dialog ) {
 				var actualFocusedElement = dialog._.focusList[ dialog._.currentFocusIndex ];
 				var expectedFocusedElement;
 
-				if ( config.buttonName ) {
-					expectedFocusedElement = dialog.getButton( config.buttonName );
+				if ( options.buttonName ) {
+					expectedFocusedElement = dialog.getButton( options.buttonName );
 				} else {
-					expectedFocusedElement = dialog.getContentElement( config.tab, config.elementId );
+					expectedFocusedElement = dialog.getContentElement( options.tab, options.elementId );
+				}
+
+				if ( !expectedFocusedElement ) {
+					assert.fail( 'Expected focused element cannot be found in the dialog.' );
 				}
 
 				assert.areEqual( expectedFocusedElement, actualFocusedElement,
 					'Element: "' + expectedFocusedElement.id + '" should be equal to currently focused element: "' + actualFocusedElement.id + '".' );
+
 				return dialog;
 			};
 		},
 
-		// Assert to check focus on tab elements in dialog
-		// tabName {String} ID of a tab
+		// Assert checkign focus on tab elements in dialog
+		//
+		// @param {String} tabName ID of a tab
 		assertFocusedTab: function( tabName ) {
 			return function( dialog ) {
 				assert.areEqual( -1, dialog._.currentFocusIndex );

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -334,16 +334,25 @@
 		focusElement: function( config ) {
 			return function( dialog ) {
 				return new CKEDITOR.tools.promise( function( resolve, reject ) {
+					var resolveTimeout,
+						rejectTimeout;
+
 					dialog.once( 'focusChange', function() {
 						// Keep the event asynchronous to have sure that all changes related to focus change on a given element or tab
 						// was already prcoessed.
-						CKEDITOR.tools.setTimeout( function() {
+						resolveTimeout = CKEDITOR.tools.setTimeout( function() {
+							if ( rejectTimeout !== undefined ) {
+								window.clearTimeout( rejectTimeout );
+							}
 							resolve( dialog );
 						} );
 					} );
 
 					// Safety switch to finish promise in case of focusing not tracked element, or not changing a focus in a dialog.
-					CKEDITOR.tools.setTimeout( function() {
+					rejectTimeout = CKEDITOR.tools.setTimeout( function() {
+						if ( resolveTimeout !== undefined ) {
+							window.clearTimeout( resolveTimeout );
+						}
 						reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
 					}, 5000 );
 

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -1,7 +1,7 @@
 ( function() {
 	'use strict';
 
-	// Function extends dialog with a new event (`focus:change`) which is executed, when tab or element on focusList gain a focus
+	// Function extends dialog with a new event (`focusChange`) which is executed, when tab or element on focusList gain a focus
 	// This general approach helps to finish promises, when focus was changed inside the dialog.
 	function onLoadHandler( evt ) {
 		var dialog = evt.sender;
@@ -9,14 +9,14 @@
 		// Apply listening to focus change on tabs in dialog
 		CKEDITOR.tools.array.forEach( CKEDITOR.tools.object.values( dialog._.tabs ), function( item ) {
 			item[ 0 ].on( 'focus', function() {
-				dialog.fire( 'focus:change' );
+				dialog.fire( 'focusChange' );
 			}, null, null, 100000 );
 		} );
 
 		// Apply listening to focus change on elements in dialog.
 		CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
 			item.on( 'focus', function() {
-				dialog.fire( 'focus:change' );
+				dialog.fire( 'focusChange' );
 			}, null, null, 100000 );
 		} );
 	}
@@ -294,12 +294,12 @@
 
 		// Provides a thenable function which preserved proper config in a closure.
 		// The idea is to wrap function which change focus (focusChanger) with a promise. Then wait until dialog generate
-		// a `focus:change` event which should be fired because of execution of onLoadHandler.
+		// a `focusChange` event which should be fired because of execution of onLoadHandler.
 		// There is additional safety switch which rejects promise after 5 seconds without focus change.
 		focusElement: function( config ) {
 			return function( dialog ) {
 				return new CKEDITOR.tools.promise( function( resolve, reject ) {
-					dialog.once( 'focus:change', function() {
+					dialog.once( 'focusChange', function() {
 						// Keep the event asynchronous to have sure that all changes related to focus change on a given element or tab
 						// was already prcoessed.
 						CKEDITOR.tools.setTimeout( function() {

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -114,6 +114,101 @@
 				],
 				onLoad: onLoadHandler
 			};
+		},
+		hiddenPageDialogDefinition = function() {
+			return {
+				title: 'Hidden page dialog',
+				contents: [
+					{
+						id: 'hp-test1',
+						label: 'HP 1',
+						elements: [
+							{
+								type: 'text',
+								id: 'hp-input11',
+								label: 'input 11'
+							},
+							{
+								type: 'text',
+								id: 'hp-input12',
+								label: 'input 12'
+							},
+							{
+								type: 'text',
+								id: 'hp-input13',
+								label: 'input 13'
+							}
+						]
+					},
+					{
+						id: 'hp-test2',
+						label: 'HP 2',
+						elements: [
+							{
+								type: 'text',
+								id: 'hp-input21',
+								label: 'input 21',
+								requiredContent: 'fakeElement'
+							},
+							{
+								type: 'text',
+								id: 'hp-input22',
+								label: 'input 22'
+							},
+							{
+								type: 'text',
+								id: 'hp-input23',
+								label: 'input 23',
+								requiredContent: 'fakeElement'
+							}
+						]
+					},
+					{
+						id: 'hp-test3',
+						label: 'HP 3',
+						requiredContent: 'fakeElement',
+						elements: [
+							{
+								type: 'text',
+								id: 'hp-input31',
+								label: 'input 31'
+							},
+							{
+								type: 'text',
+								id: 'hp-input32',
+								label: 'input 32'
+							},
+							{
+								type: 'text',
+								id: 'hp-input33',
+								label: 'input 33'
+							},
+							{
+								type: 'text',
+								id: 'hp-input34',
+								label: 'input 34'
+							},
+							{
+								type: 'text',
+								id: 'hp-input35',
+								label: 'input 35'
+							}
+						]
+					},
+					{
+						id: 'hp-test4',
+						label: 'HP 4',
+						elements: [
+							{
+								type: 'text',
+								id: 'hp-input41',
+								label: 'input 41'
+							}
+						]
+					}
+				],
+				onLoad: onLoadHandler
+			};
 		};
 
 	function onLoadHandler( evt ) {
@@ -419,8 +514,44 @@
 				} ) )
 				.then( focus( { key: KEYS.F10, altKey: true } ) )
 				.then( assertFocusedTab( 'mp-test1' ) );
-		}
+		},
 
+		'test hidden page dialog should skip focus from hidden element on page': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'hiddenPageDialog' )
+				.then( assertFocusedElement( {
+					tab: 'hp-test1',
+					elementId: 'hp-input11'
+				} ) )
+				.then( focus( { direction: 'previous' } ) )
+				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( assertFocusedTab( 'hp-test2' ) )
+				.then( focus( { direction: 'next' } ) )
+				.then( assertFocusedElement( {
+					tab: 'hp-test2',
+					elementId: 'hp-input22'
+				} ) )
+				.then( focus( { direction: 'next' } ) )
+				.then( assertFocusedElement( {
+					buttonName: 'cancel'
+				} ) );
+		},
+
+		'test hidden page dialog should skip focus from hidden tab on page': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'hiddenPageDialog' )
+				.then( assertFocusedElement( {
+					tab: 'hp-test1',
+					elementId: 'hp-input11'
+				} ) )
+				.then( focus( { direction: 'previous' } ) )
+				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( assertFocusedTab( 'hp-test2' ) )
+				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( assertFocusedTab( 'hp-test4' ) );
+		}
 	};
 
 	tests = bender.tools.createAsyncTests( tests );
@@ -429,9 +560,11 @@
 		init: function() {
 			CKEDITOR.dialog.add( 'singlePageDialogDefinition', singlePageDialogDefinition );
 			CKEDITOR.dialog.add( 'multiPageDialogDefinition', multiPageDialogDefinition );
+			CKEDITOR.dialog.add( 'hiddenPageDialogDefinition', hiddenPageDialogDefinition );
 
 			this.editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialogDefinition' ) );
 			this.editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialogDefinition' ) );
+			this.editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialogDefinition' ) );
 		},
 
 		tearDown: function() {

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -23,8 +23,7 @@
 	bender.editor = true;
 
 	// Tests doesn't contain cases where focus is preserved on an element, as such cases doesn't trigger a focus event.
-	// Detection of such cases would be really time consuming and might result with a falsa positive when some other element accidently
-	// obtain focus.
+	// Detection of such cases would be really time consuming and might result with a falsa positive.
 	var tests = {
 		'test single page dialog should focus elements in a correct order': function() {
 			var bot = this.editorBot;

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -15,7 +15,7 @@
 			ARROW_UP: 38,
 			ARROW_DOWN: 40
 		},
-		definitions = window.dialogTools.definitions,
+
 		assertFocusedElement = window.dialogTools.assertFocusedElement,
 		assertFocusedTab = window.dialogTools.assertFocusedTab,
 		focusElement = window.dialogTools.focusElement;
@@ -273,13 +273,7 @@
 
 	CKEDITOR.tools.extend( tests, {
 		init: function() {
-			CKEDITOR.dialog.add( 'singlePageDialog', definitions.singlePage );
-			CKEDITOR.dialog.add( 'multiPageDialog', definitions.multiPage );
-			CKEDITOR.dialog.add( 'hiddenPageDialog', definitions.hiddenPage );
-
-			this.editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialog' ) );
-			this.editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialog' ) );
-			this.editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialog' ) );
+			window.dialogTools.addPredefinedDialogsToEditor( this.editor );
 		},
 
 		tearDown: function() {

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -22,8 +22,11 @@
 
 	bender.editor = true;
 
+	// Tests doesn't contain cases where focus is preserved on an element, as such cases doesn't trigger a focus event.
+	// Detection of such cases would be really time consuming and might result with a falsa positive when some other element accidently
+	// obtain focus.
 	var tests = {
-		'test single page dialog should focus elements in correct order': function() {
+		'test single page dialog should focus elements in a correct order': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
@@ -57,7 +60,7 @@
 		},
 
 		// Test simulate focusing with "click" / "touch", as direct calling `click()` method on html element doesn't trigger focus change.
-		'test single page dialog should set focused element after calling focus function': function() {
+		'test single page dialog should change the focused element after executing the focus function': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
@@ -89,7 +92,7 @@
 				} ) );
 		},
 
-		'test simple page dialog should set focus after keyboard operations': function() {
+		'test simple page dialog should change focus after pressing the TAB key': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
@@ -117,7 +120,7 @@
 				} ) );
 		},
 
-		'test multi page dialog should focus elements in tab list': function() {
+		'test multi page dialog should focus elements in a tab list': function() {
 			var bot = this.editorBot;
 			return bot.asyncDialog( 'multiPageDialog' )
 				.then( assertFocusedElement( {
@@ -128,7 +131,7 @@
 				.then( assertFocusedTab( 'mp-test1' ) );
 		},
 
-		'test multi page dialog should move focus to panel with TAB key': function() {
+		'test multi page dialog should move the focus to the panel with the TAB key': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
@@ -145,7 +148,7 @@
 				} ) );
 		},
 
-		'test multi page dialog should move focus to panel with SPACE key': function() {
+		'test multi page dialog should move the focus to the panel with the SPACE key': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
@@ -162,7 +165,7 @@
 				} ) );
 		},
 
-		'test multi page dialog should move focus to panel with ENTER key': function() {
+		'test multi page dialog should move the focus to the panel with the ENTER key': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
@@ -179,7 +182,7 @@
 				} ) );
 		},
 
-		'test multi page dialog should move focus to between tabs with ARROW keys': function() {
+		'test multi page dialog should move the focus inside the tab navigation of a dialog with ARROW keys': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
@@ -200,7 +203,7 @@
 				.then( assertFocusedTab( 'mp-test2' ) );
 		},
 
-		'test multi page dialog should bring focus to tab with ALT+F10 keys': function() {
+		'test multi page dialog should bring the focus to the tab with the ALT+F10 keys': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
@@ -225,7 +228,7 @@
 				.then( assertFocusedTab( 'mp-test1' ) );
 		},
 
-		'test hidden page dialog should skip focus from hidden element on page': function() {
+		'test hidden page dialog should skip the focus of the hidden element on the page': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'hiddenPageDialog' )
@@ -247,7 +250,7 @@
 				} ) );
 		},
 
-		'test hidden page dialog should skip focus from hidden tab on page': function() {
+		'test hidden page dialog should skip the focus from the hidden tab on the page': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'hiddenPageDialog' )

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -33,7 +33,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
@@ -68,7 +67,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
@@ -101,7 +99,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
@@ -129,7 +126,6 @@
 		'test multi page dialog should focus elements in a tab list': function() {
 			var bot = this.editorBot;
 			return bot.asyncDialog( 'multiPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -142,7 +138,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -160,7 +155,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -178,7 +172,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -196,7 +189,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -218,7 +210,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -244,7 +235,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'hiddenPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'hp-test1',
 					elementId: 'hp-input11'
@@ -267,7 +257,6 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'hiddenPageDialog' )
-				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'hp-test1',
 					elementId: 'hp-input11'
@@ -301,19 +290,6 @@
 			}
 		}
 	} );
-
-	// From some unknow reason we need to wait until dialog fully setup, to have proper focus in it.
-	function ie11fix( dialog ) {
-		if ( CKEDITOR.env.ie && CKEDITOR.env.version === 11 ) {
-			return new CKEDITOR.tools.promise( function( resolve ) {
-				CKEDITOR.tools.setTimeout( function() {
-					resolve( dialog );
-				}, 0 );
-			} );
-		} else {
-			return dialog;
-		}
-	}
 
 	bender.test( tests );
 } )();

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -1,0 +1,100 @@
+/* bender-tags: editor, dialog */
+/* bender-ckeditor-plugins: dialog */
+
+( function() {
+	'use strict';
+
+	var currentFocusCallback;
+	var dialogItemFocusListener = function( evt ) {
+		if ( currentFocusCallback ) {
+			currentFocusCallback( evt.sender );
+		}
+	};
+
+	var singlePageDialogDefinition = function() {
+		return {
+			title: 'Single page dialog',
+			contents: [
+				{
+					id: 'test1',
+					elements: [
+						{
+							type: 'text',
+							id: 'sp-input1',
+							label: 'input 1'
+						},
+						{
+							type: 'text',
+							id: 'sp-input2',
+							label: 'input 2'
+						},
+						{
+							type: 'text',
+							id: 'sp-input3',
+							label: 'input 3'
+						}
+					]
+				}
+			],
+			onLoad: function( evt ) {
+				// This funciton should be called once per dialog, regardless of number of tests.
+				var dialog = evt.sender;
+
+				// attach focus listener in dialog;
+				CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
+					item.on( 'focus', dialogItemFocusListener, null, null, 100000 );
+				} );
+
+			}
+		};
+	};
+
+
+	function assertFocus( dialog, element ) {
+		var currentlyFocusedElement = dialog._.focusList[ dialog._.currentFocusIndex ];
+		assert.areEqual( element, currentlyFocusedElement,
+			'Element: "' + element.id + '" should be equal to currently focused element: "' + currentlyFocusedElement.id + '".'  );
+	}
+
+	function focusNext( dialog ) {
+		dialog.changeFocus( 1 );
+	}
+
+	bender.editor = true;
+
+	var tests = {
+		init: function() {
+			CKEDITOR.dialog.add( 'singlePageDialogDefinition', singlePageDialogDefinition );
+
+			this.editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialogDefinition' ) );
+		},
+
+		tearDown: function() {
+			var dialog;
+
+			currentFocusCallback = null;
+			while ( ( dialog = CKEDITOR.dialog.getCurrent() ) ) {
+				dialog.hide();
+			}
+		},
+
+		'test single page test': function() {
+			var bot = this.editorBot;
+
+			bot.dialog( 'singlePageDialog', function( dialog ) {
+				currentFocusCallback = function() {
+					resume( function() {
+						assertFocus( dialog, dialog.getContentElement( 'test1', 'sp-input2' ) );
+					} );
+				};
+
+				assertFocus( dialog, dialog.getContentElement( 'test1', 'sp-input1' ) );
+
+				focusNext( dialog );
+				wait();
+			} );
+		}
+	};
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -18,145 +18,190 @@
 		};
 
 	var singlePageDialogDefinition = function() {
-		return {
-			title: 'Single page dialog',
-			contents: [
-				{
-					id: 'test1',
-					elements: [
-						{
-							type: 'text',
-							id: 'sp-input1',
-							label: 'input 1'
-						},
-						{
-							type: 'text',
-							id: 'sp-input2',
-							label: 'input 2'
-						},
-						{
-							type: 'text',
-							id: 'sp-input3',
-							label: 'input 3'
-						}
-					]
-				}
-			],
-			onLoad: function( evt ) {
-				// This funciton should be called once per dialog, regardless of number of tests.
-				var dialog = evt.sender;
-
-				// attach focus listener in dialog;
-				CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
-					item.on( 'focus', function() {
-						dialog.fire( 'focus:change' );
-					}, null, null, 100000 );
-				} );
-
-			}
+			return {
+				title: 'Single page dialog',
+				contents: [
+					{
+						id: 'sp-test1',
+						elements: [
+							{
+								type: 'text',
+								id: 'sp-input1',
+								label: 'input 1'
+							},
+							{
+								type: 'text',
+								id: 'sp-input2',
+								label: 'input 2'
+							},
+							{
+								type: 'text',
+								id: 'sp-input3',
+								label: 'input 3'
+							}
+						]
+					}
+				],
+				onLoad: onLoadHandler
+			};
+		},
+		multiPageDialogDefinition = function() {
+			return {
+				title: 'Mult page dialog',
+				contents: [
+					{
+						id: 'mp-test1',
+						label: 'MP 1',
+						elements: [
+							{
+								type: 'text',
+								id: 'mp-input11',
+								label: 'input 11'
+							},
+							{
+								type: 'text',
+								id: 'mp-input12',
+								label: 'input 12'
+							},
+							{
+								type: 'text',
+								id: 'mp-input13',
+								label: 'input 13'
+							}
+						]
+					},
+					{
+						id: 'mp-test2',
+						label: 'MP 2',
+						elements: [
+							{
+								type: 'text',
+								id: 'mp-input21',
+								label: 'input 21'
+							}
+						]
+					},
+					{
+						id: 'mp-test3',
+						label: 'MP 3',
+						elements: [
+							{
+								type: 'text',
+								id: 'mp-input31',
+								label: 'input 31'
+							},
+							{
+								type: 'text',
+								id: 'mp-input32',
+								label: 'input 32'
+							},
+							{
+								type: 'text',
+								id: 'mp-input33',
+								label: 'input 33'
+							},
+							{
+								type: 'text',
+								id: 'mp-input34',
+								label: 'input 34'
+							},
+							{
+								type: 'text',
+								id: 'mp-input35',
+								label: 'input 35'
+							}
+						]
+					}
+				],
+				onLoad: onLoadHandler
+			};
 		};
-	};
 
+	function onLoadHandler( evt ) {
+		// This funciton should be called once per dialog, regardless of number of tests.
+		var dialog = evt.sender;
 
-	function assertFocus( dialog, config ) {
-		var actualFocusedElement = dialog._.focusList[ dialog._.currentFocusIndex ];
-		var expectedFocusedElement;
+		// attach focus listener in dialog;
+		CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
+			item.on( 'focus', function() {
+				dialog.fire( 'focus:change' );
+			}, null, null, 100000 );
+		} );
+
+	}
+
+	function assertFocus( config ) {
+		return function( dialog ) {
+			var actualFocusedElement = dialog._.focusList[ dialog._.currentFocusIndex ];
+			var expectedFocusedElement;
+
+			if ( config.buttonName ) {
+				expectedFocusedElement = dialog.getButton( config.buttonName );
+			} else {
+				expectedFocusedElement = dialog.getContentElement( config.tab, config.elementId );
+			}
+
+			assert.areEqual( expectedFocusedElement, actualFocusedElement,
+				'Element: "' + expectedFocusedElement.id + '" should be equal to currently focused element: "' + actualFocusedElement.id + '".' );
+			return dialog;
+		};
+	}
+
+	function focusChanger( dialog, config ) {
+		var element;
+
+		if ( config.direction === 'next' ) {
+			dialog.changeFocus( 1 );
+			return;
+		}
+
+		if ( config.direction === 'previous' ) {
+			dialog.changeFocus( -1 );
+			return;
+		}
+
+		if ( config.elementId && config.tab ) {
+			element = dialog.getContentElement( config.tab, config.elementId ).getInputElement();
+			element.focus();
+			return;
+		}
 
 		if ( config.buttonName ) {
-			expectedFocusedElement = dialog.getButton( config.buttonName );
-		} else {
-			expectedFocusedElement = dialog.getContentElement( config.tab, config.elementId );
-		}
-
-		assert.areEqual( expectedFocusedElement, actualFocusedElement,
-			'Element: "' + expectedFocusedElement.id + '" should be equal to currently focused element: "' + actualFocusedElement.id + '".' );
-		return dialog;
-	}
-
-	function _focus( dialog, direction ) {
-		return new CKEDITOR.tools.promise( function( resolve, reject ) {
-			dialog.once( 'focus:change', function() {
-				CKEDITOR.tools.setTimeout( function() {
-					resolve( dialog );
-				} );
-			} );
-
-			if ( hasRejects ) {
-				CKEDITOR.tools.setTimeout( function() {
-					reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
-				}, 5000 );
-			}
-
-			if ( direction === 'next' ) {
-				dialog.changeFocus( 1 );
-			} else {
-				dialog.changeFocus( -1 );
-			}
-		} );
-	}
-
-	function focusNext( dialog ) {
-		return _focus( dialog, 'next' );
-	}
-
-	function focusPrevious( dialog ) {
-		return _focus( dialog, 'previous' );
-	}
-
-	function focusElement( dialog, config ) {
-		var tab = config.tab,
-			elementId = config.elementId,
-			buttonName = config.buttonName,
-			element;
-
-		if ( buttonName )
-			element = dialog.getButton( buttonName ).getInputElement();
-		else {
-			element = dialog.getContentElement( tab, elementId ).getInputElement();
-		}
-
-		return new CKEDITOR.tools.promise( function( resolve, reject ) {
-			dialog.once( 'focus:change', function() {
-				CKEDITOR.tools.setTimeout( function() {
-					resolve( dialog );
-				} );
-			} );
-
-			if ( hasRejects ) {
-				CKEDITOR.tools.setTimeout( function() {
-					reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
-				}, 5000 );
-			}
-
+			element = dialog.getButton( config.buttonName ).getInputElement();
 			element.focus();
-		} );
+			return;
+		}
+
+		if ( config.key ) {
+			dialog._.element.fire( 'keydown', new CKEDITOR.dom.event( {
+				keyCode: config.key,
+				shiftKey: config.shiftKey ? true : false,
+				altKey: config.altKey ? true : false
+			} ) );
+			return;
+		}
+
+		throw new Error( 'Invalid focus config' );
 	}
 
-	function pressKey( dialog, config ) {
-		var key = config.key,
-			shiftKey = config.shiftKey || false,
-			altKey = config.altKey || false;
-
-		return new CKEDITOR.tools.promise( function( resolve, reject ) {
-			dialog.once( 'focus:change', function() {
-				CKEDITOR.tools.setTimeout( function() {
-					resolve( dialog );
+	function focus( config ) {
+		return function( dialog ) {
+			return new CKEDITOR.tools.promise( function( resolve, reject ) {
+				dialog.once( 'focus:change', function() {
+					CKEDITOR.tools.setTimeout( function() {
+						resolve( dialog );
+					} );
 				} );
+
+				if ( hasRejects ) {
+					CKEDITOR.tools.setTimeout( function() {
+						reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
+					}, 5000 );
+				}
+
+				focusChanger( dialog, config );
 			} );
-
-			if ( hasRejects ) {
-				CKEDITOR.tools.setTimeout( function() {
-					reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
-				}, 5000 );
-			}
-
-			dialog._.element.fire( 'keydown', new CKEDITOR.dom.event( {
-				keyCode: key,
-				shiftKey: shiftKey,
-				altKey: altKey
-			} ) );
-		} );
-
+		};
 	}
 
 	bender.editor = true;
@@ -166,34 +211,33 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
-				.then( function( dialog ) {
-					assertFocus( dialog, {
-						tab: 'test1',
-						elementId: 'sp-input1'
-					} );
-					return dialog;
-				} )
-				.then( focusNext )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-						tab: 'test1',
-						elementId: 'sp-input2'
-					} );
-				} )
-				.then( focusNext )
-				.then( focusNext )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							buttonName: 'cancel'
-						} );
-				} )
-				.then( focusPrevious )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							tab: 'test1',
-							elementId: 'sp-input3'
-						} );
-				} );
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input1'
+				} ) )
+				.then( focus( {
+					direction: 'next'
+				} ) )
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input2'
+				} ) )
+				.then( focus( {
+					direction: 'next'
+				} ) )
+				.then( focus( {
+					direction: 'next'
+				} ) )
+				.then( assertFocus( {
+					buttonName: 'cancel'
+				} ) )
+				.then( focus( {
+					direction: 'previous'
+				} ) )
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input3'
+				} ) );
 		},
 
 		// Test simulate focusing with "click" / "touch", as direct calling `click()` method on html element doesn't trigger focus change.
@@ -201,75 +245,76 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							tab: 'test1',
-							elementId: 'sp-input1'
-						} );
-				} )
-				.then( function( dialog ) {
-					return focusElement( dialog, {
-							tab: 'test1',
-							elementId: 'sp-input2'
-						} );
-				} )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							tab: 'test1',
-							elementId: 'sp-input2'
-						} );
-				} )
-				.then( function( dialog ) {
-					return focusElement( dialog, {
-						buttonName: 'ok'
-					} );
-				} )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							buttonName: 'ok'
-						} );
-				} );
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input1'
+				} ) )
+				.then( focus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input2'
+				} ) )
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input2'
+				} ) )
+				.then( focus( {
+					buttonName: 'ok'
+				} ) )
+				.then( assertFocus( {
+					buttonName: 'ok'
+				} ) )
+				.then( focus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input1'
+				} ) )
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input1'
+				} ) );
 		},
 
 		'test simple page dialog should set focus after keyboard operations': function() {
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input1'
+				} ) )
+				.then( focus( {
+					key: KEYS.TAB
+				} ) )
+				.then( assertFocus( {
+					tab: 'sp-test1',
+					elementId: 'sp-input2'
+				} ) )
+				.then( focus( {
+					key: KEYS.TAB,
+					shiftKey: true
+				} ) )
+				.then( focus( {
+					key: KEYS.TAB,
+					shiftKey: true
+				} ) )
+				.then( assertFocus( {
+					buttonName: 'ok'
+				} ) );
+		},
+
+		'test multi page dialog should focus elements in correct order': function() {
+			var bot = this.editorBot;
+			return bot.asyncDialog( 'multiPageDialog' )
+				.then( assertFocus( {
+					tab: 'mp-test1',
+					elementId: 'mp-input11'
+				} ) )
+				.then( focus( { direction: 'previous' } ) )
 				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							tab: 'test1',
-							elementId: 'sp-input1'
-						} );
+					debugger;
+					return dialog;
 				} )
-				.then( function( dialog ) {
-					return pressKey( dialog, {
-						key: KEYS.TAB
-					} );
-				} )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							tab: 'test1',
-							elementId: 'sp-input2'
-						} );
-				} )
-				.then( function( dialog ) {
-					return pressKey( dialog, {
-						key: KEYS.TAB,
-						shiftKey: true
-					} );
-				} )
-				.then( function( dialog ) {
-					return pressKey( dialog, {
-						key: KEYS.TAB,
-						shiftKey: true
-					} );
-				} )
-				.then( function( dialog ) {
-					return assertFocus( dialog, {
-							buttonName: 'ok'
-						} );
-				} );
 		}
+
 	};
 
 	tests = bender.tools.createAsyncTests( tests );
@@ -277,8 +322,10 @@
 	CKEDITOR.tools.extend( tests, {
 		init: function() {
 			CKEDITOR.dialog.add( 'singlePageDialogDefinition', singlePageDialogDefinition );
+			CKEDITOR.dialog.add( 'multiPageDialogDefinition', multiPageDialogDefinition );
 
 			this.editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialogDefinition' ) );
+			this.editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialogDefinition' ) );
 		},
 
 		tearDown: function() {

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -53,39 +53,32 @@
 			'Element: "' + element.id + '" should be equal to currently focused element: "' + currentlyFocusedElement.id + '".' );
 	}
 
-	function focusNext( dialog ) {
+	function _focus( dialog, direction ) {
 		return new CKEDITOR.tools.promise( function( resolve, reject ) {
 			dialog.once( 'focus:change', function() {
-				// short moment for focus stabilization;
 				CKEDITOR.tools.setTimeout( function() {
 					resolve( dialog );
-				}, 50 );
+				} );
 			} );
 
 			if ( hasRejects ) {
 				CKEDITOR.tools.setTimeout( reject, 5000 );
 			}
 
-			dialog.changeFocus( 1 );
+			if ( direction === 'next' ) {
+				dialog.changeFocus( 1 );
+			} else {
+				dialog.changeFocus( -1 );
+			}
 		} );
 	}
 
+	function focusNext( dialog ) {
+		return _focus( dialog, 'next' );
+	}
+
 	function focusPrevious( dialog ) {
-		return new CKEDITOR.tools.promise( function( resolve, reject ) {
-			dialog.once( 'focus:change', function() {
-				// short moment for focus stabilization;
-				CKEDITOR.tools.setTimeout( function() {
-					resolve( dialog );
-				}, 50 );
-
-			} );
-
-			if ( hasRejects ) {
-				CKEDITOR.tools.setTimeout( reject, 5000 );
-			}
-
-			dialog.changeFocus( -1 );
-		} );
+		return _focus( dialog, 'previous' );
 	}
 
 

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -1,11 +1,11 @@
 /* bender-tags: editor, dialog */
 /* bender-ckeditor-plugins: dialog */
+/* bender-include: _helpers/tools.js */
 
 ( function() {
 	'use strict';
-	// Test suite indicates if tests should have 5 second safety switch timeout for rejecting promises.
-	var hasRejects = true,
-		KEYS = {
+
+	var KEYS = {
 			TAB: 9,
 			ENTER: 13,
 			SPACE: 32,
@@ -14,302 +14,11 @@
 			ARROW_LEFT: 37,
 			ARROW_UP: 38,
 			ARROW_DOWN: 40
-		};
-
-	var singlePageDialogDefinition = function() {
-			return {
-				title: 'Single page dialog',
-				contents: [
-					{
-						id: 'sp-test1',
-						elements: [
-							{
-								type: 'text',
-								id: 'sp-input1',
-								label: 'input 1'
-							},
-							{
-								type: 'text',
-								id: 'sp-input2',
-								label: 'input 2'
-							},
-							{
-								type: 'text',
-								id: 'sp-input3',
-								label: 'input 3'
-							}
-						]
-					}
-				],
-				onLoad: onLoadHandler
-			};
 		},
-		multiPageDialogDefinition = function() {
-			return {
-				title: 'Mult page dialog',
-				contents: [
-					{
-						id: 'mp-test1',
-						label: 'MP 1',
-						elements: [
-							{
-								type: 'text',
-								id: 'mp-input11',
-								label: 'input 11'
-							},
-							{
-								type: 'text',
-								id: 'mp-input12',
-								label: 'input 12'
-							},
-							{
-								type: 'text',
-								id: 'mp-input13',
-								label: 'input 13'
-							}
-						]
-					},
-					{
-						id: 'mp-test2',
-						label: 'MP 2',
-						elements: [
-							{
-								type: 'text',
-								id: 'mp-input21',
-								label: 'input 21'
-							}
-						]
-					},
-					{
-						id: 'mp-test3',
-						label: 'MP 3',
-						elements: [
-							{
-								type: 'text',
-								id: 'mp-input31',
-								label: 'input 31'
-							},
-							{
-								type: 'text',
-								id: 'mp-input32',
-								label: 'input 32'
-							},
-							{
-								type: 'text',
-								id: 'mp-input33',
-								label: 'input 33'
-							},
-							{
-								type: 'text',
-								id: 'mp-input34',
-								label: 'input 34'
-							},
-							{
-								type: 'text',
-								id: 'mp-input35',
-								label: 'input 35'
-							}
-						]
-					}
-				],
-				onLoad: onLoadHandler
-			};
-		},
-		hiddenPageDialogDefinition = function() {
-			return {
-				title: 'Hidden page dialog',
-				contents: [
-					{
-						id: 'hp-test1',
-						label: 'HP 1',
-						elements: [
-							{
-								type: 'text',
-								id: 'hp-input11',
-								label: 'input 11'
-							},
-							{
-								type: 'text',
-								id: 'hp-input12',
-								label: 'input 12'
-							},
-							{
-								type: 'text',
-								id: 'hp-input13',
-								label: 'input 13'
-							}
-						]
-					},
-					{
-						id: 'hp-test2',
-						label: 'HP 2',
-						elements: [
-							{
-								type: 'text',
-								id: 'hp-input21',
-								label: 'input 21',
-								requiredContent: 'fakeElement'
-							},
-							{
-								type: 'text',
-								id: 'hp-input22',
-								label: 'input 22'
-							},
-							{
-								type: 'text',
-								id: 'hp-input23',
-								label: 'input 23',
-								requiredContent: 'fakeElement'
-							}
-						]
-					},
-					{
-						id: 'hp-test3',
-						label: 'HP 3',
-						requiredContent: 'fakeElement',
-						elements: [
-							{
-								type: 'text',
-								id: 'hp-input31',
-								label: 'input 31'
-							},
-							{
-								type: 'text',
-								id: 'hp-input32',
-								label: 'input 32'
-							},
-							{
-								type: 'text',
-								id: 'hp-input33',
-								label: 'input 33'
-							},
-							{
-								type: 'text',
-								id: 'hp-input34',
-								label: 'input 34'
-							},
-							{
-								type: 'text',
-								id: 'hp-input35',
-								label: 'input 35'
-							}
-						]
-					},
-					{
-						id: 'hp-test4',
-						label: 'HP 4',
-						elements: [
-							{
-								type: 'text',
-								id: 'hp-input41',
-								label: 'input 41'
-							}
-						]
-					}
-				],
-				onLoad: onLoadHandler
-			};
-		};
-
-	function onLoadHandler( evt ) {
-		// This funciton should be called once per dialog, regardless of number of tests.
-		var dialog = evt.sender;
-
-		CKEDITOR.tools.array.forEach( CKEDITOR.tools.object.values( dialog._.tabs ), function( item ) {
-			item[ 0 ].on( 'focus', function() {
-				dialog.fire( 'focus:change' );
-			}, null, null, 100000 );
-		} );
-
-		CKEDITOR.tools.array.forEach( dialog._.focusList, function( item ) {
-			item.on( 'focus', function() {
-				dialog.fire( 'focus:change' );
-			}, null, null, 100000 );
-		} );
-	}
-
-	function assertFocusedElement( config ) {
-		return function( dialog ) {
-			var actualFocusedElement = dialog._.focusList[ dialog._.currentFocusIndex ];
-			var expectedFocusedElement;
-
-			if ( config.buttonName ) {
-				expectedFocusedElement = dialog.getButton( config.buttonName );
-			} else {
-				expectedFocusedElement = dialog.getContentElement( config.tab, config.elementId );
-			}
-
-			assert.areEqual( expectedFocusedElement, actualFocusedElement,
-				'Element: "' + expectedFocusedElement.id + '" should be equal to currently focused element: "' + actualFocusedElement.id + '".' );
-			return dialog;
-		};
-	}
-
-	function assertFocusedTab( tabName ) {
-		return function( dialog ) {
-			assert.areEqual( -1, dialog._.currentFocusIndex );
-			assert.areEqual( tabName, dialog._.currentTabId );
-
-			return dialog;
-		};
-	}
-
-	function focusChanger( dialog, config ) {
-		var element;
-
-		if ( config.direction === 'next' ) {
-			dialog.changeFocus( 1 );
-			return;
-		}
-
-		if ( config.direction === 'previous' ) {
-			dialog.changeFocus( -1 );
-			return;
-		}
-
-		if ( config.elementId && config.tab ) {
-			element = dialog.getContentElement( config.tab, config.elementId ).getInputElement();
-			element.focus();
-			return;
-		}
-
-		if ( config.buttonName ) {
-			element = dialog.getButton( config.buttonName ).getInputElement();
-			element.focus();
-			return;
-		}
-
-		if ( config.key ) {
-			dialog._.element.fire( 'keydown', new CKEDITOR.dom.event( {
-				keyCode: config.key,
-				shiftKey: config.shiftKey ? true : false,
-				altKey: config.altKey ? true : false
-			} ) );
-			return;
-		}
-
-		throw new Error( 'Invalid focus config: ' + JSON.stringify( config ) );
-	}
-
-	function focus( config ) {
-		return function( dialog ) {
-			return new CKEDITOR.tools.promise( function( resolve, reject ) {
-				dialog.once( 'focus:change', function() {
-					CKEDITOR.tools.setTimeout( function() {
-						resolve( dialog );
-					} );
-				} );
-
-				if ( hasRejects ) {
-					CKEDITOR.tools.setTimeout( function() {
-						reject( new Error( 'Focus hasn\'t change for last 5 seconds' ) );
-					}, 5000 );
-				}
-
-				focusChanger( dialog, config );
-			} );
-		};
-	}
+		definitions = window.dialogTools.definitions,
+		assertFocusedElement = window.dialogTools.assertFocusedElement,
+		assertFocusedTab = window.dialogTools.assertFocusedTab,
+		focusElement = window.dialogTools.focusElement;
 
 	bender.editor = true;
 
@@ -322,23 +31,23 @@
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					direction: 'next'
 				} ) )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input2'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					direction: 'next'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					direction: 'next'
 				} ) )
 				.then( assertFocusedElement( {
 					buttonName: 'cancel'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					direction: 'previous'
 				} ) )
 				.then( assertFocusedElement( {
@@ -356,7 +65,7 @@
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input2'
 				} ) )
@@ -364,13 +73,13 @@
 					tab: 'sp-test1',
 					elementId: 'sp-input2'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					buttonName: 'ok'
 				} ) )
 				.then( assertFocusedElement( {
 					buttonName: 'ok'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
 				} ) )
@@ -388,18 +97,18 @@
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					key: KEYS.TAB
 				} ) )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input2'
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					key: KEYS.TAB,
 					shiftKey: true
 				} ) )
-				.then( focus( {
+				.then( focusElement( {
 					key: KEYS.TAB,
 					shiftKey: true
 				} ) )
@@ -415,7 +124,7 @@
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
 				} ) )
-				.then( focus( { direction: 'previous' } ) )
+				.then( focusElement( { direction: 'previous' } ) )
 				.then( assertFocusedTab( 'mp-test1' ) );
 		},
 
@@ -427,9 +136,9 @@
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
 				} ) )
-				.then( focus( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
 				.then( assertFocusedTab( 'mp-test1' ) )
-				.then( focus( { key: KEYS.TAB } ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -444,9 +153,9 @@
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
 				} ) )
-				.then( focus( { direction: 'previous' } ) )
+				.then( focusElement( { direction: 'previous' } ) )
 				.then( assertFocusedTab( 'mp-test1' ) )
-				.then( focus( { key: KEYS.SPACE } ) )
+				.then( focusElement( { key: KEYS.SPACE } ) )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -461,9 +170,9 @@
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
 				} ) )
-				.then( focus( { direction: 'previous' } ) )
+				.then( focusElement( { direction: 'previous' } ) )
 				.then( assertFocusedTab( 'mp-test1' ) )
-				.then( focus( { key: KEYS.ENTER } ) )
+				.then( focusElement( { key: KEYS.ENTER } ) )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -478,16 +187,16 @@
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
 				} ) )
-				.then( focus( { direction: 'previous' } ) )
+				.then( focusElement( { direction: 'previous' } ) )
 				.then( assertFocusedTab( 'mp-test1' ) )
-				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
 				.then( assertFocusedTab( 'mp-test2' ) )
-				.then( focus( { key: KEYS.ARROW_UP } ) )
+				.then( focusElement( { key: KEYS.ARROW_UP } ) )
 				.then( assertFocusedTab( 'mp-test1' ) )
-				.then( focus( { key: KEYS.ARROW_DOWN } ) )
-				.then( focus( { key: KEYS.ARROW_DOWN } ) )
+				.then( focusElement( { key: KEYS.ARROW_DOWN } ) )
+				.then( focusElement( { key: KEYS.ARROW_DOWN } ) )
 				.then( assertFocusedTab( 'mp-test3' ) )
-				.then( focus( { key: KEYS.ARROW_LEFT } ) )
+				.then( focusElement( { key: KEYS.ARROW_LEFT } ) )
 				.then( assertFocusedTab( 'mp-test2' ) );
 		},
 
@@ -499,20 +208,20 @@
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
 				} ) )
-				.then( focus( { direction: 'next' } ) )
-				.then( focus( { direction: 'next' } ) )
+				.then( focusElement( { direction: 'next' } ) )
+				.then( focusElement( { direction: 'next' } ) )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input13'
 				} ) )
-				.then( focus( { key: KEYS.F10, altKey: true } ) )
+				.then( focusElement( { key: KEYS.F10, altKey: true } ) )
 				.then( assertFocusedTab( 'mp-test1' ) )
-				.then( focus( { direction: 'previous' } ) )
-				.then( focus( { direction: 'previous' } ) )
+				.then( focusElement( { direction: 'previous' } ) )
+				.then( focusElement( { direction: 'previous' } ) )
 				.then( assertFocusedElement( {
 					buttonName: 'cancel'
 				} ) )
-				.then( focus( { key: KEYS.F10, altKey: true } ) )
+				.then( focusElement( { key: KEYS.F10, altKey: true } ) )
 				.then( assertFocusedTab( 'mp-test1' ) );
 		},
 
@@ -524,15 +233,15 @@
 					tab: 'hp-test1',
 					elementId: 'hp-input11'
 				} ) )
-				.then( focus( { direction: 'previous' } ) )
-				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( focusElement( { direction: 'previous' } ) )
+				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
 				.then( assertFocusedTab( 'hp-test2' ) )
-				.then( focus( { direction: 'next' } ) )
+				.then( focusElement( { direction: 'next' } ) )
 				.then( assertFocusedElement( {
 					tab: 'hp-test2',
 					elementId: 'hp-input22'
 				} ) )
-				.then( focus( { direction: 'next' } ) )
+				.then( focusElement( { direction: 'next' } ) )
 				.then( assertFocusedElement( {
 					buttonName: 'cancel'
 				} ) );
@@ -546,10 +255,10 @@
 					tab: 'hp-test1',
 					elementId: 'hp-input11'
 				} ) )
-				.then( focus( { direction: 'previous' } ) )
-				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( focusElement( { direction: 'previous' } ) )
+				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
 				.then( assertFocusedTab( 'hp-test2' ) )
-				.then( focus( { key: KEYS.ARROW_RIGHT } ) )
+				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
 				.then( assertFocusedTab( 'hp-test4' ) );
 		}
 	};
@@ -558,13 +267,13 @@
 
 	CKEDITOR.tools.extend( tests, {
 		init: function() {
-			CKEDITOR.dialog.add( 'singlePageDialogDefinition', singlePageDialogDefinition );
-			CKEDITOR.dialog.add( 'multiPageDialogDefinition', multiPageDialogDefinition );
-			CKEDITOR.dialog.add( 'hiddenPageDialogDefinition', hiddenPageDialogDefinition );
+			CKEDITOR.dialog.add( 'singlePageDialog', definitions.singlePage );
+			CKEDITOR.dialog.add( 'multiPageDialog', definitions.multiPage );
+			CKEDITOR.dialog.add( 'hiddenPageDialog', definitions.hiddenPage );
 
-			this.editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialogDefinition' ) );
-			this.editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialogDefinition' ) );
-			this.editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialogDefinition' ) );
+			this.editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialog' ) );
+			this.editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialog' ) );
+			this.editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialog' ) );
 		},
 
 		tearDown: function() {

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -20,7 +20,11 @@
 		assertFocusedTab = window.dialogTools.assertFocusedTab,
 		focusElement = window.dialogTools.focusElement;
 
-	bender.editor = true;
+	bender.editor = {
+		config: {
+			dialog_buttonsOrder: 'rtl'
+		}
+	};
 
 	// Tests doesn't contain cases where focus is preserved on an element, as such cases doesn't trigger a focus event.
 	// Detection of such cases would be really time consuming and might result with a falsa positive.
@@ -29,6 +33,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
@@ -63,6 +68,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
@@ -95,6 +101,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'singlePageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'sp-test1',
 					elementId: 'sp-input1'
@@ -122,6 +129,7 @@
 		'test multi page dialog should focus elements in a tab list': function() {
 			var bot = this.editorBot;
 			return bot.asyncDialog( 'multiPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -134,6 +142,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -151,6 +160,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -168,6 +178,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -185,6 +196,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -206,6 +218,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'multiPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'mp-test1',
 					elementId: 'mp-input11'
@@ -231,6 +244,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'hiddenPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'hp-test1',
 					elementId: 'hp-input11'
@@ -253,6 +267,7 @@
 			var bot = this.editorBot;
 
 			return bot.asyncDialog( 'hiddenPageDialog' )
+				.then( ie11fix )
 				.then( assertFocusedElement( {
 					tab: 'hp-test1',
 					elementId: 'hp-input11'
@@ -286,6 +301,19 @@
 			}
 		}
 	} );
+
+	// From some unknow reason we need to wait until dialog fully setup, to have proper focus in it.
+	function ie11fix( dialog ) {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version === 11 ) {
+			return new CKEDITOR.tools.promise( function( resolve ) {
+				CKEDITOR.tools.setTimeout( function() {
+					resolve( dialog );
+				}, 0 );
+			} );
+		} else {
+			return dialog;
+		}
+	}
 
 	bender.test( tests );
 } )();

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -27,7 +27,7 @@
 	};
 
 	// Tests doesn't contain cases where focus is preserved on an element, as such cases doesn't trigger a focus event.
-	// Detection of such cases would be really time consuming and might result with a falsa positive.
+	// Detection of such situation would be really time consuming and might give a false positive results.
 	var tests = {
 		'test single page dialog should focus elements in a correct order': function() {
 			var bot = this.editorBot;
@@ -62,7 +62,8 @@
 				} ) );
 		},
 
-		// Test simulate focusing with "click" / "touch", as direct calling `click()` method on html element doesn't trigger focus change.
+		// Test simulate focusing with "click" / "touch" by focusing specific element.
+		// Direct call of `click()` method on the html element doesn't trigger focus change.
 		'test single page dialog should change the focused element after executing the focus function': function() {
 			var bot = this.editorBot;
 

--- a/tests/plugins/dialog/manual/focus.html
+++ b/tests/plugins/dialog/manual/focus.html
@@ -1,0 +1,13 @@
+<div>
+	<textarea cols="80" id="editor1" name="editor1" rows="10">
+		&lt;p&gt;&lt;strong&gt;Apollo 11&lt;/strong&gt; was the spaceflight that landed the first humans, Americans Neil Armstrong and Buzz Aldrin, on the Moon on July 20, 1969, at 20:18 UTC. Armstrong became the first to step onto the lunar surface 6 hours later on July 21 at 02:56 UTC.&lt;/p&gt;&lt;p&gt;Armstrong spent about three and a half two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected&lt;/p&gt;
+	</textarea>
+
+
+	<script>
+		if ( bender.tools.env.mobile ) {
+			bender.ignore();
+		}
+		var editor = CKEDITOR.replace( 'editor1' );
+	</script>
+</div>

--- a/tests/plugins/dialog/manual/focus.md
+++ b/tests/plugins/dialog/manual/focus.md
@@ -1,0 +1,14 @@
+@bender-tags: 3474, bug, 4.13.1, dialog, focus
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, find
+
+1. Open the `find and replace` dialog window
+2. Use the <kbd>TAB</kbd> key to move focus sowehere further in the dialog window
+3. Click into the active tab in the dialog navigation
+4. Again use the <kbd>TAB</kbd> key to move focus
+
+### Expected:
+The focus start to cycle from the beginning when tab was clicked
+
+### Unexpected:
+The focus start to cycle from the previously focused element after clicking into navigation tab.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3474](https://github.com/ckeditor/ckeditor4/issues/3474): Fixed: Incorrect focus order after tab in dialog navigation was clicked.
* [#3689](https://github.com/ckeditor/ckeditor4/issues/3689): Fixed: Cannot change dialog tabs focus with keyboard arrows after focusing with any tab with mouse click.
```
## What changes did you make?

After clicking into the tab in navigation setup a proper focus and state.
There is also some clean up to prevent jshint errors.

Closes: #3474, closes: #3689