### PR TITLE
Fixed dataIndentationChars empty string bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.14.2
 
+Fixed Issues:
+
+* [#3795](https://github.com/ckeditor/ckeditor4/issues/3795): Fixed: Setting [`dataIndentationChars`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-dataIndentationChars) config option to an empty string is ignored and replaced by a tab (`\t`) character. Thanks to [Thomas Grinderslev](https://github.com/Znegl)!
+
 ## CKEditor 4.14.1
 
 Fixed Issues:

--- a/plugins/htmlwriter/plugin.js
+++ b/plugins/htmlwriter/plugin.js
@@ -8,7 +8,7 @@ CKEDITOR.plugins.add( 'htmlwriter', {
 		var writer = new CKEDITOR.htmlWriter();
 
 		writer.forceSimpleAmpersand = editor.config.forceSimpleAmpersand;
-		writer.indentationChars = editor.config.dataIndentationChars || '\t';
+		writer.indentationChars = typeof editor.config.dataIndentationChars === 'string' ? editor.config.dataIndentationChars : '\t';
 
 		// Overwrite default basicWriter initialized in hmtlDataProcessor constructor.
 		editor.dataProcessor.writer = writer;

--- a/tests/plugins/htmlwriter/htmlwriter.js
+++ b/tests/plugins/htmlwriter/htmlwriter.js
@@ -66,19 +66,27 @@ bender.test( {
 } );
 
 bender.test({
-  'test dataIndentationChars': function() {
-	var data = '<ol><li>One</li><li>Two</li><li>Three</li></ol>';
+	'test dataIndentationChars': function() {
+	  var data = '<ol><li>One</li><li>Two</li><li>Three</li></ol>';
 
-	bender.editorBot.create( {
-	  name: 'dataIndentationChars',
-	  formattedOutput: true,
-	  config: {
-		dataIndentationChars: ''
-	  }
-	}, function( bot ) {
-	  bot.setData( data, function() {
-		assert.areSame( data, bot.getData( false, false ) );
+	  bender.editorBot.create( {
+		  name: 'dataIndentationChars',
+		  formattedOutput: true,
+		  config: {
+			dataIndentationChars: ''
+		  }
+	  }, function( bot ) {
+		bot.editor.dataProcessor.writer.setRules( 'ol', {
+			indent: true
+		} );
+
+		bot.editor.dataProcessor.writer.setRules( 'li', {
+			indent: true
+		} );
+
+		bot.setData( data, function() {
+			  assert.areSame( data, bot.getData( false, false ) );
+		} );
 	  } );
-	} );
-  }
+	}
 })

--- a/tests/plugins/htmlwriter/htmlwriter.js
+++ b/tests/plugins/htmlwriter/htmlwriter.js
@@ -1,5 +1,6 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: wysiwygarea, htmlwriter */
+
 bender.test( {
 	'test extra line break': function() {
 		var data = '<div>Text <strong>inline</strong> Text <p>paragraph</p></div>';
@@ -62,31 +63,32 @@ bender.test( {
 				assert.areSame( data, bot.getData( false, false ) );
 			} );
 		} );
+	},
+
+	// (#3795)
+	'test dataIndentationChars': function() {
+		// We are testing against indentation, not new line character. Preserve new lines for smoother comparison.
+		var data = '<ol>\n<li>One</li>\n<li>Two</li>\n<li>Three</li>\n</ol>\n';
+
+		bender.editorBot.create( {
+			name: 'dataIndentationChars',
+			formattedOutput: true,
+			config: {
+				allowedContent: true,
+				dataIndentationChars: ''
+			}
+		}, function( bot ) {
+			bot.editor.dataProcessor.writer.setRules( 'ol', {
+				indent: true
+			} );
+
+			bot.editor.dataProcessor.writer.setRules( 'li', {
+				indent: true
+			} );
+
+			bot.setData( data, function() {
+				assert.areSame( data, bot.getData( false, false ) );
+			} );
+		} );
 	}
 } );
-
-bender.test({
-	'test dataIndentationChars': function() {
-	  var data = '<ol><li>One</li><li>Two</li><li>Three</li></ol>';
-
-	  bender.editorBot.create( {
-		  name: 'dataIndentationChars',
-		  formattedOutput: true,
-		  config: {
-			dataIndentationChars: ''
-		  }
-	  }, function( bot ) {
-		bot.editor.dataProcessor.writer.setRules( 'ol', {
-			indent: true
-		} );
-
-		bot.editor.dataProcessor.writer.setRules( 'li', {
-			indent: true
-		} );
-
-		bot.setData( data, function() {
-			  assert.areSame( data, bot.getData( false, false ) );
-		} );
-	  } );
-	}
-})

--- a/tests/plugins/htmlwriter/htmlwriter.js
+++ b/tests/plugins/htmlwriter/htmlwriter.js
@@ -64,3 +64,21 @@ bender.test( {
 		} );
 	}
 } );
+
+bender.test({
+  'test dataIndentationChars': function() {
+	var data = '<ol><li>One</li><li>Two</li><li>Three</li></ol>';
+
+	bender.editorBot.create( {
+	  name: 'dataIndentationChars',
+	  formattedOutput: true,
+	  config: {
+		dataIndentationChars: ''
+	  }
+	}, function( bot ) {
+	  bot.setData( data, function() {
+		assert.areSame( data, bot.getData( false, false ) );
+	  } );
+	} );
+  }
+})

--- a/tests/plugins/htmlwriter/htmlwriter.js
+++ b/tests/plugins/htmlwriter/htmlwriter.js
@@ -66,7 +66,7 @@ bender.test( {
 	},
 
 	// (#3795)
-	'test dataIndentationChars': function() {
+	'test dataIndentationChars with empty character': function() {
 		// We are testing against indentation, not new line character. Preserve new lines for smoother comparison.
 		var data = '<ol>\n<li>One</li>\n<li>Two</li>\n<li>Three</li>\n</ol>\n';
 

--- a/tests/plugins/htmlwriter/manual/dataindentationchars.html
+++ b/tests/plugins/htmlwriter/manual/dataindentationchars.html
@@ -1,0 +1,13 @@
+<div id="editor">
+	<ol>
+		<li>One</li>
+		<li>Two</li>
+		<li>Three</li>
+	</ol>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		dataIndentationChars: ''
+	} );
+</script>

--- a/tests/plugins/htmlwriter/manual/dataindentationchars.md
+++ b/tests/plugins/htmlwriter/manual/dataindentationchars.md
@@ -2,12 +2,12 @@
 @bender-tags: 4.14.2, 3795, bug, htmlwriter
 @bender-ckeditor-plugins: toolbar,wysiwygarea,sourcearea,htmlwriter,list
 
-1. Switch editor into source mode using "Source" button.
+Switch editor into source mode using "Source" button.
 
 ### Expected
 
-List items `<li>` should not be indented.
+List items `<li>` shouldn't be indented.
 
 ### Unexpected
 
-List items `<li>` are be indented.
+List items `<li>` are indented.

--- a/tests/plugins/htmlwriter/manual/dataindentationchars.md
+++ b/tests/plugins/htmlwriter/manual/dataindentationchars.md
@@ -1,0 +1,13 @@
+@bender-ui: collapsed
+@bender-tags: 4.14.1, 3795, bug, htmlwriter
+@bender-ckeditor-plugins: toolbar,wysiwygarea,sourcearea,htmlwriter,list
+
+1. Switch editor into source mode using "Source" button.
+
+### Expected
+
+List items `<li>` should not be indented.
+
+### Unexpected
+
+List items `<li>` are be indented.

--- a/tests/plugins/htmlwriter/manual/dataindentationchars.md
+++ b/tests/plugins/htmlwriter/manual/dataindentationchars.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.14.1, 3795, bug, htmlwriter
+@bender-tags: 4.14.2, 3795, bug, htmlwriter
 @bender-ckeditor-plugins: toolbar,wysiwygarea,sourcearea,htmlwriter,list
 
 1. Switch editor into source mode using "Source" button.


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

Fixes this bug: https://github.com/ckeditor/ckeditor4/issues/3795

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

Yes, but I haven't been able to run the test, since running `bender server run` returns `Potentially unhandled rejection [1] ReferenceError: primordials is not defined`.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#3795](https://github.com/ckeditor/ckeditor4/issues/3795): Fixed a bug where setting the dataIndentationChars config to an empty string would be ignored and replaced by the string '\t'.
```

## What changes did you make?

Updated the line where the configuration is applied to check on the type of the configuration instead of the falsyness of the value.

## Which issues your PR resolves?

Closes #3795.
