### PR TITLE
Strip non-word characters in anchor tag name/id

### DIFF
--- a/plugins/link/dialogs/anchor.js
+++ b/plugins/link/dialogs/anchor.js
@@ -48,8 +48,8 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 			    id = name.replace(/\W/g, '-'),
 				attributes = {
 					id: id,
-					name: name,
-					'data-cke-saved-name': name
+					name: id,
+					'data-cke-saved-name': id
 				},
 				selectedElement = this.getModel( editor );
 

--- a/plugins/link/dialogs/anchor.js
+++ b/plugins/link/dialogs/anchor.js
@@ -45,8 +45,9 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 		},
 		onOk: function() {
 			var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) ),
+			var id = name.replace(/\W/g, '-'),
 				attributes = {
-					id: name,
+					id: id,
 					name: name,
 					'data-cke-saved-name': name
 				},

--- a/plugins/link/dialogs/anchor.js
+++ b/plugins/link/dialogs/anchor.js
@@ -45,7 +45,7 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 		},
 		onOk: function() {
 			var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) ),
-			var id = name.replace(/\W/g, '-'),
+			    id = name.replace(/\W/g, '-'),
 				attributes = {
 					id: id,
 					name: name,


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug Fix / UX help

To help content authors create valid IDs on anchor tags. At the moment there doesn't appear to be any validation or modification of the ID attribute value that gets assigned to the anchor tag. This PR is not comprehensive but moves the needle in that it strips out non-word characters for the ID attribute. 

## Does your PR contain necessary tests? No

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

Steps to test:
1. Load up an editor with the link plugin enable and the anchor button available
2. Click on the anchor button and enter some random values into the dialogue form field. eg: "cke is W@@T"
3. Submit dialogue form and review source code in editor body
4. ID attribute on the anchor tag should be "cke-is-W--t" 

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide? Yes

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
*[#<ISSUE_NUMBER>](https://github.com/ckeditor/ckeditor4/issues/<ISSUE_NUMBER>): Stripped non-word characters from anchor tag id in link plugin. 
```

## What changes did you make?

Adds a replace function using the non-word filter `\W` to generate IDs

## Which issues does your PR resolve?
