### PR TITLE
Improve stability of Paste Tools tests with filters

### DIFF
--- a/tests/plugins/pastefromword/generated/functions.js
+++ b/tests/plugins/pastefromword/generated/functions.js
@@ -269,10 +269,8 @@
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.loadFilters( [
+	ptTools.testWithFilters( tests, [
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
-	], function() {
-		bender.test( tests );
-	} );
+	] );
 } )();

--- a/tests/plugins/pastefromword/generated/heuristics.js
+++ b/tests/plugins/pastefromword/generated/heuristics.js
@@ -96,10 +96,8 @@
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.loadFilters( [
+	ptTools.testWithFilters( tests, [
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
-	], function() {
-		bender.test( tests );
-	} );
+	] );
 } )();

--- a/tests/plugins/pastefromword/helpers.js
+++ b/tests/plugins/pastefromword/helpers.js
@@ -73,10 +73,8 @@
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.loadFilters( [
+	ptTools.testWithFilters( tests, [
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
-	], function() {
-		bender.test( tests );
-	} );
+	] );
 } )();

--- a/tests/plugins/pastefromword/pasteimage.js
+++ b/tests/plugins/pastefromword/pasteimage.js
@@ -25,7 +25,7 @@
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.loadFilters( [
+	ptTools.testWithFilters( tests, [
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
 	], function() {

--- a/tests/plugins/pastetools/_helpers/ptTools.js
+++ b/tests/plugins/pastetools/_helpers/ptTools.js
@@ -29,6 +29,20 @@
 					} );
 				}( filters[ i ] ) );
 			}
+		},
+
+		testWithFilters: function( tests, filters, callback ) {
+			this.loadFilters( filters, function() {
+				tests[ 'async:init' ] = function() {
+					if ( callback ) {
+						callback( this );
+					}
+
+					this.callback();
+				};
+
+				bender.test( tests );
+			} );
 		}
 	};
 } )();

--- a/tests/plugins/pastetools/filter/functions.js
+++ b/tests/plugins/pastetools/filter/functions.js
@@ -22,10 +22,6 @@
 		filterMock = new CKEDITOR.htmlParser.filter(),
 
 		tests = {
-			setUp: function(  ) {
-				this.commonFilter = CKEDITOR.plugins.pastetools.filters.common;
-			},
-
 			'test create style stack': function() {
 				var element = new CKEDITOR.htmlParser.element( 'p' );
 
@@ -97,10 +93,10 @@
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.loadFilters( [
+	ptTools.testWithFilters( tests, [
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
-	], function() {
-		bender.test( tests );
+	], function( testCase ) {
+		testCase.commonFilter = CKEDITOR.plugins.pastetools.filters.common;
 	} );
 } )();

--- a/tests/plugins/pastetools/filter/parsestyles.js
+++ b/tests/plugins/pastetools/filter/parsestyles.js
@@ -109,10 +109,8 @@
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.loadFilters( [
+	ptTools.testWithFilters( tests, [
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
 		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
-	], function() {
-		bender.test( tests );
-	} );
+	] );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None needed.

## What changes did you make?

I've moved loading filters as a part of `async:init` to force loading them after creating editor for tests.

Closes #3424.