### PR TITLE
Fix for error while typing in source mode

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2818,9 +2818,11 @@
 		editor.on( 'selectionCheck', fireCheckSelection );
 
 		// The selectionCheck event is fired on keyup, so we must force refreshing
-		// widgets selection on key event (#3352).
-		editor.on( 'key', function() {
-			setTimeout( fireCheckSelection, 10 );
+		// widgets selection on key event. Also fire it only in WYSIWYG mode (#3352, #3704).
+		editor.on( 'contentDom', function() {
+			editor.editable().attachListener( editor, 'key', function() {
+				setTimeout( fireCheckSelection, 10 );
+			} );
 		} );
 
 		widgetsRepo.on( 'checkSelection', widgetsRepo.checkSelection, widgetsRepo );

--- a/tests/plugins/widget/manual/selectallsourcemode.html
+++ b/tests/plugins/widget/manual/selectallsourcemode.html
@@ -1,0 +1,55 @@
+<p>Amount of copied/cut widgets: <span id="counter-clipboard">0</span></p>
+<p>Amount of selected widgets: <span id="counter-selection">0</span></p>
+<p><button id="reset">Reset counters</button></p>
+
+<div id="editor">
+	<p>Adipisicing corporis rem repellendus vel mollitia vero?</p>
+	<div data-widget="customwidget">Widget</div>
+	<p>Consectetur dolores voluptatibus illo ipsam eveniet?</p>
+	<div data-widget="customwidget">Widget</div>
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>
+CKEDITOR.replace( 'editor', {
+	extraPlugins: 'customwidget',
+	allowedContent: true,
+	on: {
+		pluginsLoaded: function( evt ) {
+			var editor = evt.editor;
+
+			editor.on( 'contentDom', function() {
+				var editable = editor.editable();
+
+				editable.attachListener( editable, 'cut', updateCounter( 'clipboard' ) );
+				editable.attachListener( editable, 'copy', updateCounter( 'clipboard' ) );
+			} );
+
+			editor.widgets.on( 'checkSelection', updateCounter( 'selection' ) );
+
+			CKEDITOR.document.getById( 'reset' ).on( 'click', function() {
+				CKEDITOR.document.getById( 'counter-selection' ).setText( 0 );
+				CKEDITOR.document.getById( 'counter-clipboard' ).setText( 0 );
+			} );
+
+			function updateCounter( id ) {
+				return function() {
+					CKEDITOR.document.getById( 'counter-' + id ).setText( editor.widgets.selected.length );
+				};
+			}
+		}
+	}
+} );
+
+CKEDITOR.plugins.add( 'customwidget', {
+	requires: 'widget',
+	allowedContent: 'div(copied)',
+
+	init: function ( editor )	{
+		editor.widgets.add( 'customwidget', {
+			button: 'Add widget',
+			template: '<div>Widget</div>'
+		} );
+	}
+} );
+</script>

--- a/tests/plugins/widget/manual/selectallsourcemode.html
+++ b/tests/plugins/widget/manual/selectallsourcemode.html
@@ -11,6 +11,10 @@
 </div>
 
 <script>
+if ( bender.tools.env.mobile ) {
+	bender.ignore();
+}
+
 CKEDITOR.replace( 'editor', {
 	extraPlugins: 'customwidget',
 	allowedContent: true,

--- a/tests/plugins/widget/manual/selectallsourcemode.md
+++ b/tests/plugins/widget/manual/selectallsourcemode.md
@@ -1,0 +1,36 @@
+@bender-tags: 4.13.1, bug, widget, 3704
+@bender-ui: collapsed
+@bender-ckeditor-plugins: image2, wysiwygarea, toolbar, sourcearea, undo, selectall
+
+1. Open console.
+2. Switch to source mode.
+3. Type anything.
+
+	## Expected
+
+	Everything works just fine.
+
+	## Unexpected
+
+	There are errors in the console: `Uncaught TypeError: Cannot read property 'getSelectedElement' of null`
+4. Switch back to WYSIWYG.
+5. Select all.
+6. Check counter of selected widgets.
+
+	## Expected
+
+	The number equals the number of widgets inside the editor.
+
+	## Unexpected
+
+	The number is different than the number of widgets inside the editor.
+7. Copy/cut.
+8. Check counter of copied/cut widgets.
+
+	## Expected
+
+	The number equals the number of widgets inside the editor upon copy/cut.
+
+	## Unexpected
+
+	The number is different than the number of widgets inside the editor.

--- a/tests/plugins/widget/widgetselection.js
+++ b/tests/plugins/widget/widgetselection.js
@@ -1,5 +1,5 @@
 /* bender-tags: widgetcore */
-/* bender-ckeditor-plugins: widget,undo */
+/* bender-ckeditor-plugins: widget,undo,sourcearea */
 /* bender-ckeditor-remove-plugins: tableselection */
 /* bender-include: _helpers/tools.js */
 /* global widgetTestsTools */
@@ -538,6 +538,72 @@
 				editor.fire( 'key', { domEvent: domEvent } );
 				wait();
 			} );
+		},
+
+		// (#3704)
+		'test integration of refreshing selected widgets on key event with source mode': function() {
+			var editor = this.editor;
+
+			editor.setMode( 'source', function() {
+				resume( sourceCallback );
+			} );
+			wait();
+
+			function sourceCallback() {
+				var domEvent = new CKEDITOR.dom.event( { keyCode: 65 } ),
+					stub = stubFire( editor );
+
+				setTimeout( function() {
+					resume( function() {
+						editor.widgets.fire = stub.originalFire;
+
+						assert.areSame( 0, stub.callCount(), 'Widget selection is not checked in source mode' );
+
+						editor.setMode( 'wysiwyg', function() {
+							resume( wysiwygCallback );
+						} );
+						wait();
+					} );
+				}, 50 );
+
+				editor.fire( 'key', { domEvent: domEvent } );
+				wait();
+			}
+
+			function wysiwygCallback() {
+				var domEvent = new CKEDITOR.dom.event( { keyCode: 65 } ),
+					stub = stubFire( editor );
+
+				setTimeout( function() {
+					resume( function() {
+						editor.widgets.fire = stub.originalFire;
+
+						assert.areSame( 1, stub.callCount(), 'Widget selection is checked on key in WYSIWYG mode' );
+					} );
+				}, 50 );
+
+				editor.fire( 'key', { domEvent: domEvent } );
+				wait();
+			}
+
+			function stubFire( editor ) {
+				var originalFire = editor.widgets.fire,
+					callCount = 0,
+					stub = function( event ) {
+						if ( event === 'checkSelection' ) {
+							++callCount;
+						}
+					};
+
+				editor.widgets.fire = stub;
+
+				return {
+					originalFire: originalFire,
+					callCount: function() {
+						return callCount;
+					}
+				};
+			}
 		}
 	} );
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#3704](https://github.com/ckeditor/ckeditor4/issues/3704): Fixed: Error is thrown while typing inside source area.
```

## What changes did you make?

I've bound checking selection to `key` only if `contentDom` event appeared earlier.

## Which issues your PR resolves?

Closes #3704.
