### PR TITLE
Remove empty table cells from the dialog of specialchar plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#3413](https://github.com/ckeditor/ckeditor4/issues/3413): Fixed: Menu items with labels containing double quotes are rendered incorrectly.
 * [#3475](https://github.com/ckeditor/ckeditor4/issues/3475): [Firefox] Fixed: Pasting plain text over existing content fails and throws an error.
 * [#2027](https://github.com/ckeditor/ckeditor4/issues/2027): Fixed: Incorrect email display text after reopening [Link](https://ckeditor.com/cke4/addon/link) dialog for display names starting with `@`.
+* [#3544](https://github.com/ckeditor/ckeditor4/issues/3544): Fixed: [Special Characters](https://ckeditor.com/cke4/addon/specialchar) dialog read incorrectly by screen readers due to empty table cells at the end.
 
 ## CKEditor 4.13
 

--- a/plugins/specialchar/dialogs/specialchar.js
+++ b/plugins/specialchar/dialogs/specialchar.js
@@ -215,8 +215,6 @@ CKEDITOR.dialog.add( 'specialchar', function( editor ) {
 							'<span class="cke_voice_label" id="' + charLabelId + '">' +
 							charDesc +
 							'</span></a>' );
-					} else {
-						html.push( '<td class="cke_dark_background" role="presentation">&nbsp;' );
 					}
 
 					html.push( '</td>' );

--- a/plugins/specialchar/dialogs/specialchar.js
+++ b/plugins/specialchar/dialogs/specialchar.js
@@ -219,10 +219,10 @@ CKEDITOR.dialog.add( 'specialchar', function( editor ) {
 							'</span>' +
 							'<span class="cke_voice_label" id="' + charLabelId + '">' +
 							charDesc +
-							'</span></a>' );
+							'</span></a></td>'
+						);
 					}
 
-					html.push( '</td>' );
 				}
 				html.push( '</tr>' );
 			}

--- a/plugins/specialchar/dialogs/specialchar.js
+++ b/plugins/specialchar/dialogs/specialchar.js
@@ -216,7 +216,7 @@ CKEDITOR.dialog.add( 'specialchar', function( editor ) {
 							charDesc +
 							'</span></a>' );
 					} else {
-						html.push( '<td class="cke_dark_background">&nbsp;' );
+						html.push( '<td class="cke_dark_background" role="presentation">&nbsp;' );
 					}
 
 					html.push( '</td>' );

--- a/plugins/specialchar/dialogs/specialchar.js
+++ b/plugins/specialchar/dialogs/specialchar.js
@@ -7,69 +7,74 @@ CKEDITOR.dialog.add( 'specialchar', function( editor ) {
 	// Simulate "this" of a dialog for non-dialog events.
 	// @type {CKEDITOR.dialog}
 	var dialog,
-		lang = editor.lang.specialchar;
+		lang = editor.lang.specialchar,
+		focusedNode,
+		onChoice,
+		onClick,
+		onBlur,
+		onFocus,
+		onKeydown;
 
-	var onChoice = function( evt ) {
-			var target, value;
-			if ( evt.data )
-				target = evt.data.getTarget();
-			else
-				target = new CKEDITOR.dom.element( evt );
 
-			if ( target.getName() == 'a' && ( value = target.getChild( 0 ).getHtml() ) ) {
-				target.removeClass( 'cke_light_background' );
-				dialog.hide();
+	onChoice = function( evt ) {
+		var target, value;
+		if ( evt.data )
+			target = evt.data.getTarget();
+		else
+			target = new CKEDITOR.dom.element( evt );
 
-				// We must use "insertText" here to keep text styled.
-				var span = editor.document.createElement( 'span' );
-				span.setHtml( value );
-				editor.insertText( span.getText() );
-			}
-		};
+		if ( target.getName() == 'a' && ( value = target.getChild( 0 ).getHtml() ) ) {
+			target.removeClass( 'cke_light_background' );
+			dialog.hide();
 
-	var onClick = CKEDITOR.tools.addFunction( onChoice );
+			// We must use "insertText" here to keep text styled.
+			var span = editor.document.createElement( 'span' );
+			span.setHtml( value );
+			editor.insertText( span.getText() );
+		}
+	};
 
-	var focusedNode;
+	onClick = CKEDITOR.tools.addFunction( onChoice );
 
-	var onFocus = function( evt, target ) {
-			var value;
-			target = target || evt.data.getTarget();
+	onFocus = function( evt, target ) {
+		var value;
+		target = target || evt.data.getTarget();
 
-			if ( target.getName() == 'span' )
-				target = target.getParent();
+		if ( target.getName() == 'span' )
+			target = target.getParent();
 
-			if ( target.getName() == 'a' && ( value = target.getChild( 0 ).getHtml() ) ) {
-				// Trigger blur manually if there is focused node.
-				if ( focusedNode )
-					onBlur( null, focusedNode );
+		if ( target.getName() == 'a' && ( value = target.getChild( 0 ).getHtml() ) ) {
+			// Trigger blur manually if there is focused node.
+			if ( focusedNode )
+				onBlur( null, focusedNode );
 
-				var htmlPreview = dialog.getContentElement( 'info', 'htmlPreview' ).getElement();
+			var htmlPreview = dialog.getContentElement( 'info', 'htmlPreview' ).getElement();
 
-				dialog.getContentElement( 'info', 'charPreview' ).getElement().setHtml( value );
-				htmlPreview.setHtml( CKEDITOR.tools.htmlEncode( value ) );
-				target.getParent().addClass( 'cke_light_background' );
+			dialog.getContentElement( 'info', 'charPreview' ).getElement().setHtml( value );
+			htmlPreview.setHtml( CKEDITOR.tools.htmlEncode( value ) );
+			target.getParent().addClass( 'cke_light_background' );
 
-				// Memorize focused node.
-				focusedNode = target;
-			}
-		};
+			// Memorize focused node.
+			focusedNode = target;
+		}
+	};
 
-	var onBlur = function( evt, target ) {
-			target = target || evt.data.getTarget();
+	onBlur = function( evt, target ) {
+		target = target || evt.data.getTarget();
 
-			if ( target.getName() == 'span' )
-				target = target.getParent();
+		if ( target.getName() == 'span' )
+			target = target.getParent();
 
-			if ( target.getName() == 'a' ) {
-				dialog.getContentElement( 'info', 'charPreview' ).getElement().setHtml( '&nbsp;' );
-				dialog.getContentElement( 'info', 'htmlPreview' ).getElement().setHtml( '&nbsp;' );
-				target.getParent().removeClass( 'cke_light_background' );
+		if ( target.getName() == 'a' ) {
+			dialog.getContentElement( 'info', 'charPreview' ).getElement().setHtml( '&nbsp;' );
+			dialog.getContentElement( 'info', 'htmlPreview' ).getElement().setHtml( '&nbsp;' );
+			target.getParent().removeClass( 'cke_light_background' );
 
-				focusedNode = undefined;
-			}
-		};
+			focusedNode = undefined;
+		}
+	};
 
-	var onKeydown = CKEDITOR.tools.addFunction( function( ev ) {
+	onKeydown = CKEDITOR.tools.addFunction( function( ev ) {
 		ev = new CKEDITOR.dom.event( ev );
 
 		// Get an Anchor element.

--- a/tests/plugins/specialchar/dialog.js
+++ b/tests/plugins/specialchar/dialog.js
@@ -15,7 +15,7 @@
 			}
 		},
 
-		'test specialchardialog should have table cells with role="presentation"': function() {
+		'test specialchar dialog should have table cells with role="presentation" and don\'t have empty table cells': function() {
 			var bot = this.editorBot;
 
 			bot.dialog( 'specialchar', function( dialog ) {

--- a/tests/plugins/specialchar/dialog.js
+++ b/tests/plugins/specialchar/dialog.js
@@ -1,0 +1,33 @@
+/* bender-tags: specialchar */
+/* bender-ckeditor-plugins: toolbar,wysiwygarea,specialchar */
+
+( function() {
+	'use strict';
+
+	bender.editor = true;
+
+	bender.test( {
+		tearDown: function() {
+			var dialog;
+
+			while ( ( dialog = CKEDITOR.dialog.getCurrent() ) ) {
+				dialog.hide();
+			}
+		},
+
+		'test specialchardialog should have table cells with role="presentation"': function() {
+			var bot = this.editorBot;
+
+			bot.dialog( 'specialchar', function( dialog ) {
+				var tableWithCharacters = dialog.parts.contents.findOne( 'td.cke_dialog_ui_hbox_first table[role="listbox"]' ),
+					tableCells = tableWithCharacters.find( 'td' ).toArray(),
+					i;
+
+				for ( i = 0; i < tableCells.length; i++ ) {
+					assert.areSame( 'presentation', tableCells[ i ].getAttribute( 'role' ),
+						'Table cell with index: ' + i + ' should have role="presentation". Instead it has following html: ' + tableCells[ i ].getOuterHtml() );
+				}
+			} );
+		}
+	} );
+} )();

--- a/tests/plugins/specialchar/dialog.js
+++ b/tests/plugins/specialchar/dialog.js
@@ -26,6 +26,7 @@
 				for ( i = 0; i < tableCells.length; i++ ) {
 					assert.areSame( 'presentation', tableCells[ i ].getAttribute( 'role' ),
 						'Table cell with index: ' + i + ' should have role="presentation". Instead it has following html: ' + tableCells[ i ].getOuterHtml() );
+					assert.areNotSame( '&nbsp;', tableCells[ i ].getHtml(), 'Table cell with index: ' + i + ' should not be empty.' );
 				}
 			} );
 		}

--- a/tests/plugins/specialchar/manual/presentationrole.html
+++ b/tests/plugins/specialchar/manual/presentationrole.html
@@ -1,0 +1,13 @@
+<style>
+	table[role="listbox"] td[role="presentation"] {
+		border: 2px dashed red;
+	}
+</style>
+<h2>Classic editor</h2>
+<div id="classic">
+	<p>I'm CKEditor 4 instance.</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'classic' );
+</script>

--- a/tests/plugins/specialchar/manual/presentationrole.html
+++ b/tests/plugins/specialchar/manual/presentationrole.html
@@ -1,13 +1,11 @@
-<style>
-	table[role="listbox"] td[role="presentation"] {
-		border: 2px dashed red;
-	}
-</style>
 <h2>Classic editor</h2>
 <div id="classic">
 	<p>I'm CKEditor 4 instance.</p>
 </div>
 
 <script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
 	CKEDITOR.replace( 'classic' );
 </script>

--- a/tests/plugins/specialchar/manual/presentationrole.md
+++ b/tests/plugins/specialchar/manual/presentationrole.md
@@ -1,0 +1,12 @@
+@bender-ui: collapsed
+@bender-tags: 3544, 4.13.1, bug
+@bender-ckeditor-plugins: wysiwygarea, toolbar, specialchar
+
+1. Open specialchar dialog
+
+### Expected result:
+Empty table cells at the end of character list should have role="presentation". You can inspect element to check it, however,
+there are also a css rules which marks `<td>` elements with `role="presentation"` with red dashed border.
+
+### Unexpected result
+Empty table cells at the end of the list don't have presentation role.

--- a/tests/plugins/specialchar/manual/presentationrole.md
+++ b/tests/plugins/specialchar/manual/presentationrole.md
@@ -2,11 +2,19 @@
 @bender-tags: 3544, 4.13.1, bug
 @bender-ckeditor-plugins: wysiwygarea, toolbar, specialchar
 
-1. Open specialchar dialog
+1. Open specialchar dialog.
+2. Turn on Voice Over on MacOS (`CMD + F5`) or Narrator on Windows (`WIN + CTRL + Enter`).
+3. Move selection to the last character.
+4. For MacOS: press `CapsLock + Right Arrow`.
+5. For Windows: press `Right Arrow`.
+
+In case that you have problem with performing steps with assistive technology:
+1. Open console.
+2. Inspect if there exists empty table cells after last character in the dialog.
 
 ### Expected result:
-Empty table cells at the end of character list should have role="presentation". You can inspect element to check it, however,
-there are also a css rules which marks `<td>` elements with `role="presentation"` with red dashed border.
+Assisitve technology doesn't detect and read content of empty table cells at the end of special char dialog.
+There shouldn't be any empty cells at the end.
 
 ### Unexpected result
-Empty table cells at the end of the list don't have presentation role.
+Empty table cells are added at the end of characters list.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3544(https://github.com/ckeditor/ckeditor4/issues/3544) Fix: Empty table cells at the end of the dialog of [Special Characters](https://ckeditor.com/cke4/addon/specialchar) plugin was read by assistive technologies.
```
## What changes did you make?

* Remove adding empty table cells in special char dialog.
* Hoist variables to the top to prevent jshint errors.

Closes: #3544 