### PR TITLE
Fix for resizing last table column in IE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#3866](https://github.com/ckeditor/ckeditor4/issues/3866): Fixed: [`config.readOnly`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-readOnly) config variable not considered for startup read-only mode of inline editor.
 * [#3931](https://github.com/ckeditor/ckeditor4/issues/3931): [IE] Fixed: Error is thrown when pasting using paste button after accepting browser Clipboard Access Prompt dialog.
 * [#3938](https://github.com/ckeditor/ckeditor4/issues/3938): Fixed: Cannot navigate autocomplete panel via keyboard after switching to source mode.
+* [#2823](https://github.com/ckeditor/ckeditor4/issues/2823): [IE] Fixed: Cannot resize the last table column using [Table Resize](https://ckeditor.com/cke4/addon/tableresize) plugin.
 
 ## CKEditor 4.14
 

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -53,7 +53,7 @@
 				pillarPosition = null,
 				pillarDimensions = setPillarDimensions( $tr ),
 				isIE = CKEDITOR.env.ie && !CKEDITOR.env.edge,
-				isBorderCollapse = table.getComputedStyle( 'border-collapse' ) === 'collapse'
+				isBorderCollapse = table.getComputedStyle( 'border-collapse' ) === 'collapse';
 
 			pillarHeight = pillarDimensions.height;
 			pillarPosition = pillarDimensions.position;

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -92,14 +92,12 @@
 
 				pillarWidth = Math.max( pillarRight - pillarLeft, 3 );
 
-				// In case of IE and collapsed table border, we must substract all borders
-				// from previous and current cells (#2823).
+				// In case of IE and collapsed table border, we must substract pillarWidth
+				// from the current position and recalculate pillarWidth (#2823).
 				if ( isIE && isBorderCollapse ) {
-					var borderLeft = getBorderWidth( table, 'left' ),
-						borderRight = getBorderWidth( table, 'right' ),
-						index = td.$.cellIndex + 1;
+					pillarLeft -= pillarWidth;
 
-					pillarLeft -= ( borderLeft * index ) + ( borderRight * index ) + pillarWidth;
+					pillarWidth = Math.max( pillarRight - pillarLeft, 3 );
 				}
 
 

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -27,7 +27,7 @@
 				computed = 0;
 		}
 
-		return parseInt( computed, 10 );
+		return parseFloat( computed );
 	}
 
 	// Sets pillar height and position based on given table element (head, body, footer).
@@ -51,7 +51,9 @@
 				pillarRow,
 				pillarHeight = 0,
 				pillarPosition = null,
-				pillarDimensions = setPillarDimensions( $tr );
+				pillarDimensions = setPillarDimensions( $tr ),
+				isIE = CKEDITOR.env.ie && !CKEDITOR.env.edge,
+				isBorderCollapse = table.getComputedStyle( 'border-collapse' ) === 'collapse'
 
 			pillarHeight = pillarDimensions.height;
 			pillarPosition = pillarDimensions.position;
@@ -89,6 +91,17 @@
 				}
 
 				pillarWidth = Math.max( pillarRight - pillarLeft, 3 );
+
+				// In case of IE and collapsed table border, we must substract all borders
+				// from previous and current cells (#2823).
+				if ( isIE && isBorderCollapse ) {
+					var borderLeft = getBorderWidth( table, 'left' ),
+						borderRight = getBorderWidth( table, 'right' ),
+						index = td.$.cellIndex + 1;
+
+					pillarLeft -= ( borderLeft * index ) + ( borderRight * index ) + pillarWidth;
+				}
+
 
 				// The pillar should reflects exactly the shape of the hovered
 				// column border line.

--- a/tests/plugins/tableresize/manual/iebordercollapse.html
+++ b/tests/plugins/tableresize/manual/iebordercollapse.html
@@ -1,4 +1,19 @@
-<div id="editor">
+<h2>LTR</h2>
+<div id="ltr">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tr>
+			<td>Cell 1</td>
+			<td>Cell 2</td>
+		</tr>
+		<tr>
+			<td>Cell 3</td>
+			<td>Cell 4</td>
+		</tr>
+	</table>
+</div>
+
+<h2>RTL</h2>
+<div id="rtl">
 	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 		<tr>
 			<td>Cell 1</td>
@@ -17,5 +32,8 @@
 	}
 
 	CKEDITOR.addCss( 'table { border-collapse: collapse; }' );
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'ltr' );
+	CKEDITOR.replace( 'rtl', {
+		contentsLangDirection: 'rtl'
+	} );
 </script>

--- a/tests/plugins/tableresize/manual/iebordercollapse.html
+++ b/tests/plugins/tableresize/manual/iebordercollapse.html
@@ -1,0 +1,21 @@
+<div id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tr>
+			<td>Cell 1</td>
+			<td>Cell 2</td>
+		</tr>
+		<tr>
+			<td>Cell 3</td>
+			<td>Cell 4</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.ie || CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.addCss( 'table { border-collapse: collapse; }' );
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableresize/manual/iebordercollapse.md
+++ b/tests/plugins/tableresize/manual/iebordercollapse.md
@@ -1,26 +1,25 @@
 @bender-ui: collapsed
-@bender-tags: bug, 2823, 4.14.0
-@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, basicstyles, undo
+@bender-tags: bug, 2823, 4.14.1
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, basicstyles, undo, sourcearea
 
 ## Procedure
 1. Move mouse over the right table border (border after the last column).
 
-	### Expected
+### Expected
 
-	* Move cursor is visible.
+* Move cursor is visible.
+	Note: cursor can become visible slightly _before_ the right border.
 
-		Note: cursor can become visible slightly _after_ the right border.
+### Unexpected
 
-	### Unexpected
-
-	* Default cursor is visible.
+* Default cursor is visible.
 
 2. Try to resize table using that border.
 
-	### Expected
+### Expected
 
-	* Table is resized.
+* Table is resized.
 
-	### Unexpected
+### Unexpected
 
-	* Nothing happens.
+* Nothing happens.

--- a/tests/plugins/tableresize/manual/iebordercollapse.md
+++ b/tests/plugins/tableresize/manual/iebordercollapse.md
@@ -1,0 +1,26 @@
+@bender-ui: collapsed
+@bender-tags: bug, 2823, 4.14.0
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, basicstyles, undo
+
+## Procedure
+1. Move mouse over the right table border (border after the last column).
+
+	### Expected
+
+	* Move cursor is visible.
+
+		Note: cursor can become visible slightly _after_ the right border.
+
+	### Unexpected
+
+	* Default cursor is visible.
+
+2. Try to resize table using that border.
+
+	### Expected
+
+	* Table is resized.
+
+	### Unexpected
+
+	* Nothing happens.

--- a/tests/plugins/tableresize/manual/iebordercollapse.md
+++ b/tests/plugins/tableresize/manual/iebordercollapse.md
@@ -2,24 +2,28 @@
 @bender-tags: bug, 2823, 4.14.1
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, basicstyles, undo, sourcearea
 
-## Procedure
+_Perform test steps for both editors_.
+
+## Steps
+
 1. Move mouse over the right table border (border after the last column).
 
-### Expected
+  ### Expected
 
-* Move cursor is visible.
-	Note: cursor can become visible slightly _before_ the right border.
+  * Move cursor is visible.
 
-### Unexpected
+	**Note**: cursor can become visible slightly _before_ the right border.
 
-* Default cursor is visible.
+  ### Unexpected
+
+  * Default cursor is visible.
 
 2. Try to resize table using that border.
 
-### Expected
+  ### Expected
 
-* Table is resized.
+  * Table is resized.
 
-### Unexpected
+  ### Unexpected
 
-* Nothing happens.
+  * Nothing happens.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches which change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow CKEditor 4 code style guide?

Your code should follow guidelines from [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with code style guide

## What is the proposed changelog entry for this pull request?

```
*[#2823](https://github.com/ckeditor/ckeditor4/issues/2823): [IE] Fixed: Can't resize the last table column using [Table Resize](https://ckeditor.com/cke4/addon/tableresize) plugin.
```

## What changes did you make?

It seems that IE calculates widths incorrectly if table has `border-collapse: collapse` style. Moving pillar to the left to the equivalent distance of all cells borders + pillar width makes it work in IE11. However it' still buggy in IE8 and sometimes it becomes broken again after the first resize.

## Which issues your PR resolves?

Closes #2823.