### PR TITLE
Bugfix - Tableresize not working in maximized mode with divarea

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Fixed Issues:
 * [#1883](https://github.com/ckeditor/ckeditor4/issues/1883): Fixed: [`editor.resize`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-resize) method doesn't work with CSS units.
 * [#3926](https://github.com/ckeditor/ckeditor4/issues/3926): Fixed: Dragging and dropping [Widget](https://ckeditor.com/cke4/addon/widget) sometimes produces an error.
 * [#4008](https://github.com/ckeditor/ckeditor4/issues/4008): Fixed: [Remove Format](https://ckeditor.com/cke4/addon/removeformat) doesn't work with collapsed selection.
+* [#909](https://github.com/ckeditor/ckeditor4/issues/909): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) plugin does not work when editor is placed in absolutely positioned container. Thanks to [Roland Petto](https://github.com/arpi68)!
+* [#1959](https://github.com/ckeditor/ckeditor4/issues/1959): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) plugin does not work in [maximized](https://ckeditor.com/cke4/addon/maximize) editor when [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) feature enabled. Thanks to [Roland Petto](https://github.com/arpi68)!
 
 ## CKEditor 4.14
 

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -286,7 +286,7 @@
 
 		resizer = CKEDITOR.dom.element.createFromHtml( '<div data-cke-temp=1 contenteditable=false unselectable=on ' +
 			'style="position:absolute;cursor:col-resize;filter:alpha(opacity=0);opacity:0;' +
-				'padding:0;background-color:#004;background-image:none;border:0px none;z-index:10"></div>', document );
+				'padding:0;background-color:#004;background-image:none;border:0px none;z-index:10000"></div>', document );
 
 		// Clean DOM when editor is destroyed.
 		editor.on( 'destroy', function() {

--- a/tests/plugins/tableresize/manual/maximizeddivarea.html
+++ b/tests/plugins/tableresize/manual/maximizeddivarea.html
@@ -1,4 +1,7 @@
-<div id="editor">
+<h2>Classic editor</h2>
+
+<div id="classic">
+	<p>Classic editor</p>
 	<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
 		<thead>
 			<tr>
@@ -22,6 +25,66 @@
 	</table>
 </div>
 
+<h2>Divarea editor</h2>
+
+<div id="divarea">
+	<p>Divarea editor</p>
+	<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
+		<thead>
+		<tr>
+			<th scope="row" style="width:150px">Header</th>
+			<th scope="col" style="width:300px" colspan="2">Header</th>
+			<th scope="col" style="width:150px">Header</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<th scope="row" style="width:150px">Header</th>
+			<td style="width:150px">not header</td>
+			<td style="width:150px">not header</td>
+			<td style="width:150px">not header</td>
+		</tr>
+		<tr>
+			<th scope="row" style="width:300px" colspan="2">Header</th>
+			<td style="width:300px" colspan="2">not header</td>
+		</tr>
+		</tbody>
+	</table>
+</div>
+
+<h2>Inline editor</h2>
+
+<div id="inline" contenteditable="true">
+	<p>Inline editor</p>
+	<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
+		<thead>
+		<tr>
+			<th scope="row" style="width:150px">Header</th>
+			<th scope="col" style="width:300px" colspan="2">Header</th>
+			<th scope="col" style="width:150px">Header</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<th scope="row" style="width:150px">Header</th>
+			<td style="width:150px">not header</td>
+			<td style="width:150px">not header</td>
+			<td style="width:150px">not header</td>
+		</tr>
+		<tr>
+			<th scope="row" style="width:300px" colspan="2">Header</th>
+			<td style="width:300px" colspan="2">not header</td>
+		</tr>
+		</tbody>
+	</table>
+</div>
+
 <script>
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'classic', {
+		removePlugins: 'divarea'
+	} );
+
+	CKEDITOR.replace( 'divarea' );
+
+	CKEDITOR.inline( 'inline' );
 </script>

--- a/tests/plugins/tableresize/manual/maximizeddivarea.html
+++ b/tests/plugins/tableresize/manual/maximizeddivarea.html
@@ -1,0 +1,27 @@
+<div id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
+		<thead>
+			<tr>
+				<th scope="row" style="width:150px">Header</th>
+				<th scope="col" style="width:300px" colspan="2">Header</th>
+				<th scope="col" style="width:150px">Header</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<th scope="row" style="width:150px">Header</th>
+				<td style="width:150px">not header</td>
+				<td style="width:150px">not header</td>
+				<td style="width:150px">not header</td>
+			</tr>
+			<tr>
+				<th scope="row" style="width:300px" colspan="2">Header</th>
+				<td style="width:300px" colspan="2">not header</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableresize/manual/maximizeddivarea.html
+++ b/tests/plugins/tableresize/manual/maximizeddivarea.html
@@ -52,39 +52,10 @@
 	</table>
 </div>
 
-<h2>Inline editor</h2>
-
-<div id="inline" contenteditable="true">
-	<p>Inline editor</p>
-	<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
-		<thead>
-		<tr>
-			<th scope="row" style="width:150px">Header</th>
-			<th scope="col" style="width:300px" colspan="2">Header</th>
-			<th scope="col" style="width:150px">Header</th>
-		</tr>
-		</thead>
-		<tbody>
-		<tr>
-			<th scope="row" style="width:150px">Header</th>
-			<td style="width:150px">not header</td>
-			<td style="width:150px">not header</td>
-			<td style="width:150px">not header</td>
-		</tr>
-		<tr>
-			<th scope="row" style="width:300px" colspan="2">Header</th>
-			<td style="width:300px" colspan="2">not header</td>
-		</tr>
-		</tbody>
-	</table>
-</div>
-
 <script>
 	CKEDITOR.replace( 'classic', {
 		removePlugins: 'divarea'
 	} );
 
 	CKEDITOR.replace( 'divarea' );
-
-	CKEDITOR.inline( 'inline' );
 </script>

--- a/tests/plugins/tableresize/manual/maximizeddivarea.md
+++ b/tests/plugins/tableresize/manual/maximizeddivarea.md
@@ -8,8 +8,8 @@
 
 ### Expected
 
-Table is able to be resized.
+It is possible to resize the table or any of its columns (using CKEditor 4 resizer).
 
 ### Unexpected
 
-Not possible to resize table (no resize cursor appears).
+Not possible to resize the table (resize cursor is not visible).

--- a/tests/plugins/tableresize/manual/maximizeddivarea.md
+++ b/tests/plugins/tableresize/manual/maximizeddivarea.md
@@ -1,0 +1,15 @@
+@bender-ui: collapsed
+@bender-tags: bug, 909, 1959, 4.14.1
+@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, divarea, tableresize, maximize
+
+1. Maximize editor by pressing maximize button.
+
+1. Try to resize table inside editor.
+
+### Expected
+
+Table is able to be resized.
+
+### Unexpected
+
+Not possible to resize table (no resize cursor appears).

--- a/tests/plugins/tableresize/manual/maximizeddivarea.md
+++ b/tests/plugins/tableresize/manual/maximizeddivarea.md
@@ -1,6 +1,8 @@
 @bender-ui: collapsed
 @bender-tags: bug, 909, 1959, 4.14.1
-@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, divarea, tableresize, maximize
+@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, divarea, floatingspace, tableresize, maximize
+
+*Repeat below steps in all editors.*
 
 1. Maximize editor by pressing maximize button.
 

--- a/tests/plugins/tableresize/manual/maximizedinlinedivarea.html
+++ b/tests/plugins/tableresize/manual/maximizedinlinedivarea.html
@@ -1,0 +1,41 @@
+<style>
+	.container {
+		position: absolute;
+		width: 800px;
+		height: 300px;
+		z-index: 10000;
+	}
+</style>
+
+<h2>Inline editor</h2>
+
+<div class="container">
+	<div id="inline" contenteditable="true">
+		<p>Inline editor</p>
+		<table border="1" cellpadding="1" cellspacing="1" style="width:600px">
+			<thead>
+			<tr>
+				<th scope="row" style="width:150px">Header</th>
+				<th scope="col" style="width:300px" colspan="2">Header</th>
+				<th scope="col" style="width:150px">Header</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr>
+				<th scope="row" style="width:150px">Header</th>
+				<td style="width:150px">not header</td>
+				<td style="width:150px">not header</td>
+				<td style="width:150px">not header</td>
+			</tr>
+			<tr>
+				<th scope="row" style="width:300px" colspan="2">Header</th>
+				<td style="width:300px" colspan="2">not header</td>
+			</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<script>
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/tableresize/manual/maximizedinlinedivarea.md
+++ b/tests/plugins/tableresize/manual/maximizedinlinedivarea.md
@@ -1,10 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: bug, 909, 1959, 4.14.1
-@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, divarea, tableresize, maximize
-
-*Repeat below steps in all editors.*
-
-1. Maximize editor by pressing maximize button.
+@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, divarea, floatingspace, tableresize, maximize
 
 1. Try to resize table inside editor.
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix - Tableresize not working in maximized mode when using divarea

## What is the proposed changelog entry for this pull request?

Tableresize not working in maximized mode when using divarea

## What changes did you make?

z-index of resizer in maximized mode too low.
Set z-index of resizer to 10000

## Which issues your PR resolves?

Closes #1959.
Closes #909.
