### PR TITLE
Add aria-expanded attribute for rich combo buttons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#4107](https://github.com/ckeditor/ckeditor4/issues/4107): Fixed: Multiple [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) instances cause keyboard navigation issues.
 * [#4041](https://github.com/ckeditor/ckeditor4/issues/4041): Fixed: [`selection.scrollIntoView`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_selection.html#method-scrollIntoView) method throws an error when editor selection is not set.
 * [#3361](https://github.com/ckeditor/ckeditor4/issues/3361): Fixed: Loading multiple [custom editor configurations](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig) is prone to race condition between them.
+* [#4007](https://github.com/ckeditor/ckeditor4/issues/4007): Fixed: Screen readers don't announce [Rich Combo](https://ckeditor.com/cke4/addon/richcombo) plugin is collapsed/expanded.
 
 ## CKEditor 4.14.1
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -373,12 +373,18 @@ CKEDITOR.plugins.add( 'richcombo', {
 				if ( this._.state == state )
 					return;
 
-				var el = this.document.getById( 'cke_' + this.id );
+				var el = this.document.getById( 'cke_' + this.id ),
+					linkEl = el.getElementsByTag( 'a' ).getItem( 0 );
+
 				el.setState( state, 'cke_combo' );
 
 				state == CKEDITOR.TRISTATE_DISABLED ?
 					el.setAttribute( 'aria-disabled', true ) :
 					el.removeAttribute( 'aria-disabled' );
+
+				if ( linkEl ) {
+					linkEl.setAttribute( 'aria-expanded', state == CKEDITOR.TRISTATE_ON );
+				}
 
 				this._.state = state;
 			},

--- a/tests/plugins/richcombo/manual/ariaexpanded.html
+++ b/tests/plugins/richcombo/manual/ariaexpanded.html
@@ -1,0 +1,11 @@
+<h2>Classic editor</h2>
+
+<textarea id="editor">
+	<p>I'm CKEditor 4 instance.</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		lang: 'en'
+	} );
+</script>

--- a/tests/plugins/richcombo/manual/ariaexpanded.html
+++ b/tests/plugins/richcombo/manual/ariaexpanded.html
@@ -5,6 +5,10 @@
 </textarea>
 
 <script>
+	if ( CKEDITOR.env.ie || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor', {
 		lang: 'en'
 	} );

--- a/tests/plugins/richcombo/manual/ariaexpanded.md
+++ b/tests/plugins/richcombo/manual/ariaexpanded.md
@@ -1,0 +1,29 @@
+@bender-ui: collapsed
+@bender-tags: 4007, 4.14.2, bug
+@bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
+
+**Note:** This is the test for screen readers, so open one before testing.
+
+1. Press <kbd>Tab</kbd> key multiple times to move focus to the editor.
+1. Press <kbd>Alt+F10</kbd> to switch focus to the toolbar and navigate to the `Styles` combo.
+
+  **Expected:**
+
+  * ChromeVox, NVDA, Narrator, VoiceOver - announced the list is collapsed.
+  * JAWS announced how to navigate through dropdown in its own way.
+
+  **Unexpected:**
+
+  Screen reader didn't announce that combo is collapsed.
+
+1. Press <kbd>Space</kbd>.
+
+  **Expected:**
+
+  * ChromeVox and NVDA - announced the list is expanded.
+  * Narrator and VoiceOver - didn't announce the list is expanded (they follow the browser focus too quickly and move to the list itself).
+  * JAWS announced how to navigate through dropdown in its own way.
+
+  **Unexpected:**
+
+  Different behaviour than described above (depending on the screen reader).

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -61,6 +61,34 @@ bender.test( {
 		assert.areEqual( anchorEl.getAttribute( 'aria-haspopup' ), 'listbox' );
 	},
 
+	// (#4007)
+	'test richcombo has aria-expanded=false attribute set at initialisation': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo' ),
+			comboBtn = CKEDITOR.document.findOne( '#cke_' + combo.id + ' .cke_combo_button' );
+
+		combo.createPanel( editor );
+
+		assert.areEqual( 'false', comboBtn.getAttribute( 'aria-expanded' ), 'Aria-expanded attribute should be set at the element creation.' );
+	},
+
+	// (#4007)
+	'test richcombo has aria-expanded=true attribute set when opened': function() {
+		var editor = this.editor,
+			bot = this.editorBot,
+			activeCombo = editor.ui.get( 'custom_combo' ),
+			inactiveCombo = editor.ui.get( 'custom_combo_with_options' ),
+			activeComboBtn = CKEDITOR.document.findOne( '#cke_' + activeCombo.id + ' .cke_combo_button' ),
+			inactiveComboBtn = CKEDITOR.document.findOne( '#cke_' + inactiveCombo.id + ' .cke_combo_button' );
+
+		activeCombo.createPanel( editor );
+
+		bot.combo( 'custom_combo', function() {
+			assert.areEqual( 'true', activeComboBtn.getAttribute( 'aria-expanded' ), 'Aria-expanded attribute was not set to true.' );
+			assert.areEqual( 'false', inactiveComboBtn.getAttribute( 'aria-expanded' ), 'Aria-expanded attribute of different combo was changed' );
+		} );
+	},
+
 	// (#1477)
 	'test destroy removes combo listeners': function() {
 		var combo = this.editor.ui.get( 'custom_combo' ),


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4007](https://github.com/ckeditor/ckeditor4/issues/4007): Fixed: Screen readers don't announce [`Rich Combo` plugin](https://ckeditor.com/cke4/addon/richcombo) is collapsed/expanded.
```

## What changes did you make?

`aria-expanded` attribute with `false` value is now added at the combo initialisation and toggled when the according command state changes. Note that the SR announces it differently depending on the screen reader used:

* ChromeVox and NVDA - works fine: announces that list is collapsed/expanded.
* Narrator (Windows) and VoiceOver (MacOS) - only announces the list is collapsed; when it's opened, the focus jumps straight to the combo options and reader doesn't take time to say the list state changed. I'm not sure it can be helped anyhow though.
* JAWS announces how to navigate through dropdown in its own way, but in general it works fine.

## Which issues does your PR resolve?

Closes #4007.
