### PR TITLE
Add CKEDITOR.dom.range#getNative()

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2927,32 +2927,28 @@ CKEDITOR.dom.range = function( root ) {
 		 * @returns {CKEDITOR.dom.rect[]}
 		 */
 		getClientRects: ( function() {
-			if ( this.document.getSelection !== undefined ) {
-				return function( isAbsolute ) {
-					// We need to create native range so we can call native getClientRects.
-					var range = this.root.getDocument().$.createRange(),
-						rectList;
+			var range = this.getNative();
 
-					range.setStart( this.startContainer.$, this.startOffset );
-					range.setEnd( this.endContainer.$, this.endOffset );
-
-					rectList = range.getClientRects();
-
-					rectList = fixWidgetsRects( rectList, this );
-
-					if ( !rectList.length ) {
-						rectList = fixEmptyRectList( rectList, range, this );
-					}
-
-					return CKEDITOR.tools.array.map( rectList, function( item ) {
-						return convertRect( item, isAbsolute, this );
-					}, this );
-				};
-			} else {
+			if ( !range ) {
 				return function( isAbsolute ) {
 					return [ convertRect( getRect( this.createBookmark() ), isAbsolute, this ) ];
 				};
 			}
+
+			return function( isAbsolute ) {
+				// We need to create native range so we can call native getClientRects.
+				var rectList = range.getClientRects();
+
+				rectList = fixWidgetsRects( rectList, this );
+
+				if ( !rectList.length ) {
+					rectList = fixEmptyRectList( rectList, range, this );
+				}
+
+				return CKEDITOR.tools.array.map( rectList, function( item ) {
+					return convertRect( item, isAbsolute, this );
+				}, this );
+			};
 
 			// Remove all widget rects except for outermost one.
 			function fixWidgetsRects( rectList, context ) {

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2927,9 +2927,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * @returns {CKEDITOR.dom.rect[]}
 		 */
 		getClientRects: ( function() {
-			var range = this.getNative();
-
-			if ( !range ) {
+			if ( !( 'createRange' in document ) ) {
 				return function( isAbsolute ) {
 					return [ convertRect( getRect( this.createBookmark() ), isAbsolute, this ) ];
 				};
@@ -2937,7 +2935,8 @@ CKEDITOR.dom.range = function( root ) {
 
 			return function( isAbsolute ) {
 				// We need to create native range so we can call native getClientRects.
-				var rectList = range.getClientRects();
+				var range = this.getNative(),
+					rectList = range.getClientRects();
 
 				rectList = fixWidgetsRects( rectList, this );
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2869,6 +2869,21 @@ CKEDITOR.dom.range = function( root ) {
 		},
 
 		/**
+		 * Returns [native range](https://developer.mozilla.org/en-US/docs/Web/API/Range) represented by this object.
+		 *
+		 * @since 4.14.0
+		 * @returns {Object}
+		 */
+		getNative: function() {
+			var range = this.root.getDocument().$.createRange();
+
+			range.setStart( this.startContainer.$, this.startOffset );
+			range.setEnd( this.endContainer.$, this.endOffset );
+
+			return range;
+		},
+
+		/**
 		 * Returns an array of {@link CKEDITOR.dom.rect} elements that are represented as rectangles which are covered by ranges.
 		 * Rectangles represent the area of the screen occupied by the elements contained within the range.
 		 *

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2870,12 +2870,19 @@ CKEDITOR.dom.range = function( root ) {
 
 		/**
 		 * Returns [native range](https://developer.mozilla.org/en-US/docs/Web/API/Range) represented by this object.
-		 *
+		 * If the browser does not support W3C Selection API, `null` is returned.
 		 * @since 4.14.0
-		 * @returns {Object}
+		 * @returns {Range/null}
 		 */
 		getNative: function() {
-			var range = this.root.getDocument().$.createRange();
+			var nativeDocument = this.root.getDocument().$,
+				range;
+
+			if ( !( 'createRange' in nativeDocument ) ) {
+				return null;
+			}
+
+			range = nativeDocument.createRange();
 
 			range.setStart( this.startContainer.$, this.startOffset );
 			range.setEnd( this.endContainer.$, this.endOffset );

--- a/core/selection.js
+++ b/core/selection.js
@@ -2208,8 +2208,6 @@
 
 					range = ranges[ i ];
 
-					var nativeRange = this.document.$.createRange();
-
 					if ( range.collapsed && CKEDITOR.env.webkit && rangeRequiresFix( range ) ) {
 						// Append a zero-width space so WebKit will not try to
 						// move the selection by itself (https://dev.ckeditor.com/ticket/1272).
@@ -2229,21 +2227,7 @@
 						}
 					}
 
-					nativeRange.setStart( range.startContainer.$, range.startOffset );
-
-					try {
-						nativeRange.setEnd( range.endContainer.$, range.endOffset );
-					} catch ( e ) {
-						// There is a bug in Firefox implementation (it would be too easy
-						// otherwise). The new start can't be after the end (W3C says it can).
-						// So, let's create a new range and collapse it to the desired point.
-						if ( e.toString().indexOf( 'NS_ERROR_ILLEGAL_VALUE' ) >= 0 ) {
-							range.collapse( 1 );
-							nativeRange.setEnd( range.endContainer.$, range.endOffset );
-						} else {
-							throw e;
-						}
-					}
+					var nativeRange = range.getNative();
 
 					// Select the range.
 					sel.addRange( nativeRange );

--- a/tests/core/dom/range/misc.js
+++ b/tests/core/dom/range/misc.js
@@ -453,6 +453,27 @@
 			nativeRange = range.getNative();
 
 			assert.areSame( null, nativeRange, 'Null is returned' );
+		},
+
+		// There was a bug in Firefox that restricted creating of ranges where end offset
+		// was before start offset. However this seems to be no longer the case.
+		// I added this test just to be sure (#1960).
+		'test creating native range with endOffset smaller than startOffset (Firefox bug)': function() {
+			if ( !CKEDITOR.env.gecko ) {
+				assert.ignore();
+			}
+
+			var range = new CKEDITOR.dom.range( doc ),
+				container = CKEDITOR.dom.element.createFromHtml( '<span>Test</span>' ),
+				textNode = container.getChild( 0 );
+
+			doc.getBody().append( container );
+			range.setStart( textNode, 3 );
+			range.setEnd( textNode, 1 );
+
+			range.getNative();
+
+			assert.pass( 'Nothing exploded' );
 		}
 	};
 

--- a/tests/core/dom/range/misc.js
+++ b/tests/core/dom/range/misc.js
@@ -412,6 +412,25 @@
 			range.setEndAfter( doc.getById( '_td1' ) );
 
 			assert.isTrue( range._getTableElement( 'tbody' ).equals( doc.getById( '_tbody' ) ), 'filtering elements' );
+		},
+
+		// (#1960)
+		'test getNative': function() {
+			var range = new CKEDITOR.dom.range( doc ),
+				container = CKEDITOR.dom.element.createFromHtml( '<span>Test</span>' ),
+				nativeRange;
+
+			doc.getBody().append( container );
+			range.selectNodeContents( container );
+
+			nativeRange = range.getNative();
+
+			assert.areSame( nativeRange.startContainer.ownerDocument, range.document.$, 'document is the same' );
+			assert.areSame( nativeRange.startContainer, range.startContainer.$, 'startContainer is the same' );
+			assert.areSame( nativeRange.endContainer, range.endContainer.$, 'endContainer is the same' );
+			assert.areSame( nativeRange.startOffset, range.startOffset, 'startOffset is the same' );
+			assert.areSame( nativeRange.endOffset, range.endOffset, 'endOffset is the same' );
+			assert.areSame( nativeRange.collapsed, range.collapsed, 'collapsed is the same' );
 		}
 	};
 

--- a/tests/core/dom/range/misc.js
+++ b/tests/core/dom/range/misc.js
@@ -415,7 +415,11 @@
 		},
 
 		// (#1960)
-		'test getNative': function() {
+		'test getNative (non-IE 8 browsers)': function() {
+			if ( !( 'createRange' in document ) ) {
+				assert.ignore();
+			}
+
 			var range = new CKEDITOR.dom.range( doc ),
 				container = CKEDITOR.dom.element.createFromHtml( '<span>Test</span>' ),
 				nativeRange;
@@ -425,12 +429,30 @@
 
 			nativeRange = range.getNative();
 
-			assert.areSame( nativeRange.startContainer.ownerDocument, range.document.$, 'document is the same' );
-			assert.areSame( nativeRange.startContainer, range.startContainer.$, 'startContainer is the same' );
-			assert.areSame( nativeRange.endContainer, range.endContainer.$, 'endContainer is the same' );
-			assert.areSame( nativeRange.startOffset, range.startOffset, 'startOffset is the same' );
-			assert.areSame( nativeRange.endOffset, range.endOffset, 'endOffset is the same' );
-			assert.areSame( nativeRange.collapsed, range.collapsed, 'collapsed is the same' );
+			assert.areSame( range.document.$, nativeRange.startContainer.ownerDocument, 'document is the same' );
+			assert.areSame( range.startContainer.$, nativeRange.startContainer, 'startContainer is the same' );
+			assert.areSame( range.endContainer.$, nativeRange.endContainer, 'endContainer is the same' );
+			assert.areSame( range.startOffset, nativeRange.startOffset, 'startOffset is the same' );
+			assert.areSame( range.endOffset, nativeRange.endOffset, 'endOffset is the same' );
+			assert.areSame( range.collapsed, nativeRange.collapsed, 'collapsed is the same' );
+		},
+
+		// (#1960)
+		'test getNative (IE 8 browser)': function() {
+			if ( 'createRange' in document ) {
+				assert.ignore();
+			}
+
+			var range = new CKEDITOR.dom.range( doc ),
+				container = CKEDITOR.dom.element.createFromHtml( '<span>Test</span>' ),
+				nativeRange;
+
+			doc.getBody().append( container );
+			range.selectNodeContents( container );
+
+			nativeRange = range.getNative();
+
+			assert.areSame( null, nativeRange, 'Null is returned' );
 		}
 	};
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#1960](https://github.com/ckeditor/ckeditor4/issues/1960): Added [`CKEDITOR.dom.range#getNative()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-getNative) method.
```

## What changes did you make?

I've added `CKEDITOR.dom.range#getNative()` method, which returns new native range based on CKE4 one. I haven't implemented the method for IE8 – it returns `null` there – as logic for creating ranges in IE8 is very convoluted comparing to the code for every other browsers.

Additionally I've refactored some code to use the new method:

* `CKEDITOR.dom.range#getClientRects()`;
* `CKEDITOR.dom.selection#selectRanges()` – in this case I made also another refactor, removing workaround for [very old Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=205635).

Closes #1960.
