### PR TITLE
image2 maxSize enhancement

### DIFF
--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -1362,8 +1362,13 @@
 				maxSize = CKEDITOR.tools.copy( maxSize );
 				natural = CKEDITOR.plugins.image2.getNatural( image );
 
+				if ( maxSize.width === 'scaled' ) {
+					maxSize.width = natural.width * (isNaN( maxSize.height ) ? 1.0 : maxSize.height / natural.height);
+				}
 				maxSize.width = Math.max( maxSize.width === 'natural' ? natural.width : maxSize.width, min.width );
-				maxSize.height = Math.max( maxSize.height === 'natural' ? natural.height : maxSize.height, min.width );
+
+				if ( maxSize.height === 'scaled' ) maxSize.height = natural.height * maxSize.width / natural.width;
+				maxSize.height = Math.max( maxSize.height === 'natural' ? natural.height : maxSize.height, min.height );
 
 				return maxSize;
 			}
@@ -1755,7 +1760,7 @@ CKEDITOR.config.image2_captionedClass = 'image';
 /**
  * Determines the maximum size that an image can be resized to with the resize handle.
  *
- * It stores two properties: `width` and `height`. They can be set with one of the two types:
+ * It stores two properties: `width` and `height`. They can be set with one of three types:
  *
  * * A number representing a value that limits the maximum size in pixel units:
  *
@@ -1773,6 +1778,15 @@ CKEDITOR.config.image2_captionedClass = 'image';
  *		height: 'natural',
  *		width: 'natural'
  *	}
+ * ```
+ *
+ * * Or a number representing a value and the string 'scaled' that limits the maximum size in pixel units:
+ *
+ * ```js
+ *	config.image2_maxSize = {
+ *		height: 'scaled',
+ *		width: 250
+ *	};
  * ```
  *
  * Note: An image can still be resized to bigger dimensions when using the image dialog.

--- a/tests/plugins/image2/resizehandler.js
+++ b/tests/plugins/image2/resizehandler.js
@@ -22,6 +22,22 @@
 					height: 'natural'
 				}
 			}
+		},
+		scaledHeight: {
+			config: {
+				image2_maxSize: {
+					width: 350,
+					height: 'scaled'
+				}
+			}
+		},
+		scaledWidth: {
+			config: {
+				image2_maxSize: {
+					width: 'scaled',
+					height: 150
+				}
+			}
 		}
 	};
 
@@ -62,6 +78,26 @@
 					height: 131
 				}
 			},
+			scaledHeight: {
+				data: {
+					screenX: 350,
+					screenY: 121
+				},
+				expected: {
+					width: 323,
+					height: 121
+				}
+			},
+			scaledWidth: {
+				data: {
+					screenX: 400,
+					screenY: 150
+				},
+				expected: {
+					width: 400,
+					height: 150
+				}
+			},
 			naturalSize: {
 				data: {
 					screenX: 163,
@@ -80,6 +116,26 @@
 				data: {
 					screenX: 351,
 					screenY: 132
+				},
+				expected: {
+					width: null,
+					height: null
+				}
+			},
+			scaledHeight: {
+				data: {
+					screenX: 352,
+					screenY: 133
+				},
+				expected: {
+					width: null,
+					height: null
+				}
+			},
+			scaledWidth: {
+				data: {
+					screenX: 403,
+					screenY: 153
 				},
 				expected: {
 					width: null,
@@ -130,7 +186,8 @@
 						height: image.getAttribute( 'height' )
 					};
 
-					assert.isTrue( CKEDITOR.tools.objectCompare( actual, expected ) );
+					assert.isTrue( actual.height == expected.height, '['+ editor.name +'] Height: '+ actual.height +' expected '+ expected.height );
+					assert.isTrue( actual.width == expected.width, '['+ editor.name +'] Width: '+ actual.width +' expected '+ expected.width );
 				} );
 			} );
 		};


### PR DESCRIPTION
This PR adds '**scaled**' as an option for image2's maxSize width or height setting.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

```
* Added 'scaled' as an option for image2's maxSize width or height setting.
```

## What changes did you make?

Changed `getMaxSize()` in image2's `resizer.on( 'mousedown',` function to check for and process new '**scaled**' keyword.

Added test to image2's resizehandler.js test suite.

## Which issues your PR resolves?

None