### PR TITLE
Fix missing reposition of balloon toolbar after scrolling the editable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixed Issues:
 * [#3475](https://github.com/ckeditor/ckeditor4/issues/3475): [Firefox] Fixed: Pasting plain text over existing content fails and throws an error.
 * [#2027](https://github.com/ckeditor/ckeditor4/issues/2027): Fixed: Incorrect email display text after reopening [Link](https://ckeditor.com/cke4/addon/link) dialog for display names starting with `@`.
 * [#3544](https://github.com/ckeditor/ckeditor4/issues/3544): Fixed: [Special Characters](https://ckeditor.com/cke4/addon/specialchar) dialog read incorrectly by screen readers due to empty table cells at the end.
+* [#1653](https://github.com/ckeditor/ckeditor4/issues/1653): Fixed: Missing reposition of [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) when editor is scrolled with enabled [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) feature.
 
 ## CKEditor 4.13
 

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -697,9 +697,8 @@
 				CKEDITOR.ui.balloonPanel.prototype.show.call( this );
 
 				// It's necessary to execute code in a closure, as reposition is defined in a prototype.
-				// Direct assign `this.reposition` to an evenListener might result with an error when multiple editors are on a page.
-				// There might be case where `this._detachListeners`, will be executed from 2 editors. So listener will be detached by first one,
-				// but second editor will try to remove it once again what will throw an error, becasue it would have reference to the same reposition method.
+				// Otherwise hiding balloon toolbar may remove event listeners from different editors,
+				// as removing listeners are done by function delegate.
 				function repositionClosure() {
 					this.reposition();
 				}

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -688,13 +688,21 @@
 
 				this._detachListeners();
 
-				this._listeners.push( editor.on( 'change', this.reposition, this ) );
-				this._listeners.push( editor.on( 'resize', this.reposition, this ) );
-				this._listeners.push( win.on( 'resize', this.reposition, this ) );
-				this._listeners.push( win.on( 'scroll', this.reposition, this ) );
-				this._listeners.push( editorScrollableElement.on( 'scroll', this.reposition, this ) );
+				this._listeners.push( editor.on( 'change', repositionClosure, this ) );
+				this._listeners.push( editor.on( 'resize', repositionClosure, this ) );
+				this._listeners.push( win.on( 'resize', repositionClosure, this ) );
+				this._listeners.push( win.on( 'scroll', repositionClosure, this ) );
+				this._listeners.push( editorScrollableElement.on( 'scroll', repositionClosure, this ) );
 
 				CKEDITOR.ui.balloonPanel.prototype.show.call( this );
+
+				// It's necessary to execute code in a closure, as reposition is defined in a prototype.
+				// Direct assign `this.reposition` to an evenListener might result with an error when multiple editors are on a page.
+				// There might be case where `this._detachListeners`, will be executed from 2 editors. So listener will be detached by first one,
+				// but second editor will try to remove it once again what will throw an error, becasue it would have reference to the same reposition method.
+				function repositionClosure() {
+					this.reposition();
+				}
 			};
 
 			/**

--- a/plugins/balloontoolbar/plugin.js
+++ b/plugins/balloontoolbar/plugin.js
@@ -688,19 +688,13 @@
 
 				this._detachListeners();
 
-				this._listeners.push( editor.on( 'change', attachListener, this ) );
-				this._listeners.push( editor.on( 'resize', attachListener, this ) );
-
-				this._listeners.push( win.on( 'resize', attachListener, this ) );
-				this._listeners.push( win.on( 'scroll', attachListener, this ) );
-
-				this._listeners.push( editorScrollableElement.on( 'scroll', attachListener, this ) );
+				this._listeners.push( editor.on( 'change', this.reposition, this ) );
+				this._listeners.push( editor.on( 'resize', this.reposition, this ) );
+				this._listeners.push( win.on( 'resize', this.reposition, this ) );
+				this._listeners.push( win.on( 'scroll', this.reposition, this ) );
+				this._listeners.push( editorScrollableElement.on( 'scroll', this.reposition, this ) );
 
 				CKEDITOR.ui.balloonPanel.prototype.show.call( this );
-
-				function attachListener() {
-					this.reposition();
-				}
 			};
 
 			/**

--- a/tests/plugins/balloontoolbar/manual/divareascroll.html
+++ b/tests/plugins/balloontoolbar/manual/divareascroll.html
@@ -9,105 +9,17 @@
 <h2 class="top-margin">Divarea:</h2>
 <div contenteditable="true" id="editor1" class="editor">
 	<p>Some start content <a href="https://ckeditor.com">link</a>.</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
+	<p class="filler">scroll</p>
 	<p>Some middle content <a href="https://ckeditor.com">link</a>.</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
+	<p class="filler">scroll</p>
 	<p>Some end content <a href="https://ckeditor.com">link</a>.</p>
 </div>
 <h2>Classic:</h2>
 <div contenteditable="true" id="editor2" class="editor">
 	<p>Some start content <a href="https://ckeditor.com">link</a>.</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
+	<p class="filler">scroll</p>
 	<p>Some middle content <a href="https://ckeditor.com">link</a>.</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
-	<p>scroll</p>
+	<p class="filler">scroll</p>
 	<p>Some end content <a href="https://ckeditor.com">link</a>.</p>
 </div>
 <script>
@@ -123,20 +35,17 @@
 		} );
 	}
 
-	CKEDITOR.replace( 'editor1', {
-		extraPlugins: 'divarea',
+	var config = {
+		extraAllowedContent: 'p(filler)',
 		height: 200,
 		width: 400,
 		on: {
 			instanceReady: instanceReadyListener
 		}
-	} );
+	}
 
-	CKEDITOR.replace( 'editor2', {
-		height: 200,
-		width: 400,
-		on: {
-			instanceReady: instanceReadyListener
-		}
-	} );
+	CKEDITOR.addCss( 'p.filler { height: 900px; border: 1px solid red; }' );
+
+	CKEDITOR.replace( 'editor1', CKEDITOR.tools.extend( { extraPlugins: 'divarea' }, config ) );
+	CKEDITOR.replace( 'editor2', CKEDITOR.tools.extend( {}, config ) );
 </script>

--- a/tests/plugins/balloontoolbar/manual/divareascroll.html
+++ b/tests/plugins/balloontoolbar/manual/divareascroll.html
@@ -1,0 +1,142 @@
+<style>
+	body {
+		height: 5000px;
+	}
+	.top-margin {
+		margin-top: 500px;
+	}
+</style>
+<h2 class="top-margin">Divarea:</h2>
+<div contenteditable="true" id="editor1" class="editor">
+	<p>Some start content <a href="https://ckeditor.com">link</a>.</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>Some middle content <a href="https://ckeditor.com">link</a>.</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>Some end content <a href="https://ckeditor.com">link</a>.</p>
+</div>
+<h2>Classic:</h2>
+<div contenteditable="true" id="editor2" class="editor">
+	<p>Some start content <a href="https://ckeditor.com">link</a>.</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>Some middle content <a href="https://ckeditor.com">link</a>.</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>Some end content <a href="https://ckeditor.com">link</a>.</p>
+</div>
+<script>
+	// Currently balloon toolbar is not integrated with old IE browsers.
+	bender.tools.ignoreUnsupportedEnvironment( 'balloontoolbar' );
+
+	function instanceReadyListener( evt ) {
+		var editor = evt.editor;
+
+		editor.balloonToolbars.create( {
+			buttons: 'Link,Unlink',
+			cssSelector: 'a[href], img'
+		} );
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'divarea',
+		height: 200,
+		width: 400,
+		on: {
+			instanceReady: instanceReadyListener
+		}
+	} );
+
+	CKEDITOR.replace( 'editor2', {
+		height: 200,
+		width: 400,
+		on: {
+			instanceReady: instanceReadyListener
+		}
+	} );
+</script>

--- a/tests/plugins/balloontoolbar/manual/divareascroll.html
+++ b/tests/plugins/balloontoolbar/manual/divareascroll.html
@@ -119,7 +119,7 @@
 
 		editor.balloonToolbars.create( {
 			buttons: 'Link,Unlink',
-			cssSelector: 'a[href], img'
+			cssSelector: 'a[href]'
 		} );
 	}
 

--- a/tests/plugins/balloontoolbar/manual/divareascroll.md
+++ b/tests/plugins/balloontoolbar/manual/divareascroll.md
@@ -1,0 +1,15 @@
+@bender-ui: collapsed
+@bender-tags: 4.13.1, bug, 1653, balloontoolbar
+@bender-ckeditor-plugins: wysiwygarea,toolbar,balloontoolbar,link
+
+## Please notice that both editable and entire document should have a scrollbar.
+
+If editors are not visible in the test please scroll down the page.
+
+1. Put selection inside a link to show balloontolbar.
+2. Scroll editable.
+3. You can use other links and scroll document to test different variation.
+
+### Expected
+* During scroll operation balloontoolbar should remain attached to the link.
+* When link moves outside of editable, balloontoolbar should remain inside editable.

--- a/tests/plugins/balloontoolbar/manual/divareascroll.md
+++ b/tests/plugins/balloontoolbar/manual/divareascroll.md
@@ -6,10 +6,13 @@
 
 If editors are not visible in the test please scroll down the page.
 
-1. Put selection inside a link to show balloontolbar.
+1. Put selection inside a link to show balloontolbar. There are multiple links in each editor spread in the content.
 2. Scroll editable.
-3. Use other links and scroll document to test different variations.
+3. Use other links and scroll document to test different variations of balloon toolbar and scroll position.
 
 ### Expected
 * During scroll operation balloontoolbar should remain attached to the link.
 * When link moves outside of editable, balloontoolbar should remain inside editable.
+
+### Note
+* There is a bug that balloon toolbar doesn't hide when editor is outside of view port for divarea editors [#3632](https://github.com/ckeditor/ckeditor4/issues/3632).

--- a/tests/plugins/balloontoolbar/manual/divareascroll.md
+++ b/tests/plugins/balloontoolbar/manual/divareascroll.md
@@ -8,7 +8,7 @@ If editors are not visible in the test please scroll down the page.
 
 1. Put selection inside a link to show balloontolbar.
 2. Scroll editable.
-3. You can use other links and scroll document to test different variation.
+3. Use other links and scroll document to test different variations.
 
 ### Expected
 * During scroll operation balloontoolbar should remain attached to the link.

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -253,7 +253,7 @@
 						resume( function() {
 							spy.restore();
 
-							sinon.assert.calledOnce( spy );
+							sinon.assert.called( spy );
 							assert.pass();
 						} );
 					} );
@@ -287,7 +287,7 @@
 						resume( function() {
 							spy.restore();
 
-							sinon.assert.calledOnce( spy );
+							sinon.assert.called( spy );
 							assert.pass();
 						} );
 					} );
@@ -320,7 +320,7 @@
 						resume( function() {
 							spy.restore();
 
-							sinon.assert.calledOnce( spy );
+							sinon.assert.called( spy );
 							assert.pass();
 						} );
 					} );
@@ -353,7 +353,7 @@
 						resume( function() {
 							spy.restore();
 
-							sinon.assert.calledOnce( spy );
+							sinon.assert.called( spy );
 							assert.pass();
 						} );
 					} );
@@ -394,7 +394,7 @@
 						resume( function() {
 							spy.restore();
 
-							sinon.assert.calledOnce( spy );
+							sinon.assert.called( spy );
 							assert.pass();
 						} );
 					} );

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -229,6 +229,181 @@
 
 				assert.isTrue( markerElement.equals( spy.args[ 0 ][ 0 ] ) );
 			} );
+		},
+
+		// #1653
+		'test Balloon Toolbar should be respositioned after "window scroll" event': function( editor, bot ) {
+			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
+				var markerElement = editor.editable().findOne( '#bar' ),
+					spy,
+					win = CKEDITOR.document.getWindow();
+
+				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+					width: 100,
+					height: 200
+				} );
+
+				balloonToolbar.attach( markerElement );
+
+				spy = sinon.spy( balloonToolbar, 'reposition' );
+
+				win.once( 'scroll', function() {
+					// Make it async to have sure that anything related to `scroll` event will finish processing.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							spy.restore();
+
+							sinon.assert.calledOnce( spy );
+							assert.pass();
+						} );
+					} );
+				}, null, null, 100000 );
+
+				win.fire( 'scroll' );
+
+				wait();
+			} );
+		},
+
+		// #1653
+		'test Balloon Toolbar should be respositioned after "window resize" event': function( editor, bot ) {
+			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
+				var markerElement = editor.editable().findOne( '#bar' ),
+					spy,
+					win = CKEDITOR.document.getWindow();
+
+				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+					width: 100,
+					height: 200
+				} );
+
+				balloonToolbar.attach( markerElement );
+
+				spy = sinon.spy( balloonToolbar, 'reposition' );
+
+				win.once( 'resize', function() {
+					// Make it async to have sure that anything related to `scroll` event will finish processing.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							spy.restore();
+
+							sinon.assert.calledOnce( spy );
+							assert.pass();
+						} );
+					} );
+				}, null, null, 100000 );
+
+				win.fire( 'resize' );
+
+				wait();
+			} );
+		},
+
+		// #1653
+		'test Balloon Toolbar should be respositioned after "editor change" event': function( editor, bot ) {
+			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
+				var markerElement = editor.editable().findOne( '#bar' ),
+					spy;
+
+				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+					width: 100,
+					height: 200
+				} );
+
+				balloonToolbar.attach( markerElement );
+
+				spy = sinon.spy( balloonToolbar, 'reposition' );
+
+				editor.once( 'change', function() {
+					// Make it async to have sure that anything related to `scroll` event will finish processing.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							spy.restore();
+
+							sinon.assert.calledOnce( spy );
+							assert.pass();
+						} );
+					} );
+				}, null, null, 100000 );
+
+				editor.fire( 'change' );
+
+				wait();
+			} );
+		},
+
+		// #1653
+		'test Balloon Toolbar should be respositioned after "editor resize" event': function( editor, bot ) {
+			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
+				var markerElement = editor.editable().findOne( '#bar' ),
+					spy;
+
+				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+					width: 100,
+					height: 200
+				} );
+
+				balloonToolbar.attach( markerElement );
+
+				spy = sinon.spy( balloonToolbar, 'reposition' );
+
+				editor.once( 'resize', function() {
+					// Make it async to have sure that anything related to `scroll` event will finish processing.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							spy.restore();
+
+							sinon.assert.calledOnce( spy );
+							assert.pass();
+						} );
+					} );
+				}, null, null, 100000 );
+
+				editor.fire( 'resize' );
+
+				wait();
+			} );
+		},
+
+		// #1653
+		'test Balloon Toolbar should be respositioned after "editable scroll" event': function( editor, bot ) {
+			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
+				var editable = editor.editable(),
+					markerElement = editable.findOne( '#bar' ),
+					spy,
+					editableScrollElement = editable.isInline() ? editable : editable.getDocument();
+
+				// iOS classic editor listens on frame parent element for editor `scroll` event (#1910).
+				// Since iOS 13, this `if` won't be necesary any longer https://bugs.webkit.org/show_bug.cgi?id=149264.
+				if ( !editable.isInline() && CKEDITOR.env.iOS ) {
+					editableScrollElement = editor.window.getFrame().getParent();
+				}
+
+				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+					width: 100,
+					height: 200
+				} );
+
+				balloonToolbar.attach( markerElement );
+
+				spy = sinon.spy( balloonToolbar, 'reposition' );
+
+				editableScrollElement.once( 'scroll', function() {
+					// Make it async to have sure that anything related to `scroll` event will finish processing.
+					CKEDITOR.tools.setTimeout( function() {
+						resume( function() {
+							spy.restore();
+
+							sinon.assert.calledOnce( spy );
+							assert.pass();
+						} );
+					} );
+				}, null, null, 100000 );
+
+				editableScrollElement.fire( 'scroll' );
+
+				wait();
+			} );
 		}
 	};
 

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -238,14 +238,14 @@
 					spy,
 					win = CKEDITOR.document.getWindow();
 
+				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
+
 				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
 					width: 100,
 					height: 200
 				} );
 
 				balloonToolbar.attach( markerElement );
-
-				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				win.once( 'scroll', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -272,14 +272,14 @@
 					spy,
 					win = CKEDITOR.document.getWindow();
 
+				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
+
 				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
 					width: 100,
 					height: 200
 				} );
 
 				balloonToolbar.attach( markerElement );
-
-				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				win.once( 'resize', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -305,14 +305,14 @@
 				var markerElement = editor.editable().findOne( '#bar' ),
 					spy;
 
+				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
+
 				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
 					width: 100,
 					height: 200
 				} );
 
 				balloonToolbar.attach( markerElement );
-
-				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				editor.once( 'change', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -338,14 +338,14 @@
 				var markerElement = editor.editable().findOne( '#bar' ),
 					spy;
 
+				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
+
 				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
 					width: 100,
 					height: 200
 				} );
 
 				balloonToolbar.attach( markerElement );
-
-				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				editor.once( 'resize', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -379,14 +379,14 @@
 					editableScrollElement = editor.window.getFrame().getParent();
 				}
 
+				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
+
 				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
 					width: 100,
 					height: 200
 				} );
 
 				balloonToolbar.attach( markerElement );
-
-				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				editableScrollElement.once( 'scroll', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -245,7 +245,9 @@
 
 				balloonToolbar.attach( markerElement );
 
-				spy = sinon.spy( balloonToolbar, 'reposition' );
+				win.once( 'scroll', function() {
+					spy = sinon.spy( balloonToolbar, 'reposition' );
+				}, null, null, -100000 );
 
 				win.once( 'scroll', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -279,7 +281,9 @@
 
 				balloonToolbar.attach( markerElement );
 
-				spy = sinon.spy( balloonToolbar, 'reposition' );
+				win.once( 'resize', function() {
+					spy = sinon.spy( balloonToolbar, 'reposition' );
+				}, null, null, -100000 );
 
 				win.once( 'resize', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -312,7 +316,9 @@
 
 				balloonToolbar.attach( markerElement );
 
-				spy = sinon.spy( balloonToolbar, 'reposition' );
+				editor.once( 'change', function() {
+					spy = sinon.spy( balloonToolbar, 'reposition' );
+				}, null, null, -100000 );
 
 				editor.once( 'change', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -345,7 +351,9 @@
 
 				balloonToolbar.attach( markerElement );
 
-				spy = sinon.spy( balloonToolbar, 'reposition' );
+				editor.once( 'resize', function() {
+					spy = sinon.spy( balloonToolbar, 'reposition' );
+				}, null, null, -100000 );
 
 				editor.once( 'resize', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -386,7 +394,9 @@
 
 				balloonToolbar.attach( markerElement );
 
-				spy = sinon.spy( balloonToolbar, 'reposition' );
+				editableScrollElement.once( 'scroll', function() {
+					spy = sinon.spy( balloonToolbar, 'reposition' );
+				}, null, null, -100000 );
 
 				editableScrollElement.once( 'scroll', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -269,10 +269,10 @@
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
 	bender.test( tests );
 
-	// @param {CKEDITOR.dom.domObject} element - element which listens to some event which triggers a reposition of balloontoolbar
-	// @param {String} eventName - name of event which will be fired on element
-	// @param {bender.editorBot} bot - bot instance
-	function assertRepositionCall( element, eventName, bot ) {
+	// @param {CKEDITOR.dom.domObject/CKEDITOR.editor} eventTarget - target listening on a repositioning event of balloontoolbar
+	// @param {String} eventName - name of the event which will be fired on the given target
+	// @param {bender.editorBot} bot
+	function assertRepositionCall( eventTarget, eventName, bot ) {
 		bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
 			var editor = bot.editor,
 				markerElement = editor.editable().findOne( '#bar' ),
@@ -285,7 +285,7 @@
 
 			balloonToolbar.attach( markerElement );
 
-			element.once( eventName, function() {
+			eventTarget.once( eventName, function() {
 				// Make it async to have sure that anything related to event will finish processing.
 				CKEDITOR.tools.setTimeout( function() {
 					resume( function() {
@@ -297,7 +297,7 @@
 				} );
 			}, null, null, 100000 );
 
-			element.fire( eventName );
+			eventTarget.fire( eventName );
 
 			wait();
 		} );

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -261,7 +261,9 @@
 					} );
 				}, null, null, 100000 );
 
-				win.fire( 'scroll' );
+				CKEDITOR.tools.setTimeout( function() {
+					win.fire( 'scroll' );
+				} );
 
 				wait();
 			} );
@@ -297,7 +299,9 @@
 					} );
 				}, null, null, 100000 );
 
-				win.fire( 'resize' );
+				CKEDITOR.tools.setTimeout( function() {
+					win.fire( 'resize' );
+				} );
 
 				wait();
 			} );
@@ -332,7 +336,9 @@
 					} );
 				}, null, null, 100000 );
 
-				editor.fire( 'change' );
+				CKEDITOR.tools.setTimeout( function() {
+					editor.fire( 'change' );
+				} );
 
 				wait();
 			} );
@@ -367,8 +373,9 @@
 					} );
 				}, null, null, 100000 );
 
-				editor.fire( 'resize' );
-
+				CKEDITOR.tools.setTimeout( function() {
+					editor.fire( 'resize' );
+				} );
 				wait();
 			} );
 		},
@@ -410,7 +417,9 @@
 					} );
 				}, null, null, 100000 );
 
-				editableScrollElement.fire( 'scroll' );
+				CKEDITOR.tools.setTimeout( function() {
+					editableScrollElement.fire( 'scroll' );
+				} );
 
 				wait();
 			} );

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -261,9 +261,7 @@
 					} );
 				}, null, null, 100000 );
 
-				CKEDITOR.tools.setTimeout( function() {
-					win.fire( 'scroll' );
-				} );
+				win.fire( 'scroll' );
 
 				wait();
 			} );
@@ -299,9 +297,7 @@
 					} );
 				}, null, null, 100000 );
 
-				CKEDITOR.tools.setTimeout( function() {
-					win.fire( 'resize' );
-				} );
+				win.fire( 'resize' );
 
 				wait();
 			} );
@@ -336,9 +332,7 @@
 					} );
 				}, null, null, 100000 );
 
-				CKEDITOR.tools.setTimeout( function() {
-					editor.fire( 'change' );
-				} );
+				editor.fire( 'change' );
 
 				wait();
 			} );
@@ -373,9 +367,8 @@
 					} );
 				}, null, null, 100000 );
 
-				CKEDITOR.tools.setTimeout( function() {
-					editor.fire( 'resize' );
-				} );
+				editor.fire( 'resize' );
+
 				wait();
 			} );
 		},
@@ -417,9 +410,7 @@
 					} );
 				}, null, null, 100000 );
 
-				CKEDITOR.tools.setTimeout( function() {
-					editableScrollElement.fire( 'scroll' );
-				} );
+				editableScrollElement.fire( 'scroll' );
 
 				wait();
 			} );

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -233,183 +233,75 @@
 
 		// (#1653)
 		'test Balloon Toolbar should be respositioned after "window scroll" event': function( editor, bot ) {
-			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
-				var markerElement = editor.editable().findOne( '#bar' ),
-					spy,
-					win = CKEDITOR.document.getWindow();
-
-				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
-
-				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
-					width: 100,
-					height: 200
-				} );
-
-				balloonToolbar.attach( markerElement );
-
-				win.once( 'scroll', function() {
-					// Make it async to have sure that anything related to `scroll` event will finish processing.
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							spy.restore();
-
-							sinon.assert.called( spy );
-							assert.pass();
-						} );
-					} );
-				}, null, null, 100000 );
-
-				win.fire( 'scroll' );
-
-				wait();
-			} );
+			assertRepositionCall( CKEDITOR.document.getWindow(), 'scroll', bot );
 		},
 
 		// (#1653)
 		'test Balloon Toolbar should be respositioned after "window resize" event': function( editor, bot ) {
-			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
-				var markerElement = editor.editable().findOne( '#bar' ),
-					spy,
-					win = CKEDITOR.document.getWindow();
-
-				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
-
-				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
-					width: 100,
-					height: 200
-				} );
-
-				balloonToolbar.attach( markerElement );
-
-				win.once( 'resize', function() {
-					// Make it async to have sure that anything related to `scroll` event will finish processing.
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							spy.restore();
-
-							sinon.assert.called( spy );
-							assert.pass();
-						} );
-					} );
-				}, null, null, 100000 );
-
-				win.fire( 'resize' );
-
-				wait();
-			} );
+			assertRepositionCall( CKEDITOR.document.getWindow(), 'resize', bot );
 		},
 
 		// (#1653)
 		'test Balloon Toolbar should be respositioned after "editor change" event': function( editor, bot ) {
-			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
-				var markerElement = editor.editable().findOne( '#bar' ),
-					spy;
-
-				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
-
-				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
-					width: 100,
-					height: 200
-				} );
-
-				balloonToolbar.attach( markerElement );
-
-				editor.once( 'change', function() {
-					// Make it async to have sure that anything related to `scroll` event will finish processing.
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							spy.restore();
-
-							sinon.assert.called( spy );
-							assert.pass();
-						} );
-					} );
-				}, null, null, 100000 );
-
-				editor.fire( 'change' );
-
-				wait();
-			} );
+			assertRepositionCall( editor, 'change', bot );
 		},
 
 		// (#1653)
 		'test Balloon Toolbar should be respositioned after "editor resize" event': function( editor, bot ) {
-			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
-				var markerElement = editor.editable().findOne( '#bar' ),
-					spy;
-
-				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
-
-				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
-					width: 100,
-					height: 200
-				} );
-
-				balloonToolbar.attach( markerElement );
-
-				editor.once( 'resize', function() {
-					// Make it async to have sure that anything related to `scroll` event will finish processing.
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							spy.restore();
-
-							sinon.assert.called( spy );
-							assert.pass();
-						} );
-					} );
-				}, null, null, 100000 );
-
-				editor.fire( 'resize' );
-
-				wait();
-			} );
+			assertRepositionCall( editor, 'resize', bot );
 		},
 
 		// (#1653)
 		'test Balloon Toolbar should be respositioned after "editable scroll" event': function( editor, bot ) {
-			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
-				var editable = editor.editable(),
-					markerElement = editable.findOne( '#bar' ),
-					spy,
-					editableScrollElement = editable.isInline() ? editable : editable.getDocument();
+			var editable = editor.editable(),
+				editableScrollElement = editable.isInline() ? editable : editable.getDocument();
 
-				// iOS classic editor listens on frame parent element for editor `scroll` event (#1910).
-				// Since iOS 13, this `if` won't be necesary any longer https://bugs.webkit.org/show_bug.cgi?id=149264.
-				if ( !editable.isInline() && CKEDITOR.env.iOS ) {
-					editableScrollElement = editor.window.getFrame().getParent();
-				}
+			// iOS classic editor listens on frame parent element for editor `scroll` event (#1910).
+			// Since iOS 13, this `if` won't be necesary any longer https://bugs.webkit.org/show_bug.cgi?id=149264.
+			if ( !editable.isInline() && CKEDITOR.env.iOS ) {
+				editableScrollElement = editor.window.getFrame().getParent();
+			}
 
-				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
-
-				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
-					width: 100,
-					height: 200
-				} );
-
-				balloonToolbar.attach( markerElement );
-
-				editableScrollElement.once( 'scroll', function() {
-					// Make it async to have sure that anything related to `scroll` event will finish processing.
-					CKEDITOR.tools.setTimeout( function() {
-						resume( function() {
-							spy.restore();
-
-							sinon.assert.called( spy );
-							assert.pass();
-						} );
-					} );
-				}, null, null, 100000 );
-
-				editableScrollElement.fire( 'scroll' );
-
-				wait();
-			} );
+			assertRepositionCall( editableScrollElement, 'scroll', bot );
 		}
 	};
 
 	tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
 	bender.test( tests );
 
+	// @param {CKEDITOR.dom.domObject} element - element which listens to some event which triggers a reposition of balloontoolbar
+	// @param {String} eventName - name of event which will be fired on element
+	// @param {bender.editorBot} bot - bot instance
+	function assertRepositionCall( element, eventName, bot ) {
+		bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
+			var editor = bot.editor,
+				markerElement = editor.editable().findOne( '#bar' ),
+				spy = sinon.spy( CKEDITOR.ui.balloonToolbarView.prototype, 'reposition' );
+
+			balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
+				width: 100,
+				height: 200
+			} );
+
+			balloonToolbar.attach( markerElement );
+
+			element.once( eventName, function() {
+				// Make it async to have sure that anything related to event will finish processing.
+				CKEDITOR.tools.setTimeout( function() {
+					resume( function() {
+						spy.restore();
+
+						sinon.assert.called( spy );
+						assert.pass();
+					} );
+				} );
+			}, null, null, 100000 );
+
+			element.fire( eventName );
+
+			wait();
+		} );
+	}
 
 	function makeExpectedLeft( data ) {
 		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -163,7 +163,7 @@
 			arrayAssert.itemsAreEqual( [ 'bottom hcenter', 'top hcenter' ], CKEDITOR.tools.object.keys( res ) );
 		},
 
-		// #1342, #1496
+		// (#1342, #1496)
 		'test panel refresh position': function( editor, bot ) {
 			bot.setData( '<img src="' + bender.basePath + '/_assets/lena.jpg">', function() {
 				balloonToolbar = new CKEDITOR.ui.balloonToolbarView( editor, {
@@ -210,7 +210,7 @@
 			} );
 		},
 
-		// #1496
+		// (#1496)
 		'test panel reposition': function( editor, bot ) {
 			bot.setData( '<img src="' + bender.basePath + '/_assets/lena.jpg">', function() {
 				var markerElement = editor.editable().findOne( 'img' ),
@@ -231,7 +231,7 @@
 			} );
 		},
 
-		// #1653
+		// (#1653)
 		'test Balloon Toolbar should be respositioned after "window scroll" event': function( editor, bot ) {
 			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
 				var markerElement = editor.editable().findOne( '#bar' ),
@@ -265,7 +265,7 @@
 			} );
 		},
 
-		// #1653
+		// (#1653)
 		'test Balloon Toolbar should be respositioned after "window resize" event': function( editor, bot ) {
 			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
 				var markerElement = editor.editable().findOne( '#bar' ),
@@ -299,7 +299,7 @@
 			} );
 		},
 
-		// #1653
+		// (#1653)
 		'test Balloon Toolbar should be respositioned after "editor change" event': function( editor, bot ) {
 			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
 				var markerElement = editor.editable().findOne( '#bar' ),
@@ -332,7 +332,7 @@
 			} );
 		},
 
-		// #1653
+		// (#1653)
 		'test Balloon Toolbar should be respositioned after "editor resize" event': function( editor, bot ) {
 			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
 				var markerElement = editor.editable().findOne( '#bar' ),
@@ -365,7 +365,7 @@
 			} );
 		},
 
-		// #1653
+		// (#1653)
 		'test Balloon Toolbar should be respositioned after "editable scroll" event': function( editor, bot ) {
 			bot.setData( '<p>foo <span id="bar">bar</span> baz</p>', function() {
 				var editable = editor.editable(),

--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -245,9 +245,7 @@
 
 				balloonToolbar.attach( markerElement );
 
-				win.once( 'scroll', function() {
-					spy = sinon.spy( balloonToolbar, 'reposition' );
-				}, null, null, -100000 );
+				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				win.once( 'scroll', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -281,9 +279,7 @@
 
 				balloonToolbar.attach( markerElement );
 
-				win.once( 'resize', function() {
-					spy = sinon.spy( balloonToolbar, 'reposition' );
-				}, null, null, -100000 );
+				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				win.once( 'resize', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -316,9 +312,7 @@
 
 				balloonToolbar.attach( markerElement );
 
-				editor.once( 'change', function() {
-					spy = sinon.spy( balloonToolbar, 'reposition' );
-				}, null, null, -100000 );
+				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				editor.once( 'change', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -351,9 +345,7 @@
 
 				balloonToolbar.attach( markerElement );
 
-				editor.once( 'resize', function() {
-					spy = sinon.spy( balloonToolbar, 'reposition' );
-				}, null, null, -100000 );
+				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				editor.once( 'resize', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.
@@ -394,9 +386,7 @@
 
 				balloonToolbar.attach( markerElement );
 
-				editableScrollElement.once( 'scroll', function() {
-					spy = sinon.spy( balloonToolbar, 'reposition' );
-				}, null, null, -100000 );
+				spy = sinon.spy( balloonToolbar, 'reposition' );
 
 				editableScrollElement.once( 'scroll', function() {
 					// Make it async to have sure that anything related to `scroll` event will finish processing.

--- a/tests/plugins/balloontoolbar/view.js
+++ b/tests/plugins/balloontoolbar/view.js
@@ -48,7 +48,7 @@
 			assert.areSame( '', view.parts.content.getHtml() );
 		},
 
-		'test Balloon Toolbar doesnt steal the focus': function() {
+		'test Balloon Toolbar doesn\'t steal the focus': function() {
 			var editor = this.editor;
 
 			this.editorBot.setData( '<p>foo <strong>bar</strong> baz</p>', function() {
@@ -81,7 +81,7 @@
 
 				view.show();
 				assert.isTrue( view.rect.visible, 'Toolbar should be shown after show method' );
-				assert.areEqual( 4, view._listeners.length, 'Listeners should be attached after show method' );
+				assert.areEqual( 5, view._listeners.length, 'Listeners should be attached after show method' );
 
 				view.hide();
 				assert.isFalse( view.rect.visible, 'Toolbar should not be shown after hide method' );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#1653](https://github.com/ckeditor/ckeditor4/issues/1653) Fix: Missing reposition of [balloon toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) when the editable was scrolled in the [divarea](https://ckeditor.com/cke4/addon/divarea) editor.
```

## What changes did you make?

Improve listener which now detects elements with scrollbar holding the editable and attach scroll listener to it.

Closes: #1653