### PR TITLE
Fix for: Safari incorrectly removes blocks after selecting all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,13 @@ New features:
 Fixed Issues:
 
 * [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) with form input elements loses focus during typing.
+* [#3705](https://github.com/ckeditor/ckeditor4/issues/3705): [Safari] Fixed: Safari incorrectly removes blocks with [`editor.extractSelectedHtml()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-extractSelectedHtml) method after selecting all content.
 
 API Changes:
 
 * [#3387](https://github.com/ckeditor/ckeditor-dev/issues/3387): Added the [CKEDITOR.ui.richCombo#select](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-select) method.
 * [#3306](https://github.com/ckeditor/ckeditor-dev/issues/3306): Added new commands `textColor` and `bgColor` which applies the selected color choosen by the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) plugin.
- 
+
 ## CKEditor 4.13.1
 
 Fixed Issues:

--- a/core/selection/optimization.js
+++ b/core/selection/optimization.js
@@ -74,7 +74,7 @@
 
 		var oldRange = range.clone();
 
-		range.shrink( CKEDITOR.SHRINK_TEXT, false, { skipBogus: true } );
+		range.shrink( CKEDITOR.SHRINK_TEXT, false, { skipBogus: !CKEDITOR.env.webkit } );
 
 		preventListener = false;
 

--- a/tests/core/selection/manual/tripleclick.md
+++ b/tests/core/selection/manual/tripleclick.md
@@ -1,15 +1,28 @@
-@bender-tags: selection, 4.13.0, bug, 3118, 3175
+@bender-tags: selection, 4.13.0, 4.13.2, bug, 3118, 3175, 3705
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, list, format, sourcearea, undo
 
 1. Select list item by triple clicking on it.
-1. Pick `heading 1` from format combo.
+1. Pick `Heading 1` from format combo.
 
-## Expected
+	### Expected:
 
-Heading is applied only to list item.
+	Heading is applied only to list item.
 
-## Unexpected
+	### Unexpected:
 
-Paragraph after the list is turned into `h1`
+	Paragraph after the list is turned into `h1`.
 
+1. Open console.
+
+1. Start selection at the end of document and end it in the first line without selecting list item (<a href="https://user-images.githubusercontent.com/1061942/63528470-4b468f80-c503-11e9-9e95-af86e7622ad8.gif" target="_blank">gif</a>).
+
+1. Change format to `Heading 3`.
+
+	### Expected:
+
+	List item is still `h1`, the second paragraph is `h3`. There is no error in the console.
+
+	### Unexpected:
+
+	Style of list item changed or there is an error in the console.

--- a/tests/core/selection/manual/tripleclick.md
+++ b/tests/core/selection/manual/tripleclick.md
@@ -2,7 +2,10 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, list, format, sourcearea, undo
 
+1. Open console.
+
 1. Select list item by triple clicking on it.
+
 1. Pick `Heading 1` from format combo.
 
 	### Expected:
@@ -13,9 +16,7 @@
 
 	Paragraph after the list is turned into `h1`.
 
-1. Open console.
-
-1. Start selection at the end of document and end it in the first line without selecting list item (<a href="https://user-images.githubusercontent.com/1061942/63528470-4b468f80-c503-11e9-9e95-af86e7622ad8.gif" target="_blank">gif</a>).
+1. Start selection at the end of document and end it in the first line without selecting list item (<a href="https://user-images.githubusercontent.com/1061942/63528470-4b468f80-c503-11e9-9e95-af86e7622ad8.gif" target="_blank">see gif</a>).
 
 1. Change format to `Heading 3`.
 

--- a/tests/core/selection/manual/tripleclick.md
+++ b/tests/core/selection/manual/tripleclick.md
@@ -1,4 +1,4 @@
-@bender-tags: selection, 4.13.0, 4.13.2, bug, 3118, 3175, 3705
+@bender-tags: selection, 4.13.0, 4.14.0, bug, 3118, 3175, 3705
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, list, format, sourcearea, undo
 

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -124,6 +124,19 @@
 
 				assert.isFalse( editor._.shiftPressed );
 			} );
+		},
+
+		// (#3705)
+		'test deleting blocks': function( editor, bot ) {
+			bot.setData( '<p>&nbsp;</p><p>Whatever</p>', function() {
+				var range = editor.createRange();
+
+				range.selectNodeContents( editor.editable() );
+				range.select();
+				editor.extractSelectedHtml();
+
+				assert.areEqual( '<p><br></p>', editor.editable().getHtml() );
+			} );
 		}
 	};
 

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -130,26 +130,19 @@
 		'test deleting blocks': function( editor, bot ) {
 			bot.setData( '<p>&nbsp;</p><p>Whatever</p>', function() {
 				var range = editor.createRange(),
+					// In Safari the same selection has different range offsets and endContainer. Because of that it is automatically fixed
+					// and empty paragraph is converted to <br/> element.
+					expectedExtraction = CKEDITOR.env.safari ? '<br data-cke-eol="1" /><p>Whatever</p>' : '<p>@</p><p>Whatever</p>',
+					// And in IE8 only node content is removed.
+					expectedContent = CKEDITOR.env.ie && CKEDITOR.env.version == 8 ? '<p>@@</p><p></p>' : '<p>@</p>',
 					extractedHtml;
 
 				range.selectNodeContents( editor.editable() );
 				range.select();
 				extractedHtml = editor.extractSelectedHtml( true );
 
-				// In Safari the same selection has different range offsets and endContainer. Because of that it is automatically fixed
-				// and empty paragraph is converted to <br/> element.
-				if ( CKEDITOR.env.safari ) {
-					assert.isInnerHtmlMatching( '<br data-cke-eol="1" /><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
-				} else {
-					assert.isInnerHtmlMatching( '<p>@</p><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
-				}
-
-				// And in IE8 only node content is removed.
-				if ( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) {
-					assert.isInnerHtmlMatching( '<p>@@</p><p></p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
-				} else {
-					assert.isInnerHtmlMatching( '<p>@</p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
-				}
+				assert.isInnerHtmlMatching( expectedExtraction, extractedHtml, 'Extracted HTML is incorrect.' );
+				assert.isInnerHtmlMatching( expectedContent, editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
 			} );
 		}
 	};

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -136,8 +136,20 @@
 				range.select();
 				extractedHtml = editor.extractSelectedHtml( true );
 
-				assert.isInnerHtmlMatching( '<p>@</p><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
-				assert.isInnerHtmlMatching( '<p>@</p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
+				// In Safari the same selection has different range offsets and endContainer. Because of that it is automatically fixed
+				// and empty paragraph is converted to <br/> element.
+				if ( CKEDITOR.env.safari ) {
+					assert.isInnerHtmlMatching( '<br data-cke-eol="1" /><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
+				} else {
+					assert.isInnerHtmlMatching( '<p>@</p><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
+				}
+
+				// And in IE8 only node content is removed.
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) {
+					assert.isInnerHtmlMatching( '<p>@@</p><p></p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
+				} else {
+					assert.isInnerHtmlMatching( '<p>@</p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
+				}
 			} );
 		}
 	};

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -129,13 +129,15 @@
 		// (#3705)
 		'test deleting blocks': function( editor, bot ) {
 			bot.setData( '<p>&nbsp;</p><p>Whatever</p>', function() {
-				var range = editor.createRange();
+				var range = editor.createRange(),
+					extractedHtml;
 
 				range.selectNodeContents( editor.editable() );
 				range.select();
-				editor.extractSelectedHtml();
+				extractedHtml = editor.extractSelectedHtml( true );
 
-				assert.areEqual( '<p><br></p>', editor.editable().getHtml() );
+				assert.areEqual( '<p><br></p><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
+				assert.areEqual( '<p><br></p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
 			} );
 		}
 	};

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -136,8 +136,8 @@
 				range.select();
 				extractedHtml = editor.extractSelectedHtml( true );
 
-				assert.areEqual( '<p><br></p><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
-				assert.areEqual( '<p><br></p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
+				assert.isInnerHtmlMatching( '<p>@</p><p>Whatever</p>', extractedHtml, 'Extracted HTML is incorrect.' );
+				assert.isInnerHtmlMatching( '<p>@</p>', editor.editable().getHtml(), 'Editor content after extraction is incorrect.' );
 			} );
 		}
 	};


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests - is an extension of existing test to avoid code duplication.

## What is the proposed changelog entry for this pull request?

```
*[#3705](https://github.com/ckeditor/ckeditor4/issues/3705): Fix for: Safari incorrectly removes blocks after selecting all.
```

## What changes did you make?

The actual reason for this issue was selection optimization introduced in #3213 (with breaking commit [06b94a6](https://github.com/ckeditor/ckeditor4/commit/06b94a64713e34ae8cb41196f2ce00618468a76a)). When it is fired on Safari, it trims selection so that in the [example](https://jsfiddle.net/Comandeer/jnf5at6z/ ) actually just the word `Whatever` is selected and then extracted.

As that change was introduced to prevent [this bug](https://user-images.githubusercontent.com/1061942/63528470-4b468f80-c503-11e9-9e95-af86e7622ad8.gif) occurring in FF, IE and Edge, the easiest way to deal with it is using browser sniffing and skip skipping bogus (yeah!), which in a one-liner fix.

The problem is that IE 8, 9 and 10 fail unit test for this case with following results:
* IE 8:
<img width="250" alt="Screenshot 2019-12-10 at 11 35 40" src="https://user-images.githubusercontent.com/10883184/70534912-50842480-1b5c-11ea-9035-f55a9353a905.png">

* IE 9 and 10:
<img width="250" alt="Screenshot 2019-12-10 at 12 26 43" src ="https://user-images.githubusercontent.com/10883184/70534942-5ed24080-1b5c-11ea-9c82-77f80a077e4a.png">

but it doesn't look very important and I propose to extract this case as a separate issue.

## Which issues your PR resolves?

Closes #3705.