### PR TITLE
Fix broken paste of plain text in firefox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#3415](https://github.com/ckeditor/ckeditor4/issues/3415): [Firefox] Fixed: Pasting individual list elements fails. Thanks to [Jack Wickham](https://github.com/jackwickham)!
 * [#3413](https://github.com/ckeditor/ckeditor4/issues/3413): Fixed: Menu items with labels containing double quotes are rendered incorrectly.
+* [#3475](https://github.com/ckeditor/ckeditor4/issues/3475): [Firefox] Fixed: Pasting plain text over existing content fails and throws an error.
 
 ## CKEditor 4.13
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -814,7 +814,7 @@
 				// On Webkit&Gecko (#1113) we use focusout which is fired more often than blur. I.e. it will also be
 				// fired when nested editable is blurred.
 				editable.attachListener( editable, CKEDITOR.env.webkit || CKEDITOR.env.gecko ? 'focusout' : 'blur', function() {
-					var isFakeOrSingleSelection = lastSel && ( lastSel.isFake || lastSel.getRanges() < 2 );
+					var isFakeOrSingleSelection = lastSel && ( lastSel.isFake || lastSel.getRanges().length < 2 );
 
 					// Ignore cases that doesn't produce issue in Firefox (#3136).
 					if ( CKEDITOR.env.gecko && !isInline && isFakeOrSingleSelection ) {

--- a/tests/core/selection/editor.js
+++ b/tests/core/selection/editor.js
@@ -767,6 +767,29 @@ bender.test( {
 		editor.editable().findOne( '#nested' ).focus();
 
 		assert.areEqual( 'em', editor.elementPath().blockLimit.getName() );
+	},
+
+	// (#3475)
+	'test selection with one range should not be locked': function() {
+		if ( !CKEDITOR.env.gecko ) {
+			assert.ignore();
+		}
+
+		bender.editorBot.create( {
+			name: 'plain-text',
+			config: {
+				plugins: 'wysiwygarea,clipboard,toolbar'
+			}
+		}, function( bot ) {
+			var editor = bot.editor,
+				editable = editor.editable();
+
+			bot.setHtmlWithSelection( '<p>foo [bar] baz</p>' );
+
+			editable.fire( 'focusout' );
+
+			assert.areEqual( 0, editor.getSelection().isLocked, 'Simple selection should not be locked' );
+		} );
 	}
 } );
 

--- a/tests/core/selection/manual/plaintextpasteinfirefox.html
+++ b/tests/core/selection/manual/plaintextpasteinfirefox.html
@@ -1,5 +1,6 @@
 <input type="text" value="test" readonly>
 <div id="editor1">
+	<p>Foo Bar Baz</p>
 </div>
 
 <script>

--- a/tests/core/selection/manual/plaintextpasteinfirefox.html
+++ b/tests/core/selection/manual/plaintextpasteinfirefox.html
@@ -1,0 +1,11 @@
+<input type="text" value="test" readonly>
+<div id="editor1">
+</div>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1' );
+</script>

--- a/tests/core/selection/manual/plaintextpasteinfirefox.md
+++ b/tests/core/selection/manual/plaintextpasteinfirefox.md
@@ -1,0 +1,15 @@
+@bender-tags: selection, 4.13.1, bug, 3475
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard
+
+1. Open browser's console
+2. Select text in input above the editor and copy it with <kbd>CTRL</kbd>+<kbd>C</kbd>
+3. Type something in the editor for example `foo bar baz`
+4. Make **non-collapsed** selection for example over a `bar`
+5. Paste previously copied plain-text
+
+### Expected:
+Text is copied to editor.
+
+### Unexpected
+The error is thrown in the console.

--- a/tests/core/selection/manual/plaintextpasteinfirefox.md
+++ b/tests/core/selection/manual/plaintextpasteinfirefox.md
@@ -2,14 +2,13 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard
 
-1. Open browser's console
-2. Select text in input above the editor and copy it with <kbd>CTRL</kbd>+<kbd>C</kbd>
-3. Type something in the editor for example `foo bar baz`
-4. Make **non-collapsed** selection for example over a `bar`
-5. Paste previously copied plain-text
+1. Open browser's dev console.
+1. Select text in the input above the editor and copy it with <kbd>CTRL</kbd>/<kbd>CMD</kbd>+<kbd>C</kbd>.
+1. Make **non-collapsed** selection in the editor, for example over a `Bar` word.
+1. Paste previously copied text.
 
 ### Expected:
-Text is copied to editor.
+Text is correctly pasted into editor.
 
 ### Unexpected
 The error is thrown in the console.

--- a/tests/core/selection/manual/tableselection.md
+++ b/tests/core/selection/manual/tableselection.md
@@ -1,4 +1,4 @@
-@bender-tags: selection, 4.13.0, bug, 3136
+@bender-tags: selection, 4.13.0, 4.13.1, bug, 3136, 3475
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, table, tabletools, toolbar
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3475](https://github.com/ckeditor/ckeditor4/issues/3475) [Firefox] Fix: broken paste of plain text.
```

## What changes did you make?

* Correct comparison expression to use correct data types.

Closes: #3475 