### PR TITLE
Fix widget plugin when keystorke is pressed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Fixed Issues:
 * [#4008](https://github.com/ckeditor/ckeditor4/issues/4008): Fixed: [Remove Format](https://ckeditor.com/cke4/addon/removeformat) doesn't work with collapsed selection.
 * [#909](https://github.com/ckeditor/ckeditor4/issues/909): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) plugin does not work when editor is placed in absolutely positioned container. Thanks to [Roland Petto](https://github.com/arpi68)!
 * [#1959](https://github.com/ckeditor/ckeditor4/issues/1959): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) plugin does not work in [maximized](https://ckeditor.com/cke4/addon/maximize) editor when [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) feature enabled. Thanks to [Roland Petto](https://github.com/arpi68)!
+* [#3998](https://github.com/ckeditor/ckeditor4/issues/3998): Fixed: Error thrown when switching to [Source Mode](https://ckeditor.com/cke4/addon/sourcearea) via custom `Ctrl` + `Enter` [keystroke](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setKeystroke) with [Widget](https://ckeditor.com/cke4/addon/widget) plugin present.
 
 ## CKEditor 4.14
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -288,6 +288,10 @@
 		 * This method is triggered by the {@link #event-checkSelection} event.
 		 */
 		checkSelection: function() {
+			if ( !this.editor.getSelection() ) {
+				return;
+			}
+
 			var sel = this.editor.getSelection(),
 				selectedElement = sel.getSelectedElement(),
 				updater = stateUpdater( this ),
@@ -2916,10 +2920,12 @@
 		// It's not possible to manually create selection which starts inside one widget and ends in another,
 		// so we are skipping this case to simplify implementation (#3498).
 		function fixCrossContentSelection() {
-			var selection = editor.getSelection(),
-				ranges = selection && selection.getRanges(),
-				range = ranges[ 0 ];
+			var selection = editor.getSelection();
+			if ( !selection ) {
+				return;
+			}
 
+			var range = selection.getRanges()[ 0 ];
 			if ( !range || range.collapsed ) {
 				return;
 			}

--- a/tests/plugins/widget/keystroke.js
+++ b/tests/plugins/widget/keystroke.js
@@ -1,0 +1,40 @@
+/* bender-tags: widgetcore, 3998 */
+/* bender-ckeditor-plugins: wysiwygarea,sourcearea,widget */
+
+( function() {
+	'use strict';
+
+	function pressCtrlEnter( editor ) {
+		editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 13 } ) );
+	}
+
+	bender.editor = {
+		config: {
+			keystrokes: [
+				[ CKEDITOR.CTRL + 13 /*Enter*/, 'source' ]
+			]
+		}
+	};
+
+	bender.test( {
+		// (#3998)
+		'test change wysiwyg mode to source mode by pressing keystroke': function() {
+			var editor = this.editor;
+
+			assert.areSame( 'wysiwyg', editor.mode, 'Wysiwyg mode is active at start.' );
+			pressCtrlEnter( editor );
+			assert.areSame( 'source', editor.mode, 'Source mode is active (changed from wysiwyg mode).' );
+		},
+
+		// (#3998)
+		'test change source mode to wysiwyg mode by pressing keystroke': function() {
+			var editor = this.editor;
+
+			assert.areSame( 'source', editor.mode, 'Source mode is active at start.' );
+			pressCtrlEnter( editor );
+			wait( function() {
+				assert.areSame( 'wysiwyg', editor.mode, 'Wysiwyg mode is active (changed from source mode).' );
+			}, 100 );
+		}
+	} );
+} )();

--- a/tests/plugins/widget/keystroke.js
+++ b/tests/plugins/widget/keystroke.js
@@ -8,33 +8,74 @@
 		editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: CKEDITOR.CTRL + 13 } ) );
 	}
 
-	bender.editor = {
-		config: {
-			keystrokes: [
-				[ CKEDITOR.CTRL + 13 /*Enter*/, 'source' ]
-			]
+	var currentError = null;
+	window.onerror = function( error ) {
+		currentError = error;
+	};
+
+	bender.editors = {
+		wysiwyg: {
+			config: {
+				keystrokes: [
+					[ CKEDITOR.CTRL + 13 /*Enter*/, 'source' ]
+				]
+			}
+		},
+		source: {
+			config: {
+				keystrokes: [
+					[ CKEDITOR.CTRL + 13 /*Enter*/, 'source' ]
+				],
+				startupMode: 'source'
+			}
 		}
 	};
 
 	bender.test( {
+		tearDown: function() {
+			currentError = null;
+		},
+
 		// (#3998)
 		'test change wysiwyg mode to source mode by pressing keystroke': function() {
-			var editor = this.editor;
+			var editor = this.editors.wysiwyg;
 
 			assert.areSame( 'wysiwyg', editor.mode, 'Wysiwyg mode is active at start.' );
+
+			editor.on( 'mode', function() {
+				resume( function() {
+					assert.areSame( 'source', editor.mode, 'Source mode is active (changed from wysiwyg mode).' );
+
+					if ( currentError ) {
+						assert.fail( currentError );
+					}
+				} );
+			} );
+
 			pressCtrlEnter( editor );
-			assert.areSame( 'source', editor.mode, 'Source mode is active (changed from wysiwyg mode).' );
+
+			wait();
 		},
 
 		// (#3998)
 		'test change source mode to wysiwyg mode by pressing keystroke': function() {
-			var editor = this.editor;
+			var editor = this.editors.source;
 
 			assert.areSame( 'source', editor.mode, 'Source mode is active at start.' );
+
+			editor.on( 'mode', function() {
+				resume( function() {
+					assert.areSame( 'wysiwyg', editor.mode, 'Wysiwyg mode is active (changed from source mode).' );
+
+					if ( currentError ) {
+						assert.fail( currentError );
+					}
+				} );
+			} );
+
 			pressCtrlEnter( editor );
-			wait( function() {
-				assert.areSame( 'wysiwyg', editor.mode, 'Wysiwyg mode is active (changed from source mode).' );
-			}, 100 );
+
+			wait();
 		}
 	} );
 } )();

--- a/tests/plugins/widget/manual/keystroke.html
+++ b/tests/plugins/widget/manual/keystroke.html
@@ -1,0 +1,11 @@
+<div id="editor">
+	Hello world.
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		keystrokes: [
+			[ CKEDITOR.CTRL + 13 /*Enter*/, 'source' ]
+		]
+	} );
+</script>

--- a/tests/plugins/widget/manual/keystroke.md
+++ b/tests/plugins/widget/manual/keystroke.md
@@ -2,11 +2,11 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, widget
 
-1. Open console in dev tools.
+1. Open browser dev console.
 
 1. Place cursor inside editor.
 
-1. Press <kbd>CTRL</kbd> and <kbd>Enter</kbd> key.
+1. Press <kbd>CTRL</kbd> + <kbd>Enter</kbd> key.
 
 	### Expected
 
@@ -14,11 +14,11 @@
 
 	### Unexpected
 
-	Error appears in dev console or source mode editor is not opened.
+	Error appears in dev console or source mode is not opened.
 
 1. Place cursor inside editor.
 
-1. Press <kbd>CTRL</kbd> and <kbd>Enter</kbd> key.
+1. Press <kbd>CTRL</kbd> + <kbd>Enter</kbd> key.
 
 	### Expected
 
@@ -26,4 +26,4 @@
 
 	### Unexpected
 
-	Error appears in dev console or WYSIWYG area is not opened.
+	Error appears in dev console or WYSIWYG mode is not opened.

--- a/tests/plugins/widget/manual/keystroke.md
+++ b/tests/plugins/widget/manual/keystroke.md
@@ -1,0 +1,29 @@
+@bender-tags: widget, bug, 4.14.1, 3998
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, widget
+
+1. Open console in dev tools.
+
+1. Place cursor inside editor.
+
+1. Press <kbd>CTRL</kbd> and <kbd>Enter</kbd> key.
+
+	### Expected
+
+	Source mode is opened and no error appears in dev console.
+
+	### Unexpected
+
+	Error appears in dev console or source mode editor is not opened.
+
+1. Place cursor inside editor.
+
+1. Press <kbd>CTRL</kbd> and <kbd>Enter</kbd> key.
+
+	### Expected
+
+	Editor switches to WYSIWYG mode. No error appears in dev console.
+
+	### Unexpected
+
+	Error appears in dev console or WYSIWYG area is not opened.


### PR DESCRIPTION
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Bug fix.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
*[#3998](https://github.com/ckeditor/ckeditor4/issues/3998): Fix widget plugin when using keystrokes to get to source code.
```

## What changes did you make?

Added some checks if selection inside widget.js is null.

## Which issues does your PR resolve?

Closes #3998.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
