### PR TITLE
Fix unstable test for AMD

### DIFF
--- a/tests/core/tools/amd.js
+++ b/tests/core/tools/amd.js
@@ -7,15 +7,29 @@
 		'test promise implementation is loaded': function() {
 			var iframe = document.createElement( 'iframe' );
 
-			setTimeout( function() {
-				resume( function() {
-					assert.isNotUndefined( iframe.contentWindow.CKEDITOR.tools.promise );
-				} );
-			}, 500 );
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+				iframe.onreadystatechange = function() {
+					if ( iframe.contentDocument.readyState !== 'complete' ) {
+						return;
+					}
+
+					callback();
+				};
+			} else {
+				iframe.onload = callback;
+			}
 
 			iframe.src = '%BASE_PATH%core/tools/_assets/amdtest.html';
 			document.body.appendChild( iframe );
 			wait();
+
+			function callback() {
+				resume( function() {
+					wait( function() {
+						assert.isNotUndefined( iframe.contentWindow.CKEDITOR.tools.promise );
+					}, 500 );
+				} );
+			}
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None needed

## What changes did you make?

I've forced waiting for the iframe being loaded via appropriate events. Additional 500ms after load is needed for older IEs to actually fetch the polyfill.

Closes #3425.
