### PR TITLE
Fix unstable drop test

### DIFF
--- a/tests/plugins/clipboard/drop.js
+++ b/tests/plugins/clipboard/drop.js
@@ -661,7 +661,10 @@ var testsForMultipleEditor = {
 
 		// #(2292)
 		'test internal drag and drop on editors margin': function( editor ) {
-			var evt = bender.tools.mockDropEvent();
+			var evt = bender.tools.mockDropEvent(),
+				isWindows = navigator.userAgent.toLowerCase().indexOf( 'windows' ) !== -1,
+				newLine = CKEDITOR.env.gecko && CKEDITOR.env.version >= 69 && isWindows ?
+					String.fromCodePoint( 13, 10 ) : '\n';
 
 			bender.tools.selection.setWithHtml( editor,
 				'<ol>' +
@@ -679,7 +682,7 @@ var testsForMultipleEditor = {
 				expectedPasteEventCount: 1,
 				expectedDropPrevented: false,
 				expectedTransferType: CKEDITOR.DATA_TRANSFER_INTERNAL,
-				expectedText: CKEDITOR.env.edge ? 'onetwothreefour' : 'one\ntwo\nthree\nfour',
+				expectedText: CKEDITOR.env.edge ? 'onetwothreefour' : 'one' + newLine + 'two' + newLine + 'three' + newLine + 'four',
 				expectedHtml: '<ol><li><a href="http://test.com">one</a>@</li><li>two</li><li>three</li><li>four</li></ol>',
 				expectedDataType: 'html',
 				expectedDataValue: '<ol><li><a href="http://test.com">one</a>@</li><li>two</li><li>three</li><li>four</li></ol>'


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None needed.

## What changes did you make?

Seems like Firefox on Windows changed handling of new line character and produces `\n\r` instead of `\r`. I've updated expected output for Firefox on Windows.

Closes #3517.