### PR TITLE
Fix failing test for paste tools filters

### DIFF
--- a/tests/plugins/pastefromword/pasteimage.js
+++ b/tests/plugins/pastefromword/pasteimage.js
@@ -9,32 +9,42 @@
 	bender.editor = true;
 
 	var tests = {
-		init: function() {
-			this.isCustomDataTypesSupported = CKEDITOR.plugins.clipboard.isCustomDataTypesSupported;
-		},
-
 		// (https://dev.ckeditor.com/ticket/16912)
 		'test root image': function() {
-			testOutput( this.isCustomDataTypesSupported ? 'root-image' : 'root-image-simple', this.editor );
+			var editor = this.editor,
+				sampleName = CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ? 'root-image' : 'root-image-simple',
+				filterPaths = [
+					CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
+					CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
+				];
+
+			return ptTools.asyncFilterLoad( filterPaths, 'CKEDITOR.cleanWord' )
+				.then( testOutput( sampleName, editor ) );
 		},
 
 		'test nested image': function() {
-			testOutput( this.isCustomDataTypesSupported ? 'nested-image' : 'nested-image-simple', this.editor );
+			var editor = this.editor,
+				sampleName = CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ? 'nested-image' : 'nested-image-simple',
+				filterPaths = [
+					CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
+					CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
+				];
+
+			return ptTools.asyncFilterLoad( filterPaths, 'CKEDITOR.cleanWord' )
+				.then( testOutput( sampleName, editor ) );
 		}
 	};
 
 	ptTools.ignoreTestsOnMobiles( tests );
 
-	ptTools.testWithFilters( tests, [
-		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js' ),
-		CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
-	], function() {
-		bender.test( tests );
-	} );
+	tests = bender.tools.createAsyncTests( tests );
+	bender.test( tests );
 
 	function testOutput( name, editor ) {
-		bender.tools.testInputOut( name, function( input, output ) {
-			bender.assert.beautified.html( output, CKEDITOR.cleanWord( input, editor ) , name );
-		} );
+		return function( filter ) {
+			bender.tools.testInputOut( name, function( input, output ) {
+				bender.assert.beautified.html( output, filter( input, editor ) , name );
+			} );
+		};
 	}
 } )();

--- a/tests/plugins/pastefromword/pasteimage.js
+++ b/tests/plugins/pastefromword/pasteimage.js
@@ -18,7 +18,7 @@
 					CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
 				];
 
-			return ptTools.asyncFilterLoad( filterPaths, 'CKEDITOR.cleanWord' )
+			return ptTools.asyncLoadFilters( filterPaths, 'CKEDITOR.cleanWord' )
 				.then( testOutput( sampleName, editor ) );
 		},
 
@@ -30,7 +30,7 @@
 					CKEDITOR.getUrl( CKEDITOR.plugins.getPath( 'pastefromword' ) + 'filter/default.js' )
 				];
 
-			return ptTools.asyncFilterLoad( filterPaths, 'CKEDITOR.cleanWord' )
+			return ptTools.asyncLoadFilters( filterPaths, 'CKEDITOR.cleanWord' )
 				.then( testOutput( sampleName, editor ) );
 		}
 	};

--- a/tests/plugins/pastetools/_helpers/ptTools.js
+++ b/tests/plugins/pastetools/_helpers/ptTools.js
@@ -47,17 +47,26 @@
 
 		asyncFilterLoad: function( filters, refference ) {
 			return new CKEDITOR.tools.promise( function( resolve, reject ) {
+				var loaded = 0,
+					i;
+
 				if ( typeof filters == 'string' ) {
 					filters = [ filters ];
 				}
 
-				CKEDITOR.scriptLoader.load( filters, function( completed, failed ) {
-					if ( failed.length > 0 ) {
-						reject( 'Couldn\'t load scripts: "' + failed.join( '", "' ) + '"' );
-					}
+				for ( i = 0; i < filters.length; i++ ) {
+					( function( current ) {
+						CKEDITOR.scriptLoader.queue( current, function( status ) {
+							if ( !status ) {
+								reject( 'Couldn\'t load scripts: "' + current + '".' );
+							}
 
-					resolve( getByString( refference ) );
-				} );
+							if ( ++loaded === filters.length ) {
+								resolve( getByString( refference ) );
+							}
+						} );
+					}( filters[ i ] ) );
+				}
 			} );
 		}
 	};

--- a/tests/plugins/pastetools/_helpers/ptTools.js
+++ b/tests/plugins/pastetools/_helpers/ptTools.js
@@ -1,4 +1,4 @@
-/* exported pfwTools */
+/* exported ptTools */
 
 ( function() {
 	'use strict';
@@ -31,6 +31,31 @@
 			}
 		},
 
+		asyncLoadFilters: function( filters, referrence ) {
+			return new CKEDITOR.tools.promise( function( resolve, reject ) {
+				var loaded = 0;
+
+				if ( typeof filters === 'string' ) {
+					filters = [ filters ];
+				}
+
+				for ( var i = 0; i < filters.length; i++ ) {
+					( function( currentFilter ) {
+						CKEDITOR.scriptLoader.queue( currentFilter, function( status ) {
+							if ( !status ) {
+								reject( 'Couldn\'t load filter: ' + currentFilter );
+							}
+
+							loaded++;
+							if ( loaded === filters.length ) {
+								resolve( getFilterByName( referrence ) );
+							}
+						} );
+					}( filters[ i ] ) );
+				}
+			} );
+		},
+
 		testWithFilters: function( tests, filters, callback ) {
 			this.loadFilters( filters, function() {
 				tests[ 'async:init' ] = function() {
@@ -43,40 +68,14 @@
 
 				bender.test( tests );
 			} );
-		},
-
-		asyncFilterLoad: function( filters, refference ) {
-			return new CKEDITOR.tools.promise( function( resolve, reject ) {
-				var loaded = 0,
-					i;
-
-				if ( typeof filters == 'string' ) {
-					filters = [ filters ];
-				}
-
-				for ( i = 0; i < filters.length; i++ ) {
-					( function( current ) {
-						CKEDITOR.scriptLoader.queue( current, function( status ) {
-							if ( !status ) {
-								reject( 'Couldn\'t load scripts: "' + current + '".' );
-							}
-
-							if ( ++loaded === filters.length ) {
-								resolve( getByString( refference ) );
-							}
-						} );
-					}( filters[ i ] ) );
-				}
-			} );
 		}
 	};
 
-	function getByString( refference ) {
-		var keyNames = refference.split( '.' ),
-			i,
+	function getFilterByName( referrence ) {
+		var keyNames = referrence.split( '.' ),
 			currentObject = window;
 
-		for ( i = 0; i < keyNames.length; i++ ) {
+		for ( var i = 0; i < keyNames.length; i++ ) {
 			if ( keyNames[ i ] in currentObject ) {
 				currentObject = currentObject[ keyNames[ i ] ];
 			} else {
@@ -87,4 +86,3 @@
 		return currentObject;
 	}
 } )();
-

--- a/tests/plugins/pastetools/_helpers/ptTools.js
+++ b/tests/plugins/pastetools/_helpers/ptTools.js
@@ -43,7 +43,39 @@
 
 				bender.test( tests );
 			} );
+		},
+
+		asyncFilterLoad: function( filters, refference ) {
+			return new CKEDITOR.tools.promise( function( resolve, reject ) {
+				if ( typeof filters == 'string' ) {
+					filters = [ filters ];
+				}
+
+				CKEDITOR.scriptLoader.load( filters, function( completed, failed ) {
+					if ( failed.length > 0 ) {
+						reject( 'Couldn\'t load scripts: "' + failed.join( '", "' ) + '"' );
+					}
+
+					resolve( getByString( refference ) );
+				} );
+			} );
 		}
 	};
+
+	function getByString( refference ) {
+		var keyNames = refference.split( '.' ),
+			i,
+			currentObject = window;
+
+		for ( i = 0; i < keyNames.length; i++ ) {
+			if ( keyNames[ i ] in currentObject ) {
+				currentObject = currentObject[ keyNames[ i ] ];
+			} else {
+				throw new Error( 'Cannot find property: ' + keyNames[ i ] );
+			}
+		}
+
+		return currentObject;
+	}
 } )();
 

--- a/tests/plugins/pastetools/filter/common.js
+++ b/tests/plugins/pastetools/filter/common.js
@@ -18,7 +18,7 @@
 			var editor = this.editor,
 				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
 				.then( extendFilterRules )
 				.then( assertFilter( {
 					editor: editor,
@@ -51,7 +51,7 @@
 					'margin-bottom: 0in' +
 				'" >foo bar</p>';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
 				.then( extendFilterRules )
 				.then( assertFilter( {
 					editor: editor,
@@ -64,7 +64,7 @@
 			var editor = this.editor,
 				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
 				.then( extendFilterRules )
 				.then( assertFilter( {
 					editor: editor,
@@ -122,7 +122,7 @@
 			var editor = this.editor,
 				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
 				.then( extendFilterRules )
 				.then( assertFilter( {
 					editor: editor,
@@ -169,8 +169,8 @@
 	function assertFilter( options ) {
 		return function( filter ) {
 			var editor = options.editor,
-			input = options.input,
-			expected = options.expected;
+				input = options.input,
+				expected = options.expected;
 
 			// Can't use bender.tools.testInputOut as it normalizes an input html
 			var actualOutput = filter( input, editor );

--- a/tests/plugins/pastetools/filter/common.js
+++ b/tests/plugins/pastetools/filter/common.js
@@ -1,5 +1,7 @@
 /* bender-tags: editor,pastetools */
 /* bender-ckeditor-plugins: wysiwygarea,pastetools,font,toolbar */
+/* bender-include: ../_helpers/ptTools.js */
+/* global ptTools */
 
 ( function() {
 	'use strict';
@@ -11,10 +13,140 @@
 		}
 	};
 
-	var commonFilter;
+	var tests = {
+		'tests common filter should remove apple spaces': function() {
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js';
 
-	CKEDITOR.scriptLoader.load( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js', function() {
-		commonFilter = CKEDITOR.plugins.pastetools.createFilter( {
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+				.then( extendFilterRules )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<p>foo<span class="Apple-converted-space">\u00A0</span>bar</p>',
+					expected: '<p>foo bar</p>'
+				} ) );
+		},
+
+		'test common filter should remove superfluous styles': function() {
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js',
+				input = '<p style="' +
+					'background-color: transparent;' +
+					'background: transparent;' +
+					'background-color: none;' +
+					'background: none;' +
+					'background-position: initial initial;' +
+					'background-repeat: initial initial;' +
+					'caret-color;' +
+					'font-family: -webkit-standard;' +
+					'font-variant-caps;' +
+					'letter-spacing: normal;' +
+					'orphans: auto;' +
+					'widows: auto;' +
+					'text-transform: none;' +
+					'word-spacing: 0px;' +
+					'-webkit-text-size-adjust: auto;' +
+					'-webkit-text-stroke-width: 0px;' +
+					'text-indent: 0px;' +
+					'margin-bottom: 0in' +
+				'" >foo bar</p>';
+
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+				.then( extendFilterRules )
+				.then( assertFilter( {
+					editor: editor,
+					input: input,
+					expected: '<p>foo bar</p>'
+				} ) );
+		},
+
+		'test common filter should replace font-face if there is matching one': function() {
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js';
+
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+				.then( extendFilterRules )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Verdana,sans-serif">foo</font>',
+					expected: '<font face="Verdana, Geneva, sans-serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Trebuchet MS,sans-serif">foo</font>',
+					expected: '<font face="Trebuchet MS, Helvetica, sans-serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Times New Roman">foo</font>',
+					expected: '<font face="Times New Roman, Times, serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Tahoma,sans-serif">foo</font>',
+					expected: '<font face="Tahoma, Geneva, sans-serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Lucida Sans Unicode">foo</font>',
+					expected: '<font face="Lucida Sans Unicode, Lucida Grande, sans-serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Georgia,serif">foo</font>',
+					expected: '<font face="Georgia, serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Courier New,monospace">foo</font>',
+					expected: '<font face="Courier New, Courier, monospace">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Comic Sans MS,cursive">foo</font>',
+					expected: '<font face="Comic Sans MS, cursive">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Arial,sans-serif">foo</font>',
+					expected: '<font face="Arial, Helvetica, sans-serif">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Arial">foo</font>',
+					expected: '<font face="Arial, Helvetica, sans-serif">foo</font>'
+				} ) );
+		},
+
+		'test common filter should remain font-face if there is no matching one': function() {
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/common.js';
+
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.plugins.pastetools.filters.common.rules' )
+				.then( extendFilterRules )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="bar">foo</font>',
+					expected: '<font face="bar">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="arial">foo</font>',
+					expected: '<font face="arial">foo</font>'
+				} ) )
+				.then( assertFilter( {
+					editor: editor,
+					input: '<font face="Roboto">foo</font>',
+					expected: '<font face="Roboto">foo</font>'
+				} ) );
+		}
+	};
+
+	tests = bender.tools.createAsyncTests( tests );
+	bender.test( tests );
+
+	function extendFilterRules( rules ) {
+		return CKEDITOR.plugins.pastetools.createFilter( {
 			rules: [
 				// Implement general rules to filter all children in provided tree.
 				function( html, editor, filter ) {
@@ -29,136 +161,23 @@
 						}
 					};
 				},
-				CKEDITOR.plugins.pastetools.filters.common.rules
+				rules
 			]
 		} );
-	} );
-
-	function assertCommonFilter( editor, input, expected ) {
-		// Can't use bender.tools.testInputOut as it normalizes an input html
-		var actualOutput = commonFilter( input, editor );
-
-		assert.beautified.html( expected, actualOutput );
 	}
 
-	bender.test( {
-		'tests common filter should remove apple spaces': function() {
-			assertCommonFilter(
-				this.editor,
-				'<p>foo<span class="Apple-converted-space">\u00A0</span>bar</p>',
-				'<p>foo bar</p>'
-			);
-		},
+	function assertFilter( options ) {
+		return function( filter ) {
+			var editor = options.editor,
+			input = options.input,
+			expected = options.expected;
 
-		'test common filter should remove superfluous styles': function() {
-			var input = '<p style="' +
-				'background-color: transparent;' +
-				'background: transparent;' +
-				'background-color: none;' +
-				'background: none;' +
-				'background-position: initial initial;' +
-				'background-repeat: initial initial;' +
-				'caret-color;' +
-				'font-family: -webkit-standard;' +
-				'font-variant-caps;' +
-				'letter-spacing: normal;' +
-				'orphans: auto;' +
-				'widows: auto;' +
-				'text-transform: none;' +
-				'word-spacing: 0px;' +
-				'-webkit-text-size-adjust: auto;' +
-				'-webkit-text-stroke-width: 0px;' +
-				'text-indent: 0px;' +
-				'margin-bottom: 0in' +
-			'" >foo bar</p>';
+			// Can't use bender.tools.testInputOut as it normalizes an input html
+			var actualOutput = filter( input, editor );
 
-			assertCommonFilter(
-				this.editor,
-				input,
-				'<p>foo bar</p>'
-			);
-		},
+			assert.beautified.html( expected, actualOutput );
 
-		'test common filter should replace font-face if there is matching one': function() {
-			assertCommonFilter(
-				this.editor,
-				'<font face="Verdana,sans-serif">foo</font>',
-				'<font face="Verdana, Geneva, sans-serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Trebuchet MS,sans-serif">foo</font>',
-				'<font face="Trebuchet MS, Helvetica, sans-serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Times New Roman">foo</font>',
-				'<font face="Times New Roman, Times, serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Tahoma,sans-serif">foo</font>',
-				'<font face="Tahoma, Geneva, sans-serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Lucida Sans Unicode">foo</font>',
-				'<font face="Lucida Sans Unicode, Lucida Grande, sans-serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Georgia,serif">foo</font>',
-				'<font face="Georgia, serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Courier New,monospace">foo</font>',
-				'<font face="Courier New, Courier, monospace">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Comic Sans MS,cursive">foo</font>',
-				'<font face="Comic Sans MS, cursive">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Arial,sans-serif">foo</font>',
-				'<font face="Arial, Helvetica, sans-serif">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Arial">foo</font>',
-				'<font face="Arial, Helvetica, sans-serif">foo</font>'
-			);
-		},
-
-		'test common filter should remain font-face if there is no matching one': function() {
-			assertCommonFilter(
-				this.editor,
-				'<font face="bar">foo</font>',
-				'<font face="bar">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="arial">foo</font>',
-				'<font face="arial">foo</font>'
-			);
-
-			assertCommonFilter(
-				this.editor,
-				'<font face="Roboto">foo</font>',
-				'<font face="Roboto">foo</font>'
-			);
-		}
-	} );
+			return filter;
+		};
+	}
 } )();

--- a/tests/plugins/pastetools/filter/image.js
+++ b/tests/plugins/pastetools/filter/image.js
@@ -10,36 +10,62 @@
 			allowedContent: true
 		}
 	};
-
 	var RTF = [
-		'{\\pict\\picscalex100\\picscaley100\\piccropl0\\piccropr0\\piccropt0\\piccropb0\\picw300\\pich300\\picwgoal3823\\pichgoal3823\\pngblip d76df8e7aefc}',
-		'{\\*\\shppict{\\pict{\\*\\picprop{\\sp{\\sn wzDescription}{\\sv }}{\\sp{\\sn wzName}{\\sv }}}\\picscalex19\\picscaley19\\piccropl0\\piccropr0\\piccropt0' +
-		'\\piccropb0\\picw300\\pich300\\picwgoal3823\\pichgoal3823\\pngblip d76df8e7aefc }}{\\nonshppict{\\pict{\\*\\picprop{'
-	];
+			'{\\pict\\picscalex100\\picscaley100\\piccropl0\\piccropr0\\piccropt0\\piccropb0\\picw300\\pich300\\picwgoal3823\\pichgoal3823\\pngblip d76df8e7aefc}',
+			'{\\*\\shppict{\\pict{\\*\\picprop{\\sp{\\sn wzDescription}{\\sv }}{\\sp{\\sn wzName}{\\sv }}}\\picscalex19\\picscaley19\\piccropl0\\piccropr0\\piccropt0' +
+			'\\piccropb0\\picw300\\pich300\\picwgoal3823\\pichgoal3823\\pngblip d76df8e7aefc }}{\\nonshppict{\\pict{\\*\\picprop{'
+		];
 
-	CKEDITOR.scriptLoader.load( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js', function() {
-		bender.test( {
-			'test image filter should transform 1st type of rtf data': function() {
-				var inputHtml = '<img src="file://foo" />',
-					actual = CKEDITOR.pasteFilters.image( inputHtml, this.editor, RTF[ 0 ] );
+	var tests = {
+		'test image filter should transform 1st type of rtf data': function() {
+			var editor = this.editor;
 
-				assert.areSame( '<img src="data:image/png;base64,12345678" />', actual );
-			},
+			return loadImageFilter()
+				.then( function( imageFilter ) {
+					var inputHtml = '<img src="file://foo" />',
+						actual = imageFilter( inputHtml, editor, RTF[ 0 ] );
 
-			'test image filer should transform 2nd type of rtf data': function() {
-				var inputHtml = '<img src="file://foo" />',
-					actual = CKEDITOR.pasteFilters.image( inputHtml, this.editor, RTF[ 1 ] );
+					assert.areSame( '<img src="data:image/png;base64,12345678" />', actual );
+				} );
+		},
 
-				assert.areSame( '<img src="data:image/png;base64,12345678" />', actual );
-			},
+		'test image filer should transform 2nd type of rtf data': function() {
+			var editor = this.editor;
 
-			'test image filter should not transform non-file images': function() {
-				var inputHtml = '<img src="http://example.com/img.png" />',
-					actual = CKEDITOR.pasteFilters.image( inputHtml, this.editor, RTF[ 0 ] );
+			return loadImageFilter()
+				.then( function( imageFilter ) {
+					var inputHtml = '<img src="file://foo" />',
+						actual = imageFilter( inputHtml, editor, RTF[ 1 ] );
 
-				assert.areSame( '<img src="http://example.com/img.png" />', actual );
-			}
+					assert.areSame( '<img src="data:image/png;base64,12345678" />', actual );
+				} );
+		},
+
+		'test image filter should not transform non-file images': function() {
+			var editor = this.editor;
+
+			return loadImageFilter()
+				.then( function( imageFilter ) {
+					var inputHtml = '<img src="http://example.com/img.png" />',
+						actual = imageFilter( inputHtml, editor, RTF[ 0 ] );
+
+					assert.areSame( '<img src="http://example.com/img.png" />', actual );
+				} );
+		}
+	};
+
+	tests = bender.tools.createAsyncTests( tests );
+	bender.test( tests );
+
+	function loadImageFilter() {
+		return new CKEDITOR.tools.promise( function( resolve, reject ) {
+			CKEDITOR.scriptLoader.load( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js', function( success ) {
+				if ( success ) {
+					resolve( CKEDITOR.pasteFilters.image );
+				} else {
+					reject( 'Couldn\'t load the fitler script' );
+				}
+			} );
 		} );
-	} );
-
+	}
 } )();

--- a/tests/plugins/pastetools/filter/image.js
+++ b/tests/plugins/pastetools/filter/image.js
@@ -23,7 +23,7 @@
 			var editor = this.editor,
 				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.pasteFilters.image' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.pasteFilters.image' )
 				.then( function( imageFilter ) {
 					var inputHtml = '<img src="file://foo" />',
 						actual = imageFilter( inputHtml, editor, RTF[ 0 ] );
@@ -36,7 +36,7 @@
 			var editor = this.editor,
 				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.pasteFilters.image' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.pasteFilters.image' )
 				.then( function( imageFilter ) {
 					var inputHtml = '<img src="file://foo" />',
 						actual = imageFilter( inputHtml, editor, RTF[ 1 ] );
@@ -49,7 +49,7 @@
 			var editor = this.editor,
 				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js';
 
-			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.pasteFilters.image' )
+			return ptTools.asyncLoadFilters( filterPath, 'CKEDITOR.pasteFilters.image' )
 				.then( function( imageFilter ) {
 					var inputHtml = '<img src="http://example.com/img.png" />',
 						actual = imageFilter( inputHtml, editor, RTF[ 0 ] );

--- a/tests/plugins/pastetools/filter/image.js
+++ b/tests/plugins/pastetools/filter/image.js
@@ -1,5 +1,7 @@
 /* bender-tags: editor,pastetools,imagefilter */
 /* bender-ckeditor-plugins: wysiwygarea,pastetools,font,toolbar */
+/* bender-include: ../_helpers/ptTools.js */
+/* global ptTools */
 
 ( function() {
 	'use strict';
@@ -18,9 +20,10 @@
 
 	var tests = {
 		'test image filter should transform 1st type of rtf data': function() {
-			var editor = this.editor;
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js';
 
-			return loadImageFilter()
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.pasteFilters.image' )
 				.then( function( imageFilter ) {
 					var inputHtml = '<img src="file://foo" />',
 						actual = imageFilter( inputHtml, editor, RTF[ 0 ] );
@@ -30,9 +33,10 @@
 		},
 
 		'test image filer should transform 2nd type of rtf data': function() {
-			var editor = this.editor;
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js';
 
-			return loadImageFilter()
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.pasteFilters.image' )
 				.then( function( imageFilter ) {
 					var inputHtml = '<img src="file://foo" />',
 						actual = imageFilter( inputHtml, editor, RTF[ 1 ] );
@@ -42,9 +46,10 @@
 		},
 
 		'test image filter should not transform non-file images': function() {
-			var editor = this.editor;
+			var editor = this.editor,
+				filterPath = CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js';
 
-			return loadImageFilter()
+			return ptTools.asyncFilterLoad( filterPath, 'CKEDITOR.pasteFilters.image' )
 				.then( function( imageFilter ) {
 					var inputHtml = '<img src="http://example.com/img.png" />',
 						actual = imageFilter( inputHtml, editor, RTF[ 0 ] );
@@ -56,16 +61,4 @@
 
 	tests = bender.tools.createAsyncTests( tests );
 	bender.test( tests );
-
-	function loadImageFilter() {
-		return new CKEDITOR.tools.promise( function( resolve, reject ) {
-			CKEDITOR.scriptLoader.load( CKEDITOR.plugins.getPath( 'pastetools' ) + 'filter/image.js', function( success ) {
-				if ( success ) {
-					resolve( CKEDITOR.pasteFilters.image );
-				} else {
-					reject( 'Couldn\'t load the fitler script' );
-				}
-			} );
-		} );
-	}
 } )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## What is the proposed changelog entry for this pull request?

don't need

## What changes did you make?

Remove script load function and create helper based on promise.
The probably source of the issue was situation that filters could be loaded before the plugin. So reference to filter was overwritten. The change now loads when editor is ready, whats guarantee that all plugins are loaded already.

## Which issues your PR resolves?

Closes #3800, closes #3798 
