### PR TITLE
Fix for failing test tests/plugins/easyimage/pasteintegration

### DIFF
--- a/tests/plugins/easyimage/pasteintegration.js
+++ b/tests/plugins/easyimage/pasteintegration.js
@@ -17,34 +17,37 @@
 	bender.editor = true;
 
 	function assertEasyImageUpcast( config ) {
-		var editor = config.editor,
+		var bot = config.bot,
+			editor = bot.editor,
 			pastedData = config.pastedData,
 			shouldUpcast = config.shouldUpcast,
 			// spy checks if paste listener in easyimage plugin activates an early return,
 			// by spying the method available after the early return statement.
 			upcastSpy = sinon.spy( editor.widgets.registered.easyimage, '_spawnLoader' );
 
-		bender.tools.range.setWithHtml( editor.editable(), '<p>[]</p>' );
+		bot.setData( '', function() {
+			bender.tools.range.setWithHtml( editor.editable(), '<p>[]</p>' );
 
-		bender.tools.emulatePaste( editor, pastedData );
+			bender.tools.emulatePaste( editor, pastedData );
 
-		editor.once( 'afterPaste', function() {
-			resume( function() {
-				upcastSpy.restore();
+			editor.once( 'afterPaste', function() {
+				resume( function() {
+					upcastSpy.restore();
 
-				if ( shouldUpcast ) {
-					sinon.assert.calledOnce( upcastSpy );
+					if ( shouldUpcast ) {
+						sinon.assert.calledOnce( upcastSpy );
 
-					assert.areNotSame( -1, editor.getData().indexOf( 'easyimage' ), 'there should be the image upcasted to the easyimage widget' );
-				} else {
-					sinon.assert.notCalled( upcastSpy );
+						assert.areNotSame( -1, editor.getData().indexOf( 'easyimage' ), 'there should be the image upcasted to the easyimage widget' );
+					} else {
+						sinon.assert.notCalled( upcastSpy );
 
-					assert.areSame( -1, editor.getData().indexOf( 'easyimage' ), 'there should not be an image upcasted to the easyimage widget' );
-				}
+						assert.areSame( -1, editor.getData().indexOf( 'easyimage' ), 'there should not be an image upcasted to the easyimage widget' );
+					}
+				} );
 			} );
-		} );
 
-		wait();
+			wait();
+		} );
 	}
 
 	bender.test( {
@@ -54,7 +57,7 @@
 
 		'test easyimage upcasts image/jpeg': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.JPEG,
 				shouldUpcast: true
 			} );
@@ -62,7 +65,7 @@
 
 		'test easyimage upcasts image/gif': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.GIF,
 				shouldUpcast: true
 			} );
@@ -70,7 +73,7 @@
 
 		'test easyimage upcasts image/png': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.PNG,
 				shouldUpcast: true
 			} );
@@ -78,7 +81,7 @@
 
 		'test easyimage upcasts image/bmp': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.BMP,
 				shouldUpcast: true
 			} );
@@ -86,7 +89,7 @@
 
 		'test easyimage not upcasts image/svg': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.SVG,
 				shouldUpcast: false
 			} );
@@ -94,7 +97,7 @@
 
 		'test easyimage not upcasts image/foobar': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.FAKE_IMAGE,
 				shouldUpcast: false
 			} );
@@ -102,7 +105,7 @@
 
 		'test easyimage not upcasts text/html': function() {
 			assertEasyImageUpcast( {
-				editor: this.editor,
+				bot: this.editorBot,
 				pastedData: IMG.HTML,
 				shouldUpcast: false
 			} );


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow CKEditor 4 code style guide?

Your code should follow guidelines from [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ ] PR is consistent with code style guide

## What is the proposed changelog entry for this pull request?

Not needed

## What changes did you make?

I've forced clearing the editable before every test. It seems that IE has issues with selecting incorrectly inserted image.

## Which issues your PR resolves?

Closes #3869.
