### PR TITLE
Fix focus inside widget for textarea and input elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ New features:
 
 * [#2583](https://github.com/ckeditor/ckeditor-dev/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
 
+Fixed Issues:
+
+* [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fixed: Widget with form input elements loses focus during typing.
+
 ## CKEditor 4.13.1
 
 Fixed Issues:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ New features:
 
 Fixed Issues:
 
-* [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fixed: Widget with form input elements loses focus during typing.
+* [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) with form input elements loses focus during typing.
 
 ## CKEditor 4.13.1
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -941,30 +941,7 @@
 
 			if ( CKEDITOR.env.ie ) {
 				// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
-				editable.attachListener( editable, 'keydown', function( evt ) {
-					var sel = this.getSelection( 1 ),
-						ascendant = getNonEditableAscendant( sel ),
-						activeElement,
-						isValidActiveElement;
-
-					if ( !ascendant ) {
-						return;
-					}
-
-					activeElement = this.document.getActive(),
-					isValidActiveElement = activeElement && ( activeElement.getName() === 'input' || activeElement.getName() === 'textarea' );
-
-					// Allow on typing inside editable elements of widgets if those are currently focused (#3587)
-					if ( isValidActiveElement && ascendant.contains( activeElement ) ) {
-						return;
-					}
-
-					// Prevent changing selection when an ascendant is an entire editable (#1632).
-					if ( !ascendant.equals( editable ) ) {
-						sel.selectElement( ascendant );
-						evt.data.preventDefault();
-					}
-				}, editor );
+				editable.attachListener( editable, 'keydown', disableSelectionChangeForNonEditables, editor );
 			}
 
 			// Always fire the selection change on focus gain.
@@ -1051,6 +1028,35 @@
 				// The parentElement may be null for read only mode in IE10 and below (https://dev.ckeditor.com/ticket/9780).
 				if ( sel.type != 'None' && range.parentElement() && range.parentElement().ownerDocument == doc.$ )
 					range.select();
+			}
+
+			function disableSelectionChangeForNonEditables( evt ) {
+				var sel,
+					ascendant;
+
+				// Allow on typing inside editable elements of widgets if those are currently focused (#3587)
+				if ( isTypingElement( this.document.getActive() ) ) {
+					return;
+				}
+
+				sel = this.getSelection( 1 );
+				ascendant = getNonEditableAscendant( sel );
+
+				// Prevent changing selection when an ascendant is an entire editable (#1632).
+				if ( ascendant && !ascendant.equals( editable ) ) {
+					sel.selectElement( ascendant );
+					evt.data.preventDefault();
+				}
+			}
+
+			function isTypingElement( activeElement ) {
+				if ( !activeElement ) {
+					return false;
+				}
+
+				return activeElement.getName() === 'input' ||
+					activeElement.getName() === 'textarea' ||
+					activeElement.getAttribute( 'contenteditable' ) === 'true';
 			}
 
 			function getNonEditableAscendant( sel ) {

--- a/core/selection.js
+++ b/core/selection.js
@@ -943,10 +943,24 @@
 				// https://dev.ckeditor.com/ticket/14407 - Don't even let anything happen if the selection is in a non-editable element.
 				editable.attachListener( editable, 'keydown', function( evt ) {
 					var sel = this.getSelection( 1 ),
-						ascendant = getNonEditableAscendant( sel );
+						ascendant = getNonEditableAscendant( sel ),
+						activeElement,
+						isValidActiveElement;
+
+					if ( !ascendant ) {
+						return;
+					}
+
+					activeElement = this.document.getActive(),
+					isValidActiveElement = activeElement && ( activeElement.getName() === 'input' || activeElement.getName() === 'textarea' );
+
+					// Allow on typing inside editable elements of widgets if those are currently focused (#3587)
+					if ( isValidActiveElement && ascendant.contains( activeElement ) ) {
+						return;
+					}
 
 					// Prevent changing selection when an ascendant is an entire editable (#1632).
-					if ( ascendant && !ascendant.equals( editable ) ) {
+					if ( !ascendant.equals( editable ) ) {
 						sel.selectElement( ascendant );
 						evt.data.preventDefault();
 					}

--- a/core/selection.js
+++ b/core/selection.js
@@ -1055,8 +1055,7 @@
 				}
 
 				return activeElement.getName() === 'input' ||
-					activeElement.getName() === 'textarea' ||
-					activeElement.getAttribute( 'contenteditable' ) === 'true';
+					activeElement.getName() === 'textarea';
 			}
 
 			function getNonEditableAscendant( sel ) {

--- a/tests/plugins/widget/_helpers/tools.js
+++ b/tests/plugins/widget/_helpers/tools.js
@@ -355,29 +355,6 @@ var widgetTestsTools = ( function() {
 		} );
 	}
 
-	function buildWidgetDefinition( config ) {
-		var name = config.name,
-			elementName = config.elementName,
-			innerHtml = config.innerHtml;
-
-		return {
-			requiredContent: 'div(' + name + ')',
-			allowedContent: 'div(' + name + ')',
-			template: '<div class="' + name + '">' +
-				innerHtml +
-				'</div>',
-			button: 'Add ' + name + ' widget (' + elementName + ')',
-			upcast: function( element ) {
-				return element.name === 'div' && element.hasClass( name );
-			},
-			init: function() {
-				this.on( 'focus', function() {
-					this.element.findOne( elementName ).focus();
-				} );
-			}
-		};
-	}
-
 	return {
 		addTests: addTests,
 		data2Attribute: data2Attr,
@@ -389,7 +366,6 @@ var widgetTestsTools = ( function() {
 		assertDowncast: assertDowncast,
 		assertWidgetDialog: assertWidgetDialog,
 		assertWidget: assertWidget,
-		buildWidgetDefinition: buildWidgetDefinition,
 
 		widgetInitedWrapperAttributes:
 			'aria-label="[a-z]+ widget" ' +

--- a/tests/plugins/widget/_helpers/tools.js
+++ b/tests/plugins/widget/_helpers/tools.js
@@ -355,6 +355,29 @@ var widgetTestsTools = ( function() {
 		} );
 	}
 
+	function buildWidgetDefinition( config ) {
+		var name = config.name,
+			elementName = config.elementName,
+			innerHtml = config.innerHtml;
+
+		return {
+			requiredContent: 'div(' + name + ')',
+			allowedContent: 'div(' + name + ')',
+			template: '<div class="' + name + '">' +
+				innerHtml +
+				'</div>',
+			button: 'Add ' + name + ' widget (' + elementName + ')',
+			upcast: function( element ) {
+				return element.name === 'div' && element.hasClass( name );
+			},
+			init: function() {
+				this.on( 'focus', function() {
+					this.element.findOne( elementName ).focus();
+				} );
+			}
+		};
+	}
+
 	return {
 		addTests: addTests,
 		data2Attribute: data2Attr,
@@ -366,6 +389,7 @@ var widgetTestsTools = ( function() {
 		assertDowncast: assertDowncast,
 		assertWidgetDialog: assertWidgetDialog,
 		assertWidget: assertWidget,
+		buildWidgetDefinition: buildWidgetDefinition,
 
 		widgetInitedWrapperAttributes:
 			'aria-label="[a-z]+ widget" ' +

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -52,7 +52,7 @@
 
 	bender.test( {
 		'test textarea inside widget should allow on typing': function() {
-			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11 ) {
+			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 9 ) {
 				assert.ignore();
 			}
 
@@ -87,7 +87,7 @@
 		},
 
 		'test input inside widget should allow on typing': function() {
-			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11 ) {
+			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 9 ) {
 				assert.ignore();
 			}
 

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -1,8 +1,6 @@
 /* bender-tags: widgetcore */
 /* bender-ckeditor-plugins: widget,undo */
 /* bender-ckeditor-remove-plugins: tableselection */
-/* bender-include: ../../_helpers/tools.js */
-/* global widgetTestsTools */
 
 ( function() {
 	'use strict';
@@ -14,13 +12,13 @@
 				instanceReady: function( evt ) {
 					var editor = evt.editor;
 
-					editor.widgets.add( 'testwidget', widgetTestsTools.buildWidgetDefinition( {
+					editor.widgets.add( 'testwidget', buildWidgetDefinition( {
 						name: 'testwidget',
 						elementName: 'textarea',
 						innerHtml: '<textarea></textarea>'
 					} ) );
 
-					editor.widgets.add( 'testwidget2', widgetTestsTools.buildWidgetDefinition( {
+					editor.widgets.add( 'testwidget2', buildWidgetDefinition( {
 						name: 'testwidget2',
 						elementName: 'input',
 						innerHtml: '<input type="text">'
@@ -107,4 +105,27 @@
 			} );
 		}
 	} );
+
+	function buildWidgetDefinition( config ) {
+		var name = config.name,
+			elementName = config.elementName,
+			innerHtml = config.innerHtml;
+
+		return {
+			requiredContent: 'div(' + name + ')',
+			allowedContent: 'div(' + name + ')',
+			template: '<div class="' + name + '">' +
+				innerHtml +
+				'</div>',
+			button: 'Add ' + name + ' widget (' + elementName + ')',
+			upcast: function( element ) {
+				return element.name === 'div' && element.hasClass( name );
+			},
+			init: function() {
+				this.on( 'focus', function() {
+					this.element.findOne( elementName ).focus();
+				} );
+			}
+		};
+	}
 } )();

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -1,6 +1,8 @@
 /* bender-tags: widgetcore */
 /* bender-ckeditor-plugins: widget,undo */
 /* bender-ckeditor-remove-plugins: tableselection */
+/* bender-include: ../../_helpers/tools.js */
+/* global widgetTestsTools */
 
 ( function() {
 	'use strict';
@@ -12,39 +14,17 @@
 				instanceReady: function( evt ) {
 					var editor = evt.editor;
 
-					editor.widgets.add( 'testwidget', {
-						requiredContent: 'div(testwidget)',
-						allowedContent: 'div(testwidget)',
-						template: '<div class="testwidget">' +
-							'<textarea></textarea>' +
-							'</div>',
-						button: 'Add textarea widget',
-						upcast: function( element ) {
-							return element.name === 'div' && element.hasClass( 'testwidget' );
-						},
-						init: function() {
-							this.on( 'focus', function() {
-								this.element.findOne( 'textarea' ).focus();
-							} );
-						}
-					} );
+					editor.widgets.add( 'testwidget', widgetTestsTools.buildWidgetDefinition( {
+						name: 'testwidget',
+						elementName: 'textarea',
+						innerHtml: '<textarea></textarea>'
+					} ) );
 
-					editor.widgets.add( 'testwidget2', {
-						requiredContent: 'div(testwidget2)',
-						allowedContent: 'div(testwidget2)',
-						template: '<div class="testwidget2">' +
-							'<input type="text">' +
-							'</div>',
-						button: 'Add input widget',
-						upcast: function( element ) {
-							return element.name === 'div' && element.hasClass( 'testwidget2' );
-						},
-						init: function() {
-							this.on( 'focus', function() {
-								this.element.findOne( 'input' ).focus();
-							} );
-						}
-					} );
+					editor.widgets.add( 'testwidget2', widgetTestsTools.buildWidgetDefinition( {
+						name: 'testwidget2',
+						elementName: 'input',
+						innerHtml: '<input type="text">'
+					} ) );
 				}
 			}
 		}
@@ -53,13 +33,17 @@
 	// @param {bot} bot
 	// @param {String} elementName name of used html element. Value should be equal: 'input' or 'textarea'
 	// @param {Function} assertCallback funciton which returns a function to be executed on 'keydown' listener when assert for the tesr might be checked.
-	function prepareEditor( bot, elementName, assertCallback ) {
-		var editor = bot.editor;
-		var htmlElement = elementName === 'textarea' ? '<textarea></textarea>' : '<input type="text">';
+	function assertSelection( config ) {
+		var bot = config.bot,
+			elementName = config.elementName,
+			assertCallback = config.assertCallback,
+			widgetName = config.widgetName,
+			editor = bot.editor,
+			htmlElement = elementName === 'textarea' ? '<textarea></textarea>' : '<input type="text">';
 
-		bot.setData( '<div class="testwidget">' + htmlElement + '</div>', function() {
+		bot.setData( '<div class="' + widgetName + '">' + htmlElement + '</div>', function() {
 			var editable = editor.editable(),
-				widget = editor.widgets.getByElement( editable.findOne( 'div.testwidget' ) ),
+				widget = editor.widgets.getByElement( editable.findOne( 'div.' + widgetName ) ),
 				range = editor.createRange(),
 				el = widget.element.findOne( elementName );
 
@@ -85,31 +69,41 @@
 		},
 
 		'test textarea inside widget should allow on typing': function() {
-			prepareEditor( this.editorBot, 'textarea', function( editor, el, widget ) {
-				return function() {
-					var selection = editor.getSelection();
-					// Edge expands selection to inner div. IE keeps selction inside textArea.
-					// Important is to not have focused widget's wrapper.
-					if ( CKEDITOR.env.edge ) {
-						assert.isTrue( selection.getStartElement().equals( widget.element ) );
-					} else {
-						assert.isTrue( selection.getStartElement().equals( el ) );
-					}
-				};
+			assertSelection( {
+				bot: this.editorBot,
+				elementName: 'textarea',
+				widgetName: 'testwidget',
+				assertCallback: function( editor, el, widget ) {
+					return function() {
+						var selection = editor.getSelection();
+						// Edge expands selection to inner div. IE keeps selction inside textArea.
+						// Important is to not have focused widget's wrapper.
+						if ( CKEDITOR.env.edge ) {
+							assert.isTrue( selection.getStartElement().equals( widget.element ) );
+						} else {
+							assert.isTrue( selection.getStartElement().equals( el ) );
+						}
+					};
+				}
 			} );
 		},
 
 		'test input inside widget should allow on typing': function() {
-			prepareEditor( this.editorBot, 'input', function( editor, el ) {
-				return function() {
-					var selection = editor.getSelection();
-					// Edge keeps selection on input element, IE11 moves it to wrapper, however there is still possibility to type in input field.
-					if ( CKEDITOR.env.edge ) {
-						assert.isTrue( selection.getStartElement().equals( el ) );
-					} else {
-						assert.isTrue( CKEDITOR.plugins.widget.isDomWidget( selection.getStartElement() ) );
-					}
-				};
+			assertSelection( {
+				bot: this.editorBot,
+				elementName: 'input',
+				widgetName: 'testwidget2',
+				assertCallback: function( editor, el ) {
+					return function() {
+						var selection = editor.getSelection();
+						// Edge keeps selection on input element, IE11 moves it to wrapper, however there is still possibility to type in input field.
+						if ( CKEDITOR.env.edge ) {
+							assert.isTrue( selection.getStartElement().equals( el ) );
+						} else {
+							assert.isTrue( CKEDITOR.plugins.widget.isDomWidget( selection.getStartElement() ) );
+						}
+					};
+				}
 			} );
 		}
 	} );

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -50,73 +50,66 @@
 		}
 	};
 
+	// @param {bot} bot
+	// @param {String} elementName name of used html element. Value should be equal: 'input' or 'textarea'
+	// @param {Function} assertCallback funciton which returns a function to be executed on 'keydown' listener when assert for the tesr might be checked.
+	function prepareEditor( bot, elementName, assertCallback ) {
+		var editor = bot.editor;
+		var htmlElement = elementName === 'textarea' ? '<textarea></textarea>' : '<input type="text">';
+
+		bot.setData( '<div class="testwidget">' + htmlElement + '</div>', function() {
+			var editable = editor.editable(),
+				widget = editor.widgets.getByElement( editable.findOne( 'div.testwidget' ) ),
+				range = editor.createRange(),
+				el = widget.element.findOne( elementName );
+
+			el.focus();
+
+			range.selectNodeContents( el );
+			range.select();
+
+			editable.once( 'keydown', assertCallback( editor, el, widget ), null, null, 100000 );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( {
+				keyCode: 66 // B
+			} ) );
+		} );
+
+	}
+
 	bender.test( {
-		'test textarea inside widget should allow on typing': function() {
+		setUp: function() {
 			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 9 ) {
 				assert.ignore();
 			}
+		},
 
-			var editor = this.editor;
-
-			this.editorBot.setData( '<div class="testwidget"><textarea></textarea></div>', function() {
-				var editable = editor.editable(),
-					widget = editor.widgets.getByElement( editable.findOne( 'div.testwidget' ) ),
-					range = editor.createRange(),
-					textArea = widget.element.findOne( 'textarea' );
-
-				textArea.focus();
-
-				range.selectNodeContents( textArea );
-				range.select();
-
-				editable.once( 'keydown', function() {
+		'test textarea inside widget should allow on typing': function() {
+			prepareEditor( this.editorBot, 'textarea', function( editor, el, widget ) {
+				return function() {
 					var selection = editor.getSelection();
 					// Edge expands selection to inner div. IE keeps selction inside textArea.
 					// Important is to not have focused widget's wrapper.
 					if ( CKEDITOR.env.edge ) {
 						assert.isTrue( selection.getStartElement().equals( widget.element ) );
 					} else {
-						assert.isTrue( selection.getStartElement().equals( textArea ) );
+						assert.isTrue( selection.getStartElement().equals( el ) );
 					}
-				}, null, null, 100000 );
-
-				editable.fire( 'keydown', new CKEDITOR.dom.event( {
-					keyCode: 66 // B
-				} ) );
+				};
 			} );
 		},
 
 		'test input inside widget should allow on typing': function() {
-			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 9 ) {
-				assert.ignore();
-			}
-
-			var editor = this.editor;
-
-			this.editorBot.setData( '<div class="testwidget2"><input type="text"></div>', function() {
-				var editable = editor.editable(),
-					widget = editor.widgets.getByElement( editable.findOne( 'div.testwidget2' ) ),
-					range = editor.createRange(),
-					inputElement = widget.element.findOne( 'input' );
-
-				inputElement.focus();
-
-				range.selectNodeContents( inputElement );
-				range.select();
-
-				editable.once( 'keydown', function() {
+			prepareEditor( this.editorBot, 'input', function( editor, el ) {
+				return function() {
 					var selection = editor.getSelection();
 					// Edge keeps selection on input element, IE11 moves it to wrapper, however there is still possibility to type in input field.
 					if ( CKEDITOR.env.edge ) {
-						assert.isTrue( selection.getStartElement().equals( inputElement ) );
+						assert.isTrue( selection.getStartElement().equals( el ) );
 					} else {
 						assert.isTrue( CKEDITOR.plugins.widget.isDomWidget( selection.getStartElement() ) );
 					}
-				}, null, null, 100000 );
-
-				editable.fire( 'keydown', new CKEDITOR.dom.event( {
-					keyCode: 66 // B
-				} ) );
+				};
 			} );
 		}
 	} );

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -77,9 +77,10 @@
 		}
 	} );
 
-	// @param {bot} bot
-	// @param {String} elementName name of used html element. Value should be equal: 'input' or 'textarea'
-	// @param {Function} assertCallback funciton which returns a function to be executed on 'keydown' listener when assert for the tesr might be checked.
+	// @param {bot} config.bot
+	// @param {String} config.elementName name of used html element. Value should be equal: 'input' or 'textarea'
+	// @param {String} config.htmlElement string representation of an html element which is used to embed widget inside editor
+	// @param {Function} config.assertCallback funciton which returns a function to be executed on 'keydown' listener when assert for the tesr might be checked.
 	function assertSelection( config ) {
 		var bot = config.bot,
 			elementName = config.elementName,
@@ -108,6 +109,9 @@
 
 	}
 
+	// @param {String} cofig.name name of the widget. This name will be used also as a className for a widget
+	// @param {String} config.elementName name of html elements, which is editable and is located inside the widget. Expected valeus are 'input' or 'textarea'
+	// @param {String} config.innerHtml string representation of html element used to be emebedded inside widget
 	function buildWidgetDefinition( config ) {
 		var name = config.name,
 			elementName = config.elementName,

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -28,37 +28,6 @@
 		}
 	};
 
-	// @param {bot} bot
-	// @param {String} elementName name of used html element. Value should be equal: 'input' or 'textarea'
-	// @param {Function} assertCallback funciton which returns a function to be executed on 'keydown' listener when assert for the tesr might be checked.
-	function assertSelection( config ) {
-		var bot = config.bot,
-			elementName = config.elementName,
-			assertCallback = config.assertCallback,
-			widgetName = config.widgetName,
-			editor = bot.editor,
-			htmlElement = elementName === 'textarea' ? '<textarea></textarea>' : '<input type="text">';
-
-		bot.setData( '<div class="' + widgetName + '">' + htmlElement + '</div>', function() {
-			var editable = editor.editable(),
-				widget = editor.widgets.getByElement( editable.findOne( 'div.' + widgetName ) ),
-				range = editor.createRange(),
-				el = widget.element.findOne( elementName );
-
-			el.focus();
-
-			range.selectNodeContents( el );
-			range.select();
-
-			editable.once( 'keydown', assertCallback( editor, el, widget ), null, null, 100000 );
-
-			editable.fire( 'keydown', new CKEDITOR.dom.event( {
-				keyCode: 66 // B
-			} ) );
-		} );
-
-	}
-
 	bender.test( {
 		setUp: function() {
 			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 9 ) {
@@ -105,6 +74,37 @@
 			} );
 		}
 	} );
+
+	// @param {bot} bot
+	// @param {String} elementName name of used html element. Value should be equal: 'input' or 'textarea'
+	// @param {Function} assertCallback funciton which returns a function to be executed on 'keydown' listener when assert for the tesr might be checked.
+	function assertSelection( config ) {
+		var bot = config.bot,
+			elementName = config.elementName,
+			assertCallback = config.assertCallback,
+			widgetName = config.widgetName,
+			editor = bot.editor,
+			htmlElement = elementName === 'textarea' ? '<textarea></textarea>' : '<input type="text">';
+
+		bot.setData( '<div class="' + widgetName + '">' + htmlElement + '</div>', function() {
+			var editable = editor.editable(),
+				widget = editor.widgets.getByElement( editable.findOne( 'div.' + widgetName ) ),
+				range = editor.createRange(),
+				el = widget.element.findOne( elementName );
+
+			el.focus();
+
+			range.selectNodeContents( el );
+			range.select();
+
+			editable.once( 'keydown', assertCallback( editor, el, widget ), null, null, 100000 );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( {
+				keyCode: 66 // B
+			} ) );
+		} );
+
+	}
 
 	function buildWidgetDefinition( config ) {
 		var name = config.name,

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -1,0 +1,123 @@
+/* bender-tags: widgetcore */
+/* bender-ckeditor-plugins: widget,undo */
+/* bender-ckeditor-remove-plugins: tableselection */
+
+( function() {
+	'use strict';
+
+	bender.editor = {
+		config: {
+			allowedContent: true,
+			on: {
+				instanceReady: function( evt ) {
+					var editor = evt.editor;
+
+					editor.widgets.add( 'testwidget', {
+						requiredContent: 'div(testwidget)',
+						allowedContent: 'div(testwidget)',
+						template: '<div class="testwidget">' +
+							'<textarea></textarea>' +
+							'</div>',
+						button: 'Add textarea widget',
+						upcast: function( element ) {
+							return element.name === 'div' && element.hasClass( 'testwidget' );
+						},
+						init: function() {
+							this.on( 'focus', function() {
+								this.element.findOne( 'textarea' ).focus();
+							} );
+						}
+					} );
+
+					editor.widgets.add( 'testwidget2', {
+						requiredContent: 'div(testwidget2)',
+						allowedContent: 'div(testwidget2)',
+						template: '<div class="testwidget2">' +
+							'<input type="text">' +
+							'</div>',
+						button: 'Add input widget',
+						upcast: function( element ) {
+							return element.name === 'div' && element.hasClass( 'testwidget2' );
+						},
+						init: function() {
+							this.on( 'focus', function() {
+								this.element.findOne( 'input' ).focus();
+							} );
+						}
+					} );
+				}
+			}
+		}
+	};
+
+	bender.test( {
+		'test textarea inside widget should allow on typing': function() {
+			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11 ) {
+				assert.ignore();
+			}
+
+			var editor = this.editor;
+
+			this.editorBot.setData( '<div class="testwidget"><textarea></textarea></div>', function() {
+				var editable = editor.editable(),
+					widget = editor.widgets.getByElement( editable.findOne( 'div.testwidget' ) ),
+					range = editor.createRange(),
+					textArea = widget.element.findOne( 'textarea' );
+
+				textArea.focus();
+
+				range.selectNodeContents( textArea );
+				range.select();
+
+				editable.once( 'keydown', function() {
+					var selection = editor.getSelection();
+					// Edge expands selection to inner div. IE keeps selction inside textArea.
+					// Important is to not have focused widget's wrapper.
+					if ( CKEDITOR.env.edge ) {
+						assert.isTrue( selection.getStartElement().equals( widget.element ) );
+					} else {
+						assert.isTrue( selection.getStartElement().equals( textArea ) );
+					}
+				}, null, null, 100000 );
+
+				editable.fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: 66 // B
+				} ) );
+			} );
+		},
+
+		'test input inside widget should allow on typing': function() {
+			if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11 ) {
+				assert.ignore();
+			}
+
+			var editor = this.editor;
+
+			this.editorBot.setData( '<div class="testwidget2"><input type="text"></div>', function() {
+				var editable = editor.editable(),
+					widget = editor.widgets.getByElement( editable.findOne( 'div.testwidget2' ) ),
+					range = editor.createRange(),
+					inputElement = widget.element.findOne( 'input' );
+
+				inputElement.focus();
+
+				range.selectNodeContents( inputElement );
+				range.select();
+
+				editable.once( 'keydown', function() {
+					var selection = editor.getSelection();
+					// Edge keeps selection on input element, IE11 moves it to wrapper, however there is still possibility to type in input field.
+					if ( CKEDITOR.env.edge ) {
+						assert.isTrue( selection.getStartElement().equals( inputElement ) );
+					} else {
+						assert.isTrue( CKEDITOR.plugins.widget.isDomWidget( selection.getStartElement() ) );
+					}
+				}, null, null, 100000 );
+
+				editable.fire( 'keydown', new CKEDITOR.dom.event( {
+					keyCode: 66 // B
+				} ) );
+			} );
+		}
+	} );
+} )();

--- a/tests/plugins/widget/integration/selection/inputselection.js
+++ b/tests/plugins/widget/integration/selection/inputselection.js
@@ -39,6 +39,7 @@
 			assertSelection( {
 				bot: this.editorBot,
 				elementName: 'textarea',
+				htmlElement: '<textarea></textarea>',
 				widgetName: 'testwidget',
 				assertCallback: function( editor, el, widget ) {
 					return function() {
@@ -59,6 +60,7 @@
 			assertSelection( {
 				bot: this.editorBot,
 				elementName: 'input',
+				htmlElement: '<input type="text">',
 				widgetName: 'testwidget2',
 				assertCallback: function( editor, el ) {
 					return function() {
@@ -81,10 +83,10 @@
 	function assertSelection( config ) {
 		var bot = config.bot,
 			elementName = config.elementName,
+			htmlElement = config.htmlElement,
 			assertCallback = config.assertCallback,
 			widgetName = config.widgetName,
-			editor = bot.editor,
-			htmlElement = elementName === 'textarea' ? '<textarea></textarea>' : '<input type="text">';
+			editor = bot.editor;
 
 		bot.setData( '<div class="' + widgetName + '">' + htmlElement + '</div>', function() {
 			var editable = editor.editable(),

--- a/tests/plugins/widget/integration/selection/manual/ieinputwidget.html
+++ b/tests/plugins/widget/integration/selection/manual/ieinputwidget.html
@@ -3,7 +3,7 @@
 	</div>
 
 	<script>
-		if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11) {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 			bender.ignore();
 		};
 

--- a/tests/plugins/widget/integration/selection/manual/ieinputwidget.html
+++ b/tests/plugins/widget/integration/selection/manual/ieinputwidget.html
@@ -36,7 +36,7 @@
 			}
 		} );
 
-		window.editor = CKEDITOR.replace( 'editor', {
+		CKEDITOR.replace( 'editor', {
 			extraPlugins: 'testplugin',
 			allowedContent: true
 		} );

--- a/tests/plugins/widget/integration/selection/manual/ieinputwidget.html
+++ b/tests/plugins/widget/integration/selection/manual/ieinputwidget.html
@@ -1,0 +1,43 @@
+<div id="editor">
+		<p>Add widget below.</p>
+	</div>
+
+	<script>
+		if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11) {
+			bender.ignore();
+		};
+
+		CKEDITOR.plugins.add( 'testplugin', {
+			requires: 'widget',
+			init: function( editor ) {
+				editor.widgets.add( 'testwidget', {
+					requiredContent: 'div(testwidget)',
+					allowedContent: 'div(testwidget)',
+					template: '<div class="testwidget">' +
+						'<input type="text">' +
+						'</div>',
+					button: 'Add widget',
+					upcast: function( element ) {
+						return element.name === 'div' && element.hasClass( 'testwidget' )
+					},
+					init: function() {
+						this.on( 'focus', function() {
+							var input = this.element.findOne( 'input' ),
+								range = this.editor.createRange();
+
+							input.focus( 1 );
+
+							range.selectNodeContents( input );
+							range.collapse();
+							range.select();
+						} );
+					}
+				} );
+			}
+		} );
+
+		window.editor = CKEDITOR.replace( 'editor', {
+			extraPlugins: 'testplugin',
+			allowedContent: true
+		} );
+	</script>

--- a/tests/plugins/widget/integration/selection/manual/ieinputwidget.md
+++ b/tests/plugins/widget/integration/selection/manual/ieinputwidget.md
@@ -5,11 +5,11 @@
 1. Add widget (empty button in the toolbar).
 2. Try to type inside the widget in the **input** field.
 3. Deselect widget and select again.
-4. Try to type in the textarea field inside widget.
+4. Try to type in the input field inside the widget.
 
 ## Expected:
 * It's possible to type inside the widget
 * _Note: selection inside widget might behave wrongly it's caused by naive widget implementation and it's not a bug._
 
 ## Unexpected:
-* The entire widget's wrapper preserves focus so typing inside the textarea is not possible.
+* The entire widget's wrapper preserves focus so typing inside the input is not possible.

--- a/tests/plugins/widget/integration/selection/manual/ieinputwidget.md
+++ b/tests/plugins/widget/integration/selection/manual/ieinputwidget.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 4.13.1, 3587, selection, widget
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, elementspath, undo
+
+1. Add widget (empty button in the toolbar).
+2. Try to type inside the widget in the **input** field.
+3. Deselect widget and select again.
+4. Try to type in the textarea field inside widget.
+
+## Expected:
+* It's possible to type inside the widget
+* _Note: selection inside widget might behave wrongly it's caused by naive widget implementation and it's not a bug._
+
+## Unexpected:
+* The entire widget's wrapper preserves focus so typing inside the textarea is not possible.

--- a/tests/plugins/widget/integration/selection/manual/ieinputwidget.md
+++ b/tests/plugins/widget/integration/selection/manual/ieinputwidget.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.13.1, 3587, selection, widget
+@bender-tags: bug, 4.14.0, 3587, selection, widget
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, elementspath, undo
 

--- a/tests/plugins/widget/integration/selection/manual/ietextareawidget.html
+++ b/tests/plugins/widget/integration/selection/manual/ietextareawidget.html
@@ -1,0 +1,43 @@
+<div id="editor">
+	<p>Add widget below.</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11) {
+		bender.ignore();
+	};
+
+	CKEDITOR.plugins.add( 'testplugin', {
+		requires: 'widget',
+		init: function( editor ) {
+			editor.widgets.add( 'testwidget', {
+				requiredContent: 'div(testwidget)',
+				allowedContent: 'div(testwidget)',
+				template: '<div class="testwidget">' +
+					'<textarea></textarea>' +
+					'</div>',
+				button: 'Add widget',
+				upcast: function( element ) {
+					return element.name === 'div' && element.hasClass( 'testwidget' )
+				},
+				init: function() {
+					this.on( 'focus', function() {
+						var txtArea = this.element.findOne( 'textarea' ),
+							range = this.editor.createRange();
+
+						txtArea.focus( 1 );
+
+						range.selectNodeContents( txtArea );
+						range.collapse();
+						range.select();
+					} );
+				}
+			} );
+		}
+	} );
+
+	window.editor = CKEDITOR.replace( 'editor', {
+		extraPlugins: 'testplugin',
+		allowedContent: true
+	} );
+</script>

--- a/tests/plugins/widget/integration/selection/manual/ietextareawidget.html
+++ b/tests/plugins/widget/integration/selection/manual/ietextareawidget.html
@@ -36,7 +36,7 @@
 		}
 	} );
 
-	window.editor = CKEDITOR.replace( 'editor', {
+	CKEDITOR.replace( 'editor', {
 		extraPlugins: 'testplugin',
 		allowedContent: true
 	} );

--- a/tests/plugins/widget/integration/selection/manual/ietextareawidget.html
+++ b/tests/plugins/widget/integration/selection/manual/ietextareawidget.html
@@ -3,7 +3,7 @@
 </div>
 
 <script>
-	if ( !CKEDITOR.env.ie || CKEDITOR.env.version < 11) {
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
 		bender.ignore();
 	};
 

--- a/tests/plugins/widget/integration/selection/manual/ietextareawidget.md
+++ b/tests/plugins/widget/integration/selection/manual/ietextareawidget.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 4.13.1, 3587, selection, widget
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, elementspath, undo
+
+1. Add widget (empty button in the toolbar).
+2. Try to type inside the widget in the textarea field.
+3. Deselect widget and select again.
+4. Try to type in the textarea field inside widget.
+
+## Expected:
+* It's possible to type inside the widget
+* _Note: selection inside widget might behave wrongly it's caused by naive widget implementation and it's not a bug._
+
+## Unexpected:
+* The entire widget's wrapper preserves focus so typing inside the textarea is not possible.

--- a/tests/plugins/widget/integration/selection/manual/ietextareawidget.md
+++ b/tests/plugins/widget/integration/selection/manual/ietextareawidget.md
@@ -3,7 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, elementspath, undo
 
 1. Add widget (empty button in the toolbar).
-2. Try to type inside the widget in the textarea field.
+2. Try to type inside the widget in the **textarea** field.
 3. Deselect widget and select again.
 4. Try to type in the textarea field inside widget.
 

--- a/tests/plugins/widget/integration/selection/manual/ietextareawidget.md
+++ b/tests/plugins/widget/integration/selection/manual/ietextareawidget.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.13.1, 3587, selection, widget
+@bender-tags: bug, 4.14.0, 3587, selection, widget
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, elementspath, undo
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bugfix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
* [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fix: textarea and input elements inside widget are not possible to focus with a mousedown.
```

## What changes did you make?

Prevent to run logic responsible for the entire widget selection on IE and Edge, when the target element is a textarea or an input inside a widget.

Closes #3587.