### PR TITLE
Add full support for replacing element node with text or comment node in htmlparser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Fixed Issues:
 * [#3544](https://github.com/ckeditor/ckeditor4/issues/3544): Fixed: [Special Characters](https://ckeditor.com/cke4/addon/specialchar) dialog read incorrectly by screen readers due to empty table cells at the end.
 * [#1653](https://github.com/ckeditor/ckeditor4/issues/1653): Fixed: Missing reposition of [Balloon Toolbar](https://ckeditor.com/cke4/addon/balloontoolbar) when editor is scrolled with enabled [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) feature.
 * [#3559](https://github.com/ckeditor/ckeditor4/issues/3559): Fixed: [Color Dialog](https://ckeditor.com/cke4/addon/colordialog) is incorrectly positioned when used with another dialog.
+* [#3593](https://github.com/ckeditor/ckeditor4/issues/3593): Fixed: Can't access text or comment node while replacing element node with them via [`CKEDITOR.htmlParser.filter`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_htmlParser_filter.html).
 
 ## CKEditor 4.13
 

--- a/core/htmlparser/filter.js
+++ b/core/htmlparser/filter.js
@@ -219,8 +219,8 @@
 				var type = node.type;
 
 				return type == CKEDITOR.NODE_ELEMENT ? this.onElement( context, node ) :
-					type == CKEDITOR.NODE_TEXT ? new CKEDITOR.htmlParser.text( this.onText( context, node.value ) ) :
-					type == CKEDITOR.NODE_COMMENT ? new CKEDITOR.htmlParser.comment( this.onComment( context, node.value ) ) : null;
+					type == CKEDITOR.NODE_TEXT ? new CKEDITOR.htmlParser.text( this.onText( context, node.value, node ) ) :
+					type == CKEDITOR.NODE_COMMENT ? new CKEDITOR.htmlParser.comment( this.onComment( context, node.value, node ) ) : null;
 			},
 
 			onAttribute: function( context, element, name, value ) {

--- a/tests/core/htmlparser/filter.js
+++ b/tests/core/htmlparser/filter.js
@@ -859,5 +859,53 @@ bender.test( {
 		assert.areSame( 5, group.rules[ 2 ].priority );
 		assert.areSame( options3, group.rules[ 1 ].options );
 		assert.areSame( options3, group.rules[ 2 ].options );
+	},
+
+	// #3593
+	'test should be possible to replace element node with text': function() {
+		var filter = new CKEDITOR.htmlParser.filter();
+
+		filter.addRules( {
+			elements: {
+				'span': function() {
+					return new CKEDITOR.htmlParser.text( 'test' );
+				},
+
+				'$': function( el ) {
+					el.filterChildren( filter );
+				}
+			},
+
+			text: function( value, element ) {
+				// It's necessary to access to element, to generate error. Before fix it was undefiend.
+				assert.areEqual( CKEDITOR.NODE_TEXT, element.type );
+			}
+		} );
+
+		assertFilter( '<p>foo test baz</p>', '<p>foo <span>bar</span> baz</p>', filter );
+	},
+
+	// #3593
+	'test should be possible to replace element node with comment': function() {
+		var filter = new CKEDITOR.htmlParser.filter();
+
+		filter.addRules( {
+			elements: {
+				'span': function() {
+					return new CKEDITOR.htmlParser.comment( 'test' );
+				},
+
+				'$': function( el ) {
+					el.filterChildren( filter );
+				}
+			},
+
+			comment: function( value, element ) {
+				// It's necessary to access to element, to generate error. Before fix it was undefiend.
+				assert.areEqual( CKEDITOR.NODE_COMMENT, element.type );
+			}
+		} );
+
+		assertFilter( '<p>foo <!--test--> baz</p>', '<p>foo <span>bar</span> baz</p>', filter );
 	}
 } );

--- a/tests/core/htmlparser/filter.js
+++ b/tests/core/htmlparser/filter.js
@@ -861,7 +861,7 @@ bender.test( {
 		assert.areSame( options3, group.rules[ 2 ].options );
 	},
 
-	// #3593
+	// (#3593)
 	'test should be possible to replace element node with text': function() {
 		var filter = new CKEDITOR.htmlParser.filter();
 
@@ -885,7 +885,7 @@ bender.test( {
 		assertFilter( '<p>foo test baz</p>', '<p>foo <span>bar</span> baz</p>', filter );
 	},
 
-	// #3593
+	// (#3593)
 	'test should be possible to replace element node with comment': function() {
 		var filter = new CKEDITOR.htmlParser.filter();
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3593](https://github.com/ckeditor/ckeditor4/issues/3593): Fixed: Can't access to text or comment node when is replaced with [`CKEDITOR.htmlParser.filter`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_htmlParser_filter.html)
```

## What changes did you make?

Add missing 3rd argument to filter method, when an element is replaced with a text or a comment.
Fix required for  #2374

Closes #3593 
