### PR TITLE
Fix emoji dropdown tests

### DIFF
--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -107,8 +107,7 @@
 
 			waitForEmoji( bot.editor, function() {
 				// Overlay is required to not trigger mouse event what happens on CI (#3744).
-				var overlay = createOverlayElement();
-				CKEDITOR.document.getBody().append( overlay );
+				var overlay = addOverlayCover();
 
 				bot.panel( 'EmojiPanel', function( panel ) {
 					try {
@@ -378,8 +377,9 @@
 		}
 	}
 
-	function createOverlayElement() {
-		return CKEDITOR.dom.element.createFromHtml( '<div style="width:1000px;height:1000px;z-index:20000;position:fixed;top:0;left:0;"></div>' );
+	function addOverlayCover() {
+		var overlay = CKEDITOR.dom.element.createFromHtml( '<div style="width:1000px;height:1000px;z-index:20000;position:fixed;top:0;left:0;"></div>' );
+		CKEDITOR.document.getBody().append( overlay );
+		return overlay;
 	}
-
 } )();

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -106,6 +106,10 @@
 			var bot = this.editorBot;
 
 			waitForEmoji( bot.editor, function() {
+				// Overlay is required to not trigger mouse event what happens on CI (#3744).
+				var overlay = createOverlayElement();
+				CKEDITOR.document.getBody().append( overlay );
+
 				bot.panel( 'EmojiPanel', function( panel ) {
 					try {
 						var doc = panel._.iframe.getFrameDocument(),
@@ -126,6 +130,7 @@
 						assert.areSame( 'star', statusBarDescription.getText(), 'Status bar description should contain "star" name after mouseover.' );
 					} finally {
 						panel.hide();
+						overlay.remove();
 					}
 				} );
 			} );
@@ -372,4 +377,9 @@
 			wait();
 		}
 	}
+
+	function createOverlayElement() {
+		return CKEDITOR.dom.element.createFromHtml( '<div style="width:1000px;height:1000px;z-index:20000;position:fixed;top:0;left:0;"></div>' );
+	}
+
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Test case fix for CI

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

**No entry**

## What changes did you make?

Added transparent div with higher z-index than emoji panel, which prevents mouse interaction with the panel.
It seems that cursor on CI is located in the middle of the screen and since Chrome v79 it has started to interact with the emoji panel.

## Which issues your PR resolves?

Closes #3744.