### PR TITLE
Fix for: Selection throws error when pasting with Clipboard Access Prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#2607](https://github.com/ckeditor/ckeditor4/issues/2607): Fixed: [Emoji](https://ckeditor.com/cke4/addon/emoji) SVG icons file is not loaded in CORS context.
 * [#3866](https://github.com/ckeditor/ckeditor4/issues/3866): Fixed: [`config.readOnly`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-readOnly) config variable not considered for startup read-only mode of inline editor.
+* [#3931](https://github.com/ckeditor/ckeditor4/issues/3931): [IE] Fixed: Error is thrown when pasting using paste button after accepting browser Clipboard Access Prompt dialog.
 
 ## CKEditor 4.14
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -70,6 +70,10 @@
 		return true;
 	}
 
+	function isSupportingTableSelectionPlugin( editor ) {
+		return editor && editor.plugins.tableselection && editor.plugins.tableselection.isSupportedEnvironment( editor );
+	}
+
 	// After performing fake table selection, the real selection is limited
 	// to the first selected cell. Therefore to check if the real selection
 	// matches the fake selection, we check if the table cell from fake selection's
@@ -1971,7 +1975,7 @@
 			var editor = this.root.editor;
 
 			// Use fake selection on tables only with tableselection plugin (#3136).
-			if ( editor.plugins.tableselection && isTableSelection( ranges ) ) {
+			if ( isSupportingTableSelectionPlugin( editor ) && isTableSelection( ranges ) ) {
 				// Tables have it's own selection method.
 				performFakeTableSelection.call( this, ranges );
 				return;
@@ -2082,8 +2086,7 @@
 			}
 
 			// Handle special case - fake selection of table cells.
-			if ( editor && editor.plugins.tableselection &&
-				editor.plugins.tableselection.isSupportedEnvironment() &&
+			if ( isSupportingTableSelectionPlugin( editor ) &&
 				isTableSelection( ranges ) && !isSelectingTable &&
 				!ranges[ 0 ]._getTableElement( { table: 1 } ).hasAttribute( 'data-cke-tableselection-ignored' )
 			) {

--- a/tests/core/selection/manual/unlockerror.html
+++ b/tests/core/selection/manual/unlockerror.html
@@ -1,0 +1,17 @@
+<div>
+	<h1>Apollo 11</h1>
+	Lorem ipsum <b>dolor</b> sit <i>amet</i>, consectetur adipiscing elit. In commodo vulputate tempor. Sed &lt;b&gt;at elit&lt;/b&gt; vel ligula mollis aliquet a ac odio.
+	<pre>
+Aenean cursus egestas ipsum.
+	</pre>
+</div>
+
+<div id="editor"></div>
+
+<script>
+	if ( !CKEDITOR.env.ie || CKEDITOR.env.edge ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/selection/manual/unlockerror.md
+++ b/tests/core/selection/manual/unlockerror.md
@@ -1,0 +1,13 @@
+@bender-tags: selection, 4.14.1, bug, 3931
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, basicstyles, clipboard
+
+**Note:** Make sure that you have default level for Clipboard access. E.g. for IE 11 can change it in a browser options at `Internet Options > Security > Custom Level > Scripting > Allow Programmatic Clipboard Access > Prompt`.
+
+1. Open browser console.
+1. Copy HTML above the editor.
+1. Paste HTML into the editor using paste button.
+1. Make sure that Clipboard Access Prompt alert showed up.
+1. Allow Clipboard Access.
+
+**Expected:** No console error.

--- a/tests/core/selection/manual/unlockerror.md
+++ b/tests/core/selection/manual/unlockerror.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, basicstyles, clipboard
 
-**Note:** Make sure that you have default level for Clipboard access. E.g. for IE 11 can change it in a browser options at `Internet Options > Security > Custom Level > Scripting > Allow Programmatic Clipboard Access > Prompt`.
+**Note:** Make sure that you have default level for Clipboard access. For example in IE 11 you can change it in a browser options at: _Internet Options > Security > Custom Level > Scripting > Allow Programmatic Clipboard Access > Prompt_.
 
 1. Open browser console.
 1. Copy HTML above the editor.
@@ -10,4 +10,4 @@
 1. Make sure that Clipboard Access Prompt alert showed up.
 1. Allow Clipboard Access.
 
-**Expected:** No console error.
+  **Expected:** No console error. Content gets pasted.

--- a/tests/core/selection/selection.js
+++ b/tests/core/selection/selection.js
@@ -370,6 +370,22 @@ bender.test( {
 		assert.isTrue( sel.rev > initialRev, 'unlocked selection gets new rev' );
 	},
 
+	// (#3931)
+	'test unlock with no root editor': function() {
+		makeSelection( '<p>[abc]</p>' );
+
+		var sel = doc.getSelection();
+
+		sel.lock();
+
+		try {
+			sel.unlock( true );
+			assert.pass();
+		} catch ( e ) {
+			assert.fail();
+		}
+	},
+
 	'test unlock outdated selection 1': function() {
 		makeSelection( '<p>a[b<b id="bold">c]d</b></p>' );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
*[#3931 ](https://github.com/ckeditor/ckeditor4/issues/3931): [IE] Fixed: Error is thrown when pasting using paste button and Clipboard Access Prompt dialog.
```

## What changes did you make?

Simple check against undefined editor.

## Which issues does your PR resolve?

Closes #3931
