### PR TITLE
Add `aria-selected` attribute for active dialog tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New features:
 * [#2583](https://github.com/ckeditor/ckeditor-dev/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
 * [#3748](https://github.com/ckeditor/ckeditor-dev/issues/3748): Improved [Color Button](https://ckeditor.com/cke4/addon/colorbutton) state to reflect selected editor content colors.
 * [#3661](https://github.com/ckeditor/ckeditor4/issues/3661): Improved [Print](https://ckeditor.com/cke4/addon/print) plugin to respect styling rendered by the [Preview](https://ckeditor.com/cke4/addon/preview) plugin.
+* [#3547](https://github.com/ckeditor/ckeditor4/issues/3547): Active [dialog](https://ckeditor.com/cke4/addon/dialog) tab has now `aria-selected="true"` attribute.
 
 Fixed Issues:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,9 @@
 
 New features:
 
-* [#2374](https://github.com/ckeditor/ckeditor-dev/issues/2374): Added support for pasting rich content from LibreOffice with the [Paste from LibreOffice](https://ckeditor.com/cke4/addon/pastefromlibreoffice) plugin.
-* [#2583](https://github.com/ckeditor/ckeditor-dev/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
-* [#3748](https://github.com/ckeditor/ckeditor-dev/issues/3748): Improved [Color Button](https://ckeditor.com/cke4/addon/colorbutton) state to reflect selected editor content colors.
+* [#2374](https://github.com/ckeditor/ckeditor4/issues/2374): Added support for pasting rich content from LibreOffice with the [Paste from LibreOffice](https://ckeditor.com/cke4/addon/pastefromlibreoffice) plugin.
+* [#2583](https://github.com/ckeditor/ckeditor4/issues/2583): Changed [Emoji](https://ckeditor.com/cke4/addon/emoji) suggestion box to show matched emoji name instead of an ID.
+* [#3748](https://github.com/ckeditor/ckeditor4/issues/3748): Improved [Color Button](https://ckeditor.com/cke4/addon/colorbutton) state to reflect selected editor content colors.
 * [#3661](https://github.com/ckeditor/ckeditor4/issues/3661): Improved [Print](https://ckeditor.com/cke4/addon/print) plugin to respect styling rendered by the [Preview](https://ckeditor.com/cke4/addon/preview) plugin.
 * [#3547](https://github.com/ckeditor/ckeditor4/issues/3547): Active [dialog](https://ckeditor.com/cke4/addon/dialog) tab has now `aria-selected="true"` attribute.
 
@@ -15,13 +15,13 @@ Fixed Issues:
 
 * [#3587](https://github.com/ckeditor/ckeditor4/issues/3587): [Edge, IE] Fixed: [Widget](https://ckeditor.com/cke4/addon/widget) with form input elements loses focus during typing.
 * [#3705](https://github.com/ckeditor/ckeditor4/issues/3705): [Safari] Fixed: Safari incorrectly removes blocks with [`editor.extractSelectedHtml()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-extractSelectedHtml) method after selecting all content.
-* [#1306](https://github.com/ckeditor/ckeditor-dev/issues/1306): Fixed: [Font](https://ckeditor.com/cke4/addon/colorbutton) plugin creates nested HTML `span` tags when reapplying the same font multiple times.
+* [#1306](https://github.com/ckeditor/ckeditor4/issues/1306): Fixed: [Font](https://ckeditor.com/cke4/addon/colorbutton) plugin creates nested HTML `span` tags when reapplying the same font multiple times.
 
 API Changes:
 
-* [#3387](https://github.com/ckeditor/ckeditor-dev/issues/3387): Added the [CKEDITOR.ui.richCombo#select](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-select) method.
-* [#3727](https://github.com/ckeditor/ckeditor-dev/issues/3727): Added new commands `textColor` and `bgColor` which applies the selected color choosen by the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) plugin.
-* [#3728](https://github.com/ckeditor/ckeditor-dev/issues/3728): Added new commands `font` and `fontSize` which applies the selected font style choosen by the [Font](https://ckeditor.com/cke4/addon/colorbutton) plugin.
+* [#3387](https://github.com/ckeditor/ckeditor4/issues/3387): Added the [CKEDITOR.ui.richCombo#select](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_richCombo.html#method-select) method.
+* [#3727](https://github.com/ckeditor/ckeditor4/issues/3727): Added new commands `textColor` and `bgColor` which applies the selected color choosen by the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) plugin.
+* [#3728](https://github.com/ckeditor/ckeditor4/issues/3728): Added new commands `font` and `fontSize` which applies the selected font style choosen by the [Font](https://ckeditor.com/cke4/addon/colorbutton) plugin.
 
 ## CKEditor 4.13.1
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1276,6 +1276,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					page = this._.tabs[ i ][ 1 ];
 				if ( i != id ) {
 					tab.removeClass( 'cke_dialog_tab_selected' );
+					tab.removeAttribute( 'aria-selected' );
 					page.hide();
 				}
 				page.setAttribute( 'aria-hidden', i != id );
@@ -1283,6 +1284,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 			var selected = this._.tabs[ id ];
 			selected[ 0 ].addClass( 'cke_dialog_tab_selected' );
+			selected[ 0 ].setAttribute( 'aria-selected', true );
 
 			// [IE] an invisible input[type='text'] will enlarge it's width
 			// if it's value is long when it shows, so we clear it's value

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -337,6 +337,21 @@
 			};
 		},
 
+		// Asserts there is just one aria-selected tab and that it's the one with 'cke_dialog_tab_selected' class.
+		//
+		// @param {String} tab The tab ID.
+		assertAriaAttribute: function() {
+			return function( dialog ) {
+				var selectedTab = dialog.getElement().findOne( '.cke_dialog_tab_selected' ),
+					ariaSelectedTabsCount = dialog.getElement().find( '[aria-selected]' ).count();
+
+				assert.areEqual( 1, ariaSelectedTabsCount );
+				assert.isTrue( !!selectedTab.getAttribute( 'aria-selected' ) );
+
+				return dialog;
+			};
+		},
+
 		// Provides a thenable/chainable function which returns "dialog changing focus" promise when called.
 		//
 		// The idea is to wrap a function which changes focus into a promise. The promise resolves when dialog generates

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -340,7 +340,7 @@
 		// Asserts there is just one aria-selected tab and that it's the one with 'cke_dialog_tab_selected' class.
 		//
 		// @param {String} tab The tab ID.
-		assertAriaAttribute: function() {
+		assertTabsAriaAttribute: function() {
 			return function( dialog ) {
 				var selectedTab = dialog.getElement().findOne( '.cke_dialog_tab_selected' ),
 					ariaSelectedTabsCount = dialog.getElement().find( '[aria-selected]' ).count();

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -18,7 +18,8 @@
 
 		assertFocusedElement = window.dialogTools.assertFocusedElement,
 		assertFocusedTab = window.dialogTools.assertFocusedTab,
-		focusElement = window.dialogTools.focusElement;
+		focusElement = window.dialogTools.focusElement,
+		assertAriaAttribute = window.dialogTools.assertAriaAttribute;
 
 	bender.editor = {
 		config: {
@@ -205,6 +206,28 @@
 				.then( assertFocusedTab( 'mp-test3' ) )
 				.then( focusElement( { key: KEYS.ARROW_LEFT } ) )
 				.then( assertFocusedTab( 'mp-test2' ) );
+		},
+
+		// (#3547)
+		'test multi page dialog should move the aria-selected attribute when navigating with ARROW keys': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'multiPageDialog' )
+				.then( assertFocusedElement( {
+					tab: 'mp-test1',
+					elementId: 'mp-input11'
+				} ) )
+				.then( focusElement( { direction: 'previous' } ) )
+				.then( assertAriaAttribute() )
+				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
+				.then( assertAriaAttribute() )
+				.then( focusElement( { key: KEYS.ARROW_UP } ) )
+				.then( assertAriaAttribute() )
+				.then( focusElement( { key: KEYS.ARROW_DOWN } ) )
+				.then( focusElement( { key: KEYS.ARROW_DOWN } ) )
+				.then( assertAriaAttribute() )
+				.then( focusElement( { key: KEYS.ARROW_LEFT } ) )
+				.then( assertAriaAttribute() );
 		},
 
 		'test multi page dialog should bring the focus to the tab with the ALT+F10 keys': function() {

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -19,7 +19,7 @@
 		assertFocusedElement = window.dialogTools.assertFocusedElement,
 		assertFocusedTab = window.dialogTools.assertFocusedTab,
 		focusElement = window.dialogTools.focusElement,
-		assertAriaAttribute = window.dialogTools.assertAriaAttribute;
+		assertTabsAriaAttribute = window.dialogTools.assertTabsAriaAttribute;
 
 	bender.editor = {
 		config: {
@@ -218,16 +218,16 @@
 					elementId: 'mp-input11'
 				} ) )
 				.then( focusElement( { direction: 'previous' } ) )
-				.then( assertAriaAttribute() )
+				.then( assertTabsAriaAttribute() )
 				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
-				.then( assertAriaAttribute() )
+				.then( assertTabsAriaAttribute() )
 				.then( focusElement( { key: KEYS.ARROW_UP } ) )
-				.then( assertAriaAttribute() )
+				.then( assertTabsAriaAttribute() )
 				.then( focusElement( { key: KEYS.ARROW_DOWN } ) )
 				.then( focusElement( { key: KEYS.ARROW_DOWN } ) )
-				.then( assertAriaAttribute() )
+				.then( assertTabsAriaAttribute() )
 				.then( focusElement( { key: KEYS.ARROW_LEFT } ) )
-				.then( assertAriaAttribute() );
+				.then( assertTabsAriaAttribute() );
 		},
 
 		'test multi page dialog should bring the focus to the tab with the ALT+F10 keys': function() {

--- a/tests/plugins/dialog/manual/ariaselected.html
+++ b/tests/plugins/dialog/manual/ariaselected.html
@@ -1,0 +1,28 @@
+<div>
+	<textarea cols="80" id="editor" rows="10">
+		<p>Hello world!</p>
+	</textarea>
+
+	<button id="find-aria-selected">Find aria-selected tab</button>
+
+	<div>Aria value: <span id="aria-value"></span></div>
+
+	<script>
+		CKEDITOR.replace( 'editor' );
+
+		var button = CKEDITOR.document.findOne( '#find-aria-selected' ),
+			result = CKEDITOR.document.findOne( '#aria-value' ),
+			selectedTab;
+
+		button.on( 'click', function() {
+			selectedTab = CKEDITOR.document.findOne( '.cke_dialog_tab_selected' );
+			if ( !selectedTab ) {
+				result.setText( 'Open the dialog first!' );
+			} else {
+				result.setText( String( selectedTab.getAttribute( 'aria-selected' ) ) );
+			}
+
+			result.setStyle( 'color', result.getText() == 'true' ? 'green' : 'red' );
+		} );
+	</script>
+</div>

--- a/tests/plugins/dialog/manual/ariaselected.html
+++ b/tests/plugins/dialog/manual/ariaselected.html
@@ -1,28 +1,35 @@
 <div>
+	<div>Selected tab by class: <span id="selected-by-class" style="border: 1px solid red"></span></div>
+	<div>Selected tab by aria-selected: <span id="selected-by-aria" style="border: 1px solid red"></span></div>
+
 	<textarea cols="80" id="editor" rows="10">
 		<p>Hello world!</p>
 	</textarea>
 
-	<button id="find-aria-selected">Find aria-selected tab</button>
-
-	<div>Aria value: <span id="aria-value"></span></div>
-
 	<script>
 		CKEDITOR.replace( 'editor' );
 
-		var button = CKEDITOR.document.findOne( '#find-aria-selected' ),
-			result = CKEDITOR.document.findOne( '#aria-value' ),
-			selectedTab;
+		var resultClass = CKEDITOR.document.findOne( '#selected-by-class' ),
+			resultAria = CKEDITOR.document.findOne( '#selected-by-aria' ),
+			selectedByClass,
+			selectedByAria;
 
-		button.on( 'click', function() {
-			selectedTab = CKEDITOR.document.findOne( '.cke_dialog_tab_selected' );
-			if ( !selectedTab ) {
-				result.setText( 'Open the dialog first!' );
-			} else {
-				result.setText( String( selectedTab.getAttribute( 'aria-selected' ) ) );
-			}
+		CKEDITOR.instances.editor.on( 'dialogShow', function( evt ) {
+			var interval = setInterval( function() {
+				selectedByClass = evt.data.getElement().findOne( '.cke_dialog_tab_selected' );
+				selectedByAria = evt.data.getElement().findOne( '[aria-selected=true]' );
+					if ( selectedByClass ) {
+						resultClass.setText( selectedByClass.getText() );
+					}
+					if ( selectedByAria ) {
+						resultAria.setText( selectedByAria.getText() );
+					}
+				}, 100 );
 
-			result.setStyle( 'color', result.getText() == 'true' ? 'green' : 'red' );
+			CKEDITOR.instances.editor.once( 'dialogHide', function( evt ) {
+				clearInterval( interval );
+			} );
 		} );
+
 	</script>
 </div>

--- a/tests/plugins/dialog/manual/ariaselected.md
+++ b/tests/plugins/dialog/manual/ariaselected.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.14.0, feature, 3547
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link, image
+
+1. Open `link` dialog.
+
+1. Close dialog.
+
+1. Press the button below editor.
+
+**Expected** Aria value is `true`.
+
+**Unexpected** Aria value is `null`.

--- a/tests/plugins/dialog/manual/ariaselected.md
+++ b/tests/plugins/dialog/manual/ariaselected.md
@@ -4,10 +4,20 @@
 
 1. Open `link` dialog.
 
-1. Close dialog.
+  **Expected:** Both values in red boxes are the same and equal to `Link Info`.
 
-1. Press the button below editor.
+  **Unexpected:** Values are different or one of them is not present.
 
-**Expected** Aria value is `true`.
+1. Change tab to `Advanced`.
 
-**Unexpected** Aria value is `null`.
+  **Expected:** Both values in red boxes are the same and equal to `Advanced`.
+
+  **Unexpected:** Second value didn't change.
+
+1. Close `link` dialog.
+
+1. Open `image` dialog.
+
+  **Expected:** Both values in red boxes are the same and equal to `Image Info`.
+
+  **Unexpected:** Values didn't change after new dialog was opened.

--- a/tests/plugins/dialog/manual/ariaselected.md
+++ b/tests/plugins/dialog/manual/ariaselected.md
@@ -21,3 +21,5 @@
   **Expected:** Both values in red boxes are the same and equal to `Image Info`.
 
   **Unexpected:** Values didn't change after new dialog was opened.
+
+**Important**: Keep in mind that values are refreshed on interval so you may see slight delay when changing tabs very fast.


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## What is the proposed changelog entry for this pull request?

```
*[#3547](https://github.com/ckeditor/ckeditor4/issues/3547): Active [dialog](https://ckeditor.com/cke4/addon/dialog) tab has now `aria-selected="true"` attribute.
```

## What changes did you make?

Add and remove `aria-selected` attribute along with a `cke_dialog_tab_selected` class.

## Which issues your PR resolves?

Closes #3547.
