### PR TITLE
Fix for cutting in Safari when selecting all with widget at the beginning

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3426,6 +3426,11 @@
 			if ( focused ) {
 				editor.widgets.del( focused );
 			} else {
+				// We have to add fillers manually for Safari (#3537).
+				if ( CKEDITOR.env.webkit && !CKEDITOR.env.chrome ) {
+					CKEDITOR.plugins.widgetselection.addFillers( editor.editable() );
+				}
+
 				editor.extractSelectedHtml();
 			}
 

--- a/tests/plugins/widget/manual/clipboardhtmlselectallsafari.html
+++ b/tests/plugins/widget/manual/clipboardhtmlselectallsafari.html
@@ -1,0 +1,32 @@
+<div id="editor">
+	<div data-widget="customwidget">Widget</div>
+	<p>Adipisicing corporis rem repellendus vel mollitia vero? Consectetur dolores voluptatibus illo ipsam eveniet? Lorem ipsum dolor sit amet.</p>
+</div>
+
+
+<script>
+	// No console support on mobiles (without connecting to another device).
+	if ( bender.tools.env.mobile || !CKEDITOR.env.safari ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'span',
+		extraPlugins: 'customwidget',
+		allowedContent: true
+	} );
+
+	CKEDITOR.plugins.add( 'customwidget', {
+		requires: 'widget',
+		allowedContent: 'div',
+
+		init: function ( editor )	{
+			var counter = 0;
+
+			editor.widgets.add( 'customwidget', {
+				button: 'Add widget',
+				template: '<div>Widget</div>'
+			} );
+		}
+	} );
+</script>

--- a/tests/plugins/widget/manual/clipboardhtmlselectallsafari.md
+++ b/tests/plugins/widget/manual/clipboardhtmlselectallsafari.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.13.1, bug, 3537
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, undo, wysiwygarea, toolbar
+
+1. Select all.
+2. Cut.
+
+## Expected
+
+Content is removed from the editor.
+
+## Unexpected
+
+Content remains inside the editor.

--- a/tests/plugins/widget/widgetsintegration.js
+++ b/tests/plugins/widget/widgetsintegration.js
@@ -1175,6 +1175,31 @@
 			}
 		} ),
 
+		// (#3537)
+		'test content is removed after cutting (widget at the beginning)': createCopyCutTest( {
+			event: 'cut',
+			html: '<div id="w1" data-widget="test3">test3</div>' +
+			'<p>Ipsum</p>',
+
+			init: function( editor ) {
+				var range = editor.createRange(),
+					editable = editor.editable();
+
+				range.selectNodeContents( editable );
+				range.select();
+
+				// We must simulate widgetselection behaviour.
+				CKEDITOR.plugins.widgetselection.addFillers( editable );
+			},
+
+			assert: function( editor ) {
+				var data = editor.getData();
+
+				assert.isNotMatching( /<div.+?>/, data, 'widgets are removed' );
+				assert.isTrue( editor.getSelection().isCollapsed(), 'selection is collapsed' );
+			}
+		} ),
+
 		// (#3138)
 		'test undo stack after copying (multiple widgets)': createCopyCutTest( {
 			event: 'copy',


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3537](https://github.com/ckeditor/ckeditor4/issues/3537): [Safari] Fixed: can't cut when the whole content is selected and widget is at the beginning of it.
```

## What changes did you make?

I've manually added `widgetselection` fillers just for Safari.

Closes #3537.
