### PR TITLE
Fix for config not considered for startup read-only mode of inline editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-﻿CKEditor 4 Changelog
+CKEditor 4 Changelog
 ====================
 
 ## CKEditor 4.14.1
@@ -6,6 +6,7 @@
 Fixed Issues:
 
 * [#2607](https://github.com/ckeditor/ckeditor4/issues/2607): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) SVG icons file is not loaded in CORS context.
+* [#3866](https://github.com/ckeditor/ckeditor4/issues/3866): Fixed: [`config.readOnly`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-readOnly) config variable not considered for startup read-only mode of inline editor.
 
 ## CKEditor 4.14
 

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -57,7 +57,7 @@
 			// If editor element does not have contenteditable attribute, but config.readOnly
 			// is explicitly set to false, set the contentEditable property to true (#3866).
 			if ( instanceConfig && typeof instanceConfig.readOnly !== 'undefined' && !instanceConfig.readOnly ) {
-				element.$.contentEditable = true;
+				element.setAttribute( 'contenteditable', 'true' );
 			}
 
 			// Initial editor data is simply loaded from the page element content to make

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -12,7 +12,8 @@
 	 * allowed element names.
 	 *
 	 * **Note:** If the DOM element for which inline editing is being enabled does not have
-	 * the `contenteditable` attribute set to `true`, the editor will start in read-only mode.
+	 * the `contenteditable` attribute set to `true` or {@link CKEDITOR.config#readOnly config.readOnly}
+	 * configuration option set to `false`, the editor will start in read-only mode.
 	 *
 	 *		<div contenteditable="true" id="content">...</div>
 	 *		...

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -54,6 +54,12 @@
 			if ( textarea.$.form )
 				editor._attachToForm();
 		} else {
+			// If editor element does not have contenteditable attribute, but config.readOnly
+			// is explicitly set to false, set the contentEditable property to true (#3866).
+			if ( instanceConfig && typeof instanceConfig.readOnly !== 'undefined' && !instanceConfig.readOnly ) {
+				element.$.contentEditable = true;
+			}
+
 			// Initial editor data is simply loaded from the page element content to make
 			// data retrieval possible immediately after the editor creation.
 			editor.setData( element.getHtml(), null, true );

--- a/tests/core/creators/inline.html
+++ b/tests/core/creators/inline.html
@@ -1,0 +1,3 @@
+<div id="readOnly">
+	<p>Lorem ipsum</p>
+</div>

--- a/tests/core/creators/inline.js
+++ b/tests/core/creators/inline.js
@@ -21,7 +21,10 @@ bender.test( {
 			on: {
 				instanceReady: function( evt ) {
 					resume( function() {
-						assert.isFalse( evt.editor.readOnly, 'Editor is in read-only mode' );
+						var editor = evt.editor;
+
+						assert.isFalse( editor.readOnly, 'Editor is in read-only mode', 'Editor should be in read-only mode' );
+						assert.areEqual( 'true', editor.element.getAttribute( 'contenteditable' ), 'Editor should be editable' );
 					} );
 				}
 			}

--- a/tests/core/creators/inline.js
+++ b/tests/core/creators/inline.js
@@ -12,5 +12,20 @@ bender.test( {
 
 		assert.areSame( editor.name, editor.container.getId() );
 		assert.areSame( editor.name, editor.ui.contentsElement.getId() );
+	},
+
+	// (#3866)
+	'test forcing editable mode': function() {
+		CKEDITOR.inline( 'readOnly', {
+			readOnly: false,
+			on: {
+				instanceReady: function( evt ) {
+					resume( function() {
+						assert.isFalse( evt.editor.readOnly, 'Editor is in read-only mode' );
+					} );
+				}
+			}
+		} );
+		wait();
 	}
 } );

--- a/tests/core/creators/manual/inlinereadonly.html
+++ b/tests/core/creators/manual/inlinereadonly.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.inline( 'editor', {
+		readOnly: false
+	} );
+</script>

--- a/tests/core/creators/manual/inlinereadonly.md
+++ b/tests/core/creators/manual/inlinereadonly.md
@@ -1,0 +1,13 @@
+@bender-tags: bug, 4.14.0, 3866
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+1. Focus the editor.
+
+## Expected
+
+* Editor is in editable mode.
+
+## Unexpected
+
+* Editor is in read-only mode.

--- a/tests/core/creators/manual/inlinereadonly.md
+++ b/tests/core/creators/manual/inlinereadonly.md
@@ -1,13 +1,13 @@
-@bender-tags: bug, 4.14.0, 3866
+@bender-tags: bug, 4.14.1, 3866
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
 
-1. Focus the editor.
+Focus the editor.
 
 ## Expected
 
-* Editor is in editable mode.
+Editor is in editable mode.
 
 ## Unexpected
 
-* Editor is in read-only mode.
+Editor is in read-only mode.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow CKEditor 4 code style guide?

Your code should follow guidelines from [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with code style guide

## What is the proposed changelog entry for this pull request?

```
*[#3866](https://github.com/ckeditor/ckeditor4/issues/3866): Fixed: [`config.readOnly`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-readOnly) config variable not considered for startup read-only mode of inline editor.
```

## What changes did you make?

I've added check if `config.readOnly` is set and if it's falsy value, then set `contentEditable` to `true` on inline editor's element to make it editable.

## Which issues your PR resolves?

Closes #3866.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
