### PR TITLE
Fix CORS issue for Emoji SVG icons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## CKEditor 4.14.1
 
+Fixed Issues:
+
+* [#2607](https://github.com/ckeditor/ckeditor4/issues/2607): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) SVG icons file is not loaded in CORS context.
+
 ## CKEditor 4.14
 
 **Security Updates:**

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -202,7 +202,7 @@
 						imgUrl,
 						useAttr;
 
-					if ( !this.isSVGSupported() ) {
+					if ( !this.editor.plugins.emoji.isSVGSupported() ) {
 						imgUrl = CKEDITOR.getUrl( this.plugin.path + 'assets/iconsall.png' );
 
 						itemTemplate = new CKEDITOR.template(
@@ -274,9 +274,6 @@
 					} );
 
 					return '<nav aria-label="' + htmlEncode( this.lang.navigationLabel ) + '"><ul>' + items + '</ul></nav>';
-				},
-				isSVGSupported: function() {
-					return !CKEDITOR.env.ie || CKEDITOR.env.edge;
 				},
 				createSearchSection: function() {
 					var self = this;
@@ -540,7 +537,7 @@
 				 * This method ensures that the icons are loaded locally.
 				*/
 				loadSVGNavigationIcons: function() {
-					if ( !this.isSVGSupported() ) {
+					if ( !this.editor.plugins.emoji.isSVGSupported() ) {
 						return;
 					}
 
@@ -683,6 +680,10 @@
 				new EmojiDropdown( editor, this );
 			}
 
+		},
+
+		isSVGSupported: function() {
+			return !CKEDITOR.env.ie || CKEDITOR.env.edge;
 		}
 	} );
 

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -346,7 +346,7 @@
 					var loupePngUrl = CKEDITOR.getUrl( this.plugin.path + 'assets/iconsall.png' ),
 						useAttr;
 
-					if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+					if ( !this.editor.plugins.emoji.isSVGSupported() ) {
 						return '<span class="cke_emoji-search_loupe" aria-hidden="true" style="background-image:url(' + loupePngUrl + ');"></span>';
 					} else {
 						useAttr = CKEDITOR.env.safari ? 'xlink:href="#cke4-icon-emoji-10"' : 'href="#cke4-icon-emoji-10"';

--- a/plugins/emoji/plugin.js
+++ b/plugins/emoji/plugin.js
@@ -140,9 +140,6 @@
 						self.blockElement = block.element;
 						self.emojiList = self.editor._.emoji.list;
 
-						// (#2607)
-						self.loadNavigationIcons();
-
 						self.addEmojiToGroups();
 
 						block.element.getAscendant( 'html' ).addClass( 'cke_emoji' );
@@ -189,6 +186,9 @@
 				createEmojiBlock: function() {
 					var output = [];
 
+					// (#2607)
+					this.loadSVGNavigationIcons();
+
 					output.push( this.createGroupsNavigation() );
 					output.push( this.createSearchSection() );
 					output.push( this.createEmojiListBlock() );
@@ -202,7 +202,7 @@
 						imgUrl,
 						useAttr;
 
-					if ( CKEDITOR.env.ie && !CKEDITOR.env.edge ) {
+					if ( !this.isSVGSupported() ) {
 						imgUrl = CKEDITOR.getUrl( this.plugin.path + 'assets/iconsall.png' );
 
 						itemTemplate = new CKEDITOR.template(
@@ -274,6 +274,9 @@
 					} );
 
 					return '<nav aria-label="' + htmlEncode( this.lang.navigationLabel ) + '"><ul>' + items + '</ul></nav>';
+				},
+				isSVGSupported: function() {
+					return !CKEDITOR.env.ie || CKEDITOR.env.edge;
 				},
 				createSearchSection: function() {
 					var self = this;
@@ -536,7 +539,11 @@
 				 *
 				 * This method ensures that the icons are loaded locally.
 				*/
-				loadNavigationIcons: function() {
+				loadSVGNavigationIcons: function() {
+					if ( !this.isSVGSupported() ) {
+						return;
+					}
+
 					var doc = this.blockElement.getDocument();
 
 					CKEDITOR.ajax.load( CKEDITOR.getUrl( this.plugin.path + 'assets/iconsall.svg' ), function( html ) {

--- a/plugins/emoji/skins/default.css
+++ b/plugins/emoji/skins/default.css
@@ -35,6 +35,9 @@
 }
 
 /* TOP NAVIGATION */
+.cke_emoji-navigation_icons {
+	display: none;
+}
 .cke_emoji-inner_panel > nav {
 	width: 100%;
 	height: 24px;

--- a/tests/plugins/emoji/dropdown.js
+++ b/tests/plugins/emoji/dropdown.js
@@ -1,5 +1,5 @@
 /* bender-tags: emoji */
-/* bender-ckeditor-plugins: emoji,toolbar,clipboard,undo */
+/* bender-ckeditor-plugins: emoji,ajax,toolbar,clipboard,undo */
 /* bender-include: _helpers/tools.js */
 /* global emojiTools */
 
@@ -358,6 +358,35 @@
 						panel.hide();
 					}
 				} );
+			} );
+		},
+
+		// (#2607)
+		'test SVG icons support': function() {
+			if ( !this.editor.plugins.emoji.isSVGSupported() ) {
+				assert.ignore();
+			}
+
+			var bot = this.editorBot;
+
+			bot.panel( 'EmojiPanel', function( panel ) {
+				var doc = panel._.iframe.getFrameDocument();
+
+				CKEDITOR.ajax.load( this.editor.plugins.emoji.path + 'assets/iconsall.svg', function( html ) {
+					var container = new CKEDITOR.dom.element( 'div' );
+
+					container.setHtml( html );
+
+					resume( function() {
+						var icons = doc.findOne( '.cke_emoji-navigation_icons' );
+
+						assert.beautified.html( container.getHtml(), icons.getHtml(), 'Icons should be loaded as a part of panel' );
+
+						panel.hide();
+					} );
+				} );
+
+				wait();
 			} );
 		}
 	} );

--- a/tests/plugins/emoji/manual/cors.html
+++ b/tests/plugins/emoji/manual/cors.html
@@ -10,8 +10,8 @@
 
 	doc.open();
 	// CDN points into commit revision with bug fix. To verify if test fails on older revision, replace CDN script with:
-	// doc.write( '<script src="https://cdn.jsdelivr.net/npm/ckeditor4@4.14.0/ckeditor.js"><\/script>' );
-	doc.write( '<script src="https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@3ab1c74/ckeditor.js"><\/script>' );
+	// doc.write( '<script src="https://raw.githack.com/ckeditor/ckeditor4/4.14.0/ckeditor.js"><\/script>' );
+	doc.write( '<script src="https://rawcdn.githack.com/ckeditor/ckeditor4/3ab1c74c3019ca61f1e3392f06d3870c032b482d/ckeditor.js"><\/script>' );
 	doc.write( '<div id="editor"></div>' );
 	doc.write( '<script>CKEDITOR.replace( "editor", { plugins: "wysiwygarea,toolbar,emoji" } )<\/script>' );
 	doc.close();

--- a/tests/plugins/emoji/manual/cors.html
+++ b/tests/plugins/emoji/manual/cors.html
@@ -1,0 +1,18 @@
+<iframe width="800px" height="400px" id="playground"></iframe>
+
+<script>
+	bender.tools.ignoreUnsupportedEnvironment( 'emoji' );
+
+	// Encapsulate testing environment inside iframe, so automatically loaded
+	// CKEDITOR by bender won't have impact on test result.
+	var playground = document.getElementById( 'playground' ),
+		doc = playground.contentWindow.document;
+
+	doc.open();
+	// CDN points into commit revision with bug fix. To verify if test fails on older revision, replace CDN script with:
+	// doc.write( '<script src="https://cdn.jsdelivr.net/npm/ckeditor4@4.14.0/ckeditor.js"><\/script>' );
+	doc.write( '<script src="https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@3ab1c74/ckeditor.js"><\/script>' );
+	doc.write( '<div id="editor"></div>' );
+	doc.write( '<script>CKEDITOR.replace( "editor", { plugins: "wysiwygarea,toolbar,emoji" } )<\/script>' );
+	doc.close();
+</script>

--- a/tests/plugins/emoji/manual/cors.md
+++ b/tests/plugins/emoji/manual/cors.md
@@ -1,0 +1,8 @@
+@bender-tags: 4.14.1, bug, emoji, 2607
+@bender-ui: collapsed
+
+Open emoji panel.
+
+**Expected:** Panel navigation icons are visible.
+
+**Unexpected:** Panel navigation icons are blank.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#2607](https://github.com/ckeditor/ckeditor4/issues/2607): Fixed: Emoji SVG icons are not loaded due to CORS .
```

## What changes did you make?

Instead of external SVG links, XML is moved inside emoji panel to get around CORS issue.

**Note** that manual test uses https://githack.com development CDN to emulate different domain context. It should be replaced with our CDN for `4.14.1` once released. Tell if you are fine with a manual tests, so I can extract a followup ticket for it.

## Which issues does your PR resolve?

Closes #2607
