### PR TITLE
Fix autocomplete navigation with multiple instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CKEditor 4 Changelog
 Fixed Issues:
 
 * [#3795](https://github.com/ckeditor/ckeditor4/issues/3795): Fixed: Setting [`dataIndentationChars`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-dataIndentationChars) config option to an empty string is ignored and replaced by a tab (`\t`) character. Thanks to [Thomas Grinderslev](https://github.com/Znegl)!
+* [#4107](https://github.com/ckeditor/ckeditor4/issues/4107): Fixed: Multiple [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) instances cause keyboard navigation issues.
 
 ## CKEditor 4.14.1
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -298,7 +298,12 @@
 				this.registerPanelNavigation();
 			}
 
-			editor.on( 'contentDom', this.registerPanelNavigation, this );
+			// Note: CKEditor's event system has a limitation that one function
+			// cannot be used as listener for the same event more than once. Hence, wrapper function.
+			// (#4107)
+			editor.on( 'contentDom', function() {
+				this.registerPanelNavigation();
+			}, this );
 		},
 
 		registerPanelNavigation: function() {

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -162,26 +162,33 @@
 			wait();
 		},
 
-		// (#3938)
+		// (#3938, #4107)
 		'test navigation keybindings are registered after changing mode': function() {
 			var editor = this.editors.source,
-				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
+				bot = this.editorBots.standard,
+				ac1 = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				ac2 = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
 
 			editor.setMode( 'source', function() {
 				editor.setMode( 'wysiwyg', function() {
 					resume( function() {
-						var spy = sinon.spy( ac, 'onKeyDown' );
-
-						this.editorBots.standard.setHtmlWithSelection( '' );
-
-						editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {} ) );
-
-						spy.restore();
-
-						assert.isTrue( spy.called );
+						testPanelEvents( ac1, 'The first autocomplete navigation bindings should work' );
+						testPanelEvents( ac2, 'The second autocomplete navigation bindings should work' );
 					} );
 				} );
 			} );
+
+			function testPanelEvents( autocomplete, msg ) {
+				var spy = sinon.spy( autocomplete, 'onKeyDown' );
+
+				bot.setHtmlWithSelection( '' );
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( {} ) );
+
+				spy.restore();
+
+				assert.isTrue( spy.called, msg );
+			}
 
 			wait();
 		},

--- a/tests/plugins/autocomplete/manual/sourcemode.html
+++ b/tests/plugins/autocomplete/manual/sourcemode.html
@@ -1,0 +1,29 @@
+<textarea id="editor"></textarea>
+
+<script>
+	var feed = [
+		'john',
+		'thomas',
+		'anna',
+		'annabelle',
+		'cris',
+		'julia'
+	];
+
+	var editor = CKEDITOR.replace( 'editor', {
+		width: 600,
+		mentions: [
+			{
+				feed: feed,
+				minChars: 0
+			},
+			{
+				feed: feed,
+				minChars: 0,
+				marker: '#'
+			}
+		]
+	} );
+
+	bender.tools.ignoreUnsupportedEnvironment( 'mentions', editor );
+</script>

--- a/tests/plugins/autocomplete/manual/sourcemode.md
+++ b/tests/plugins/autocomplete/manual/sourcemode.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.14.2, bug, 4107
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, mentions, sourcearea
+
+1. Toggle source mode.
+1. Focus the editor.
+1. Type `@` to open completion panel.
+1. Navigate through items using arrow keys.
+1. Close completion panel using `esc` key.
+1. Type `#` to open completion panel.
+1. Navigate through items using arrow keys.
+
+## Expected
+
+For both completion panels under `@` and `#` characters, you should be able to navigate through items using arrow keys.
+
+## Unexpected
+
+Navigation keys doesn't work for both or one of completion panels after toggling source mode.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
*[#4107](https://github.com/ckeditor/ckeditor4/issues/4107): Multiple autocomplete instances cause keyboard navigation issues.
```

## What changes did you make?

Again our event system did a small trick and didn't allow to register the same method multiple times.

## Which issues does your PR resolve?

Closes #4107
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
