### PR TITLE
Remove format button should work with collapsed selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixed Issues:
 * [#3000](https://github.com/ckeditor/ckeditor4/issues/3000): Fixed: [Auto Embed](https://ckeditor.com/cke4/addon/autoembed) doesn't work with [bottom toolbar location](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-toolbarLocation).
 * [#1883](https://github.com/ckeditor/ckeditor4/issues/1883): Fixed: [`editor.resize`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-resize) method doesn't work with CSS units.
 * [#3926](https://github.com/ckeditor/ckeditor4/issues/3926): Fixed: Dragging and dropping [Widget](https://ckeditor.com/cke4/addon/widget) sometimes produces an error.
+* [#4008](https://github.com/ckeditor/ckeditor4/issues/4008): Fixed: [Remove Format](https://ckeditor.com/cke4/addon/removeformat) doesn't work with collapsed selection.
 
 ## CKEditor 4.14
 

--- a/plugins/removeformat/plugin.js
+++ b/plugins/removeformat/plugin.js
@@ -32,17 +32,10 @@ CKEDITOR.plugins.removeformat = {
 					isElement = function( element ) {
 						return element.type == CKEDITOR.NODE_ELEMENT;
 					},
-					newRanges = [],
 					range;
 
 				while ( ( range = iterator.getNextRange() ) ) {
-					var bookmarkForRangeRecreation = range.createBookmark();
-					range = editor.createRange();
-					range.setStartBefore( bookmarkForRangeRecreation.startNode );
-					bookmarkForRangeRecreation.endNode && range.setEndAfter( bookmarkForRangeRecreation.endNode );
-
-					if ( !range.collapsed )
-						range.enlarge( CKEDITOR.ENLARGE_ELEMENT );
+					range.enlarge( CKEDITOR.ENLARGE_INLINE );
 
 					// Bookmark the range so we can re-select it after processing.
 					var bookmark = range.createBookmark(),
@@ -105,9 +98,7 @@ CKEDITOR.plugins.removeformat = {
 							// Cache the next node to be processed. Do it now, because
 							// currentNode may be removed.
 							var nextNode = currentNode.getNextSourceNode( false, CKEDITOR.NODE_ELEMENT ),
-								isFakeElement =
-									( currentNode.getName() == 'img' && currentNode.data( 'cke-realelement' ) ) ||
-									currentNode.hasAttribute( 'data-cke-bookmark' );
+								isFakeElement = currentNode.getName() == 'img' && currentNode.data( 'cke-realelement' );
 
 							// This node must not be a fake element, and must not be read-only.
 							if ( !isFakeElement && filter( editor, currentNode ) ) {
@@ -124,16 +115,13 @@ CKEDITOR.plugins.removeformat = {
 						}
 					}
 
-					bookmark.startNode.remove();
-					bookmark.endNode && bookmark.endNode.remove();
-					range.moveToBookmark( bookmarkForRangeRecreation );
-					newRanges.push( range );
+					range.moveToBookmark( bookmark );
 				}
 
 				// The selection path may not changed, but we should force a selection
 				// change event to refresh command states, due to the above attribution change. (https://dev.ckeditor.com/ticket/9238)
 				editor.forceNextSelectionCheck();
-				editor.getSelection().selectRanges( newRanges );
+				editor.getSelection().selectRanges( ranges );
 			}
 		}
 	},

--- a/tests/plugins/removeformat/manual/collapsed.html
+++ b/tests/plugins/removeformat/manual/collapsed.html
@@ -1,4 +1,4 @@
-<div id="editor"><strong>Hello,</strong></div>
+<div id="editor"></div>
 
 <script>
 	CKEDITOR.replace( 'editor' );

--- a/tests/plugins/removeformat/manual/collapsed.html
+++ b/tests/plugins/removeformat/manual/collapsed.html
@@ -1,0 +1,5 @@
+<div id="editor"><strong>Hello,</strong></div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/removeformat/manual/collapsed.md
+++ b/tests/plugins/removeformat/manual/collapsed.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.11.4, bug, 4008
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, removeformat, basicstyles
+
+1. Place selection at the end of the text - `Hello,^`.
+1. Press remove format button.
+1. Type `World!`.
+
+**Expected** Typed text is a plain text.
+
+**Unexpected** Typed text is bolded.

--- a/tests/plugins/removeformat/manual/collapsed.md
+++ b/tests/plugins/removeformat/manual/collapsed.md
@@ -2,10 +2,12 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, removeformat, basicstyles
 
-1. Place selection at the end of the text - `Hello,^`.
+1. Focus the editor.
+1. Press bold button.
+1. Type `Hello,`.
 1. Press remove format button.
-1. Type `World!`.
+1. Type `World!`
 
-**Expected** Typed text is a plain text.
+**Expected** Once remove button pressed, typed text in a plain text format. 
 
-**Unexpected** Typed text is bolded.
+**Unexpected** The whole typed text is bold, despite pressing remove format button.

--- a/tests/plugins/removeformat/manual/collapsed.md
+++ b/tests/plugins/removeformat/manual/collapsed.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.4, bug, 4008
+@bender-tags: 4.14.1, bug, 4008
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, removeformat, basicstyles
 
@@ -8,6 +8,6 @@
 1. Press remove format button.
 1. Type `World!`
 
-**Expected** Once remove button pressed, typed text in a plain text format. 
+**Expected** Once remove button pressed, typed text in a plain text format.
 
 **Unexpected** The whole typed text is bold, despite pressing remove format button.

--- a/tests/plugins/removeformat/manual/selection.md
+++ b/tests/plugins/removeformat/manual/selection.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.2, bug, 2451
+@bender-tags: 4.11.2, bug, 2451, 4.11.4, 4008
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, format, list, removeformat
 

--- a/tests/plugins/removeformat/manual/selection.md
+++ b/tests/plugins/removeformat/manual/selection.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.11.2, bug, 2451, 4.11.4, 4008
+@bender-tags: 4.11.2, bug, 2451, 4.14.1, 4008
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, format, list, removeformat
 

--- a/tests/plugins/removeformat/plugin.js
+++ b/tests/plugins/removeformat/plugin.js
@@ -173,5 +173,15 @@ bender.test(
 		editor.execCommand( 'removeFormat' );
 
 		assert.beautified.html( html, bender.tools.selection.getWithHtml( editor ), { customFilters: [ filter ] } );
+	},
+
+	// (#4008)
+	'test remove format with collapsed selection': function() {
+		this.editorBot.setHtmlWithSelection( '<p><strong>Hello,^</strong></p>' );
+
+		this.editor.execCommand( 'removeFormat' );
+		this.editor.insertText( 'World!' );
+
+		assert.areEqual( '<p><strong>Hello,</strong>World!</p>', this.editor.getData() );
 	}
 } );

--- a/tests/plugins/removeformat/plugin.js
+++ b/tests/plugins/removeformat/plugin.js
@@ -177,11 +177,13 @@ bender.test(
 
 	// (#4008)
 	'test remove format with collapsed selection': function() {
+		var editor = this.editor;
+
 		this.editorBot.setHtmlWithSelection( '<p><strong>Hello,^</strong></p>' );
 
-		this.editor.execCommand( 'removeFormat' );
-		this.editor.insertText( 'World!' );
+		editor.execCommand( 'removeFormat' );
+		editor.insertText( 'World!' );
 
-		assert.areEqual( '<p><strong>Hello,</strong>World!</p>', this.editor.getData() );
+		assert.areEqual( '<p><strong>Hello,</strong>World!</p>', editor.getData() );
 	}
 } );

--- a/tests/plugins/removeformat/plugin.js
+++ b/tests/plugins/removeformat/plugin.js
@@ -154,7 +154,7 @@ bender.test(
 		} );
 	},
 
-	// #2451
+	// (#2451)
 	'test remove format keeps selection': function() {
 		var editor = this.editor,
 			html = '<ol><li><h1>[Test]</h1></li></ol>',


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
*[#4008](https://github.com/ckeditor/ckeditor4/issues/4008): Fixed: [Remove format](https://ckeditor.com/cke4/addon/removeformat) doesn't work with collapsed selection.
```

## What changes did you make?

I reverted changes introduced in https://github.com/ckeditor/ckeditor4/pull/2625 as they seem not necessary and adds this regression. Remove format operates only on inline elements, which is nicely documented here: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removeFormatTags
Also, it seems like remove format indeed only breaks inline elements:https://github.com/ckeditor/ckeditor4/blob/846b07e0d7780ff1826685ed7a9f69c169c0c6d1/plugins/removeformat/plugin.js#L63-L64

so, enlarging range only for inline elements may be a good approach. I didn't note any special issues with skipping block elements and the issue https://github.com/ckeditor/ckeditor4/issues/2451 is still covered.

## Which issues does your PR resolve?

Closes #4008
