### PR TITLE
Fix failing test tests/core/creators/themedui

### DIFF
--- a/tests/core/creators/themedui.js
+++ b/tests/core/creators/themedui.js
@@ -73,10 +73,11 @@
 					height = 50 + unitsToTest[i];
 
 				editor.resize( width, height );
-				assert.areSame( CKEDITOR.tools.convertToPx( height ), lastResizeData.outerHeight );
-				assert.areSame( CKEDITOR.tools.convertToPx( width ), lastResizeData.outerWidth );
-				assert.areSame( getEditorContentHeight( editor ), lastResizeData.contentsHeight );
-				assert.areSame( CKEDITOR.tools.convertToPx( height ), getEditorOuterHeight( editor ) );
+
+				assert.areSame( CKEDITOR.tools.convertToPx( height ), lastResizeData.outerHeight, 'Outer event height in ' + unitsToTest[ i ] + ' is incorrect.' );
+				assert.areSame( CKEDITOR.tools.convertToPx( height ), getEditorOuterHeight( editor ), 'Outer calculated height in ' + unitsToTest[ i ] + ' is incorrect.' );
+				assert.areSame( getEditorContentHeight( editor ), lastResizeData.contentsHeight, 'Content event height in ' + unitsToTest[ i ] + ' is incorrect.' );
+				assert.areSame( CKEDITOR.tools.convertToPx( width ), lastResizeData.outerWidth, 'Width in ' + unitsToTest[ i ] + ' is incorrect.' );
 			}
 		},
 
@@ -115,10 +116,11 @@
 					height = 50 + unitsToTest[i];
 
 				editor.resize( width, height, false, true );
-				assert.areSame( getEditorInnerHeight( editor ), lastResizeData.outerHeight );
-				assert.areSame( CKEDITOR.tools.convertToPx( width ), lastResizeData.outerWidth );
-				assert.areSame( getEditorContentHeight( editor ), lastResizeData.contentsHeight );
-				assert.areSame( CKEDITOR.tools.convertToPx( height ), getEditorInnerHeight( editor ) );
+
+				assert.areSame( getEditorInnerHeight( editor ), lastResizeData.outerHeight, 'Outer event height in ' + unitsToTest[ i ] + ' is incorrect.' );
+				assert.areSame( getEditorContentHeight( editor ), lastResizeData.contentsHeight, 'Content event height in ' + unitsToTest[ i ] + ' is incorrect.' );
+				assert.areSame( CKEDITOR.tools.convertToPx( height ), getEditorInnerHeight( editor ), 'Inner calculated height in ' + unitsToTest[ i ] + ' is incorrect.' );
+				assert.areSame( CKEDITOR.tools.convertToPx( width ), lastResizeData.outerWidth, 'Width in ' + unitsToTest[ i ] + ' is incorrect.' );
 			}
 		}
 	} );

--- a/tests/core/creators/themedui.js
+++ b/tests/core/creators/themedui.js
@@ -70,7 +70,7 @@
 
 			for ( var i = 0; i < unitsToTest.length; i++ ) {
 				var width = 20 + unitsToTest[i],
-					height = 50 + unitsToTest[i];
+					height = 100 + unitsToTest[i];
 
 				editor.resize( width, height );
 
@@ -92,7 +92,7 @@
 
 			for ( var i = 0; i < unitsToTest.length; i++ ) {
 				var width = 20 + unitsToTest[i],
-					height = 50 + unitsToTest[i];
+					height = 100 + unitsToTest[i];
 
 				editor.resize( width, height, true );
 				assert.areSame( getEditorOuterHeight( editor ), lastResizeData.outerHeight );
@@ -113,7 +113,7 @@
 
 			for ( var i = 0; i < unitsToTest.length; i++ ) {
 				var width = 20 + unitsToTest[i],
-					height = 50 + unitsToTest[i];
+					height = 100 + unitsToTest[i];
 
 				editor.resize( width, height, false, true );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix (failing tests)

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

none

## What changes did you make?

Failing tests resize the editor to `50pt`. It works fine on dev version, but not on built one. However in both cases the toolbar is manually set to contain just one button (`table`), so what is the problem? The other plugins changing UI - `resize` and `elementspath`. Because of them editor can't be resized to the desired `50pt`. To solve it I just changed the test `height` from `50pt` to `100pt`.

## Which issues does your PR resolve?

Closes #4084.
