### PR TITLE
Typo in Swedish

### DIFF
--- a/plugins/mathjax/lang/sv.js
+++ b/plugins/mathjax/lang/sv.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'mathjax', 'sv', {
-	title: 'Mattematik i TeX',
+	title: 'Matematik i TeX',
 	button: 'Matte',
 	dialogInput: 'Skriv din TeX här',
 	docUrl: 'http://en.wikibooks.org/wiki/LaTeX/Mathematics',


### PR DESCRIPTION
My Swedish colleagues say it should be `Matematik `instead of `Mattematik`

