### PR TITLE
Fix failing tests /tests/core/editable/misc

### DIFF
--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -112,11 +112,7 @@ bender.test( {
 			} ) );
 
 			// From Firefox 70 it returns trailing '\n' (#3633).
-			if ( CKEDITOR.env.gecko && CKEDITOR.env.version >= 700000 ) {
-				assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
-			} else {
-				assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
-			}
+			assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
 		} );
 	},
 

--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -112,7 +112,7 @@ bender.test( {
 			} ) );
 
 			// From Firefox 70 it returns trailing '\n' (#3633).
-			assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
+			assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
 		} );
 	},
 

--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -92,7 +92,12 @@ bender.test( {
 				target: img.$
 			} ) );
 
-			assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
+			// From Firefox 70 it returns trailing '\n' (#3633).
+			if ( CKEDITOR.env.gecko && CKEDITOR.env.version >= 700000 ) {
+				assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
+			} else {
+				assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
+			}
 		} );
 	},
 
@@ -110,7 +115,12 @@ bender.test( {
 				target: img.$
 			} ) );
 
-			assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
+			// From Firefox 70 it returns trailing '\n' (#3633).
+			if ( CKEDITOR.env.gecko && CKEDITOR.env.version >= 700000 ) {
+				assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
+			} else {
+				assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
+			}
 		} );
 	},
 

--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -93,7 +93,7 @@ bender.test( {
 			} ) );
 
 			// From Firefox 70 it returns trailing '\n' (#3633).
-			assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
+			assert.areSame( 'foo', CKEDITOR.tools.trim( editor.getSelection().getSelectedText() ), 'Selection has not been changed' );
 		} );
 	},
 
@@ -112,7 +112,7 @@ bender.test( {
 			} ) );
 
 			// From Firefox 70 it returns trailing '\n' (#3633).
-			assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
+			assert.areSame( 'foo', CKEDITOR.tools.trim( editor.getSelection().getSelectedText() ), 'Selection has not been changed' );
 		} );
 	},
 

--- a/tests/core/editable/misc.js
+++ b/tests/core/editable/misc.js
@@ -93,11 +93,7 @@ bender.test( {
 			} ) );
 
 			// From Firefox 70 it returns trailing '\n' (#3633).
-			if ( CKEDITOR.env.gecko && CKEDITOR.env.version >= 700000 ) {
-				assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
-			} else {
-				assert.areSame( 'foo', editor.getSelection().getSelectedText(), 'Selection has not been changed' );
-			}
+			assert.areSame( 'foo', editor.getSelection().getSelectedText().trim(), 'Selection has not been changed' );
 		} );
 	},
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

None

## What changes did you make?

If FF 70 or later is detected, test will trim the result before comparing with expected to get rid of trailing `\n`.

Closes #3633.