### PR TITLE
Fix customConfig race condition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#3795](https://github.com/ckeditor/ckeditor4/issues/3795): Fixed: Setting [`dataIndentationChars`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-dataIndentationChars) config option to an empty string is ignored and replaced by a tab (`\t`) character. Thanks to [Thomas Grinderslev](https://github.com/Znegl)!
 * [#4107](https://github.com/ckeditor/ckeditor4/issues/4107): Fixed: Multiple [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) instances cause keyboard navigation issues.
 * [#4041](https://github.com/ckeditor/ckeditor4/issues/4041): Fixed: [`selection.scrollIntoView`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_selection.html#method-scrollIntoView) method throws an error when editor selection is not set.
+* [#3361](https://github.com/ckeditor/ckeditor4/issues/3361): Fixed: Loading multiple [custom editor configurations](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig) is prone to race condition between them.
 
 ## CKEditor 4.14.1
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -260,8 +260,9 @@
 		var customConfig = editor.config.customConfig;
 
 		// Check if there is a custom config to load.
-		if ( !customConfig )
+		if ( !customConfig ) {
 			return false;
+		}
 
 		customConfig = CKEDITOR.getUrl( customConfig );
 
@@ -275,19 +276,19 @@
 
 			// If there is no other customConfig in the chain, fire the
 			// "configLoaded" event.
-			if ( CKEDITOR.getUrl( editor.config.customConfig ) == customConfig || !loadConfig( editor ) )
+			if ( CKEDITOR.getUrl( editor.config.customConfig ) == customConfig || !loadConfig( editor ) ) {
 				editor.fireOnce( 'customConfigLoaded' );
+			}
+
 		} else {
 			// Load the custom configuration file.
 			// To resolve customConfig race conflicts, use scriptLoader#queue
 			// instead of scriptLoader#load (https://dev.ckeditor.com/ticket/6504).
 			CKEDITOR.scriptLoader.queue( customConfig, function() {
-				// If the CKEDITOR.editorConfig function has been properly
-				// defined in the custom configuration file, cache it.
-				if ( CKEDITOR.editorConfig )
-					loadedConfig.fn = CKEDITOR.editorConfig;
-				else
-					loadedConfig.fn = function() {};
+				// Cache config if it has been properly set using `editorConfig`,
+				// but make sure to not overwrite existing cache if the same config has
+				// been loaded multiple times by different editors (#3361).
+				loadedConfig.fn = loadedConfig.fn || CKEDITOR.editorConfig || function() {};
 
 				// Call the load config again. This time the custom
 				// config is already cached and so it will get loaded.

--- a/tests/core/editor/custom_config_race.js
+++ b/tests/core/editor/custom_config_race.js
@@ -1,41 +1,66 @@
 /* bender-tags: editor */
 
-var assetsPath = '%TEST_DIR%_assets/',
-	instances = {},
-	initEditors = ( function() {
-		var count = 0;
+var assetsPath = '%TEST_DIR%_assets/';
 
-		return function( editors, callback ) {
-			var total = CKEDITOR.tools.object.keys( editors ).length;
+function initEditors( editors ) {
+	var count = 0;
+	var instances = {};
 
-			for ( var e in editors ) {
-				instances[ e ] = CKEDITOR.replace( e,
-					CKEDITOR.tools.extend( editors[ e ], {
-						plugins: 'wysiwygarea',
-						on: {
-							instanceReady: function() {
-								if ( ++count == total )
-									callback();
+	return function( callback ) {
+		var total = CKEDITOR.tools.object.keys( editors ).length;
+
+		for ( var e in editors ) {
+			instances[ e ] = CKEDITOR.replace( e,
+				CKEDITOR.tools.extend( editors[ e ], {
+					plugins: 'wysiwygarea',
+					on: {
+						instanceReady: function() {
+							if ( ++count == total ) {
+								resume( function() {
+									callback( instances );
+								} );
 							}
 						}
-					} )
-				);
-			}
-		};
-	} )();
+					}
+				} )
+			);
+		}
+
+		wait();
+	};
+}
 
 bender.test( {
-	'async:init': function() {
+	tearDown: function() {
+		for ( var editorName in CKEDITOR.instances ) {
+			CKEDITOR.instances[ editorName ].destroy();
+		}
+	},
+
+	// (#3361)
+	'test race of customConfigs with reused config': function() {
+		initEditors( {
+			editor1: { customConfig: assetsPath + 'raceconfig1.js' },
+			editor2: { customConfig: assetsPath + 'raceconfig2.js' },
+			editor3: { customConfig: assetsPath + 'raceconfig1.js' }
+		} )
+		( function( instances ) {
+			assert.areSame( '200px', instances.editor1.config.width, 'Instance uses own customConfig.' );
+			assert.areSame( '300px', instances.editor2.config.width, 'Instance uses own customConfig.' );
+			assert.areSame( '200px', instances.editor3.config.width, 'Instance uses own customConfig.' );
+		} );
+	},
+
+	'test race of customConfigs': function() {
 		initEditors( {
 			editor1: { customConfig: assetsPath + 'raceconfig1.js' },
 			editor2: { customConfig: assetsPath + 'raceconfig2.js' },
 			editor3: { customConfig: assetsPath + 'raceconfig3.js' }
-		}, this.callback );
-	},
-
-	'test race of customConfigs': function() {
-		assert.areSame( '200px', instances.editor1.config.width, 'Instance uses own customConfig.' );
-		assert.areSame( '300px', instances.editor2.config.width, 'Instance uses own customConfig.' );
-		assert.areSame( '400px', instances.editor3.config.width, 'Instance uses own customConfig.' );
+		} )
+		( function( instances ) {
+			assert.areSame( '200px', instances.editor1.config.width, 'Instance uses own customConfig.' );
+			assert.areSame( '300px', instances.editor2.config.width, 'Instance uses own customConfig.' );
+			assert.areSame( '400px', instances.editor3.config.width, 'Instance uses own customConfig.' );
+		} );
 	}
 } );

--- a/tests/core/editor/custom_config_race.js
+++ b/tests/core/editor/custom_config_race.js
@@ -3,27 +3,29 @@
 var assetsPath = '%TEST_DIR%_assets/';
 
 function initEditors( editors ) {
-	var count = 0;
-	var instances = {};
+	var count = 0,
+		instances = {};
 
 	return function( callback ) {
 		var total = CKEDITOR.tools.object.keys( editors ).length;
 
-		for ( var e in editors ) {
-			instances[ e ] = CKEDITOR.replace( e,
-				CKEDITOR.tools.extend( editors[ e ], {
-					plugins: 'wysiwygarea',
-					on: {
-						instanceReady: function() {
-							if ( ++count == total ) {
-								resume( function() {
-									callback( instances );
-								} );
-							}
+		for ( var editorName in editors ) {
+			var config = CKEDITOR.tools.extend( editors[ editorName ], {
+				plugins: 'wysiwygarea',
+				on: {
+					instanceReady: function() {
+						count++;
+
+						if ( count == total ) {
+							resume( function() {
+								callback( instances );
+							} );
 						}
 					}
-				} )
-			);
+				}
+			} );
+
+			instances[ editorName ] = CKEDITOR.replace( editorName, config );
 		}
 
 		wait();
@@ -45,9 +47,9 @@ bender.test( {
 			editor3: { customConfig: assetsPath + 'raceconfig1.js' }
 		} )
 		( function( instances ) {
-			assert.areSame( '200px', instances.editor1.config.width, 'Instance uses own customConfig.' );
-			assert.areSame( '300px', instances.editor2.config.width, 'Instance uses own customConfig.' );
-			assert.areSame( '200px', instances.editor3.config.width, 'Instance uses own customConfig.' );
+			assert.areSame( '200px', instances.editor1.config.width, 'editor1 instance should use its own custom config' );
+			assert.areSame( '300px', instances.editor2.config.width, 'editor2 instance should use its own custom config' );
+			assert.areSame( '200px', instances.editor3.config.width, 'editor3 instance should use its own custom config' );
 		} );
 	},
 
@@ -58,9 +60,9 @@ bender.test( {
 			editor3: { customConfig: assetsPath + 'raceconfig3.js' }
 		} )
 		( function( instances ) {
-			assert.areSame( '200px', instances.editor1.config.width, 'Instance uses own customConfig.' );
-			assert.areSame( '300px', instances.editor2.config.width, 'Instance uses own customConfig.' );
-			assert.areSame( '400px', instances.editor3.config.width, 'Instance uses own customConfig.' );
+			assert.areSame( '200px', instances.editor1.config.width, 'editor1 instance should use its own custom config' );
+			assert.areSame( '300px', instances.editor2.config.width, 'editor2 instance should use its own custom config' );
+			assert.areSame( '400px', instances.editor3.config.width, 'editor3 instance should use its own custom config' );
 		} );
 	}
 } );

--- a/tests/core/editor/manual/customconfigrace.html
+++ b/tests/core/editor/manual/customconfigrace.html
@@ -8,7 +8,7 @@
 <script>
 	var assetsPath = '%BASE_PATH%core/editor/_assets/',
 		config1 = assetsPath + 'raceconfig1.js',
-		config2 = assetsPath + 'raceconfig3.js';
+		config2 = assetsPath + 'raceconfig2.js';
 
 	CKEDITOR.replace( 'editor1', {
 		customConfig: config1

--- a/tests/core/editor/manual/customconfigrace.html
+++ b/tests/core/editor/manual/customconfigrace.html
@@ -1,0 +1,24 @@
+<h2>Editor 1</h2>
+<div id="editor1"></div>
+<h2>Editor 2</h2>
+<div id="editor2"></div>
+<h2>Editor 3</h2>
+<div id="editor3"></div>
+
+<script>
+	var assetsPath = '%BASE_PATH%core/editor/_assets/',
+		config1 = assetsPath + 'raceconfig1.js',
+		config2 = assetsPath + 'raceconfig3.js';
+
+	CKEDITOR.replace( 'editor1', {
+		customConfig: config1
+	} );
+
+	CKEDITOR.replace( 'editor2', {
+		customConfig: config2
+	} );
+
+	CKEDITOR.replace( 'editor3', {
+		customConfig: config1
+	} );
+</script>

--- a/tests/core/editor/manual/customconfigrace.md
+++ b/tests/core/editor/manual/customconfigrace.md
@@ -7,8 +7,8 @@ Verify editors width.
 ## Expected
 
 * Editor 1 and Editor 3 have the same width (`200px`).
-* Editor 2 have different width (`400px`).
+* Editor 2 have different width (`300px`).
 
 ## Unexpected
 
-Editor 2 and Editor 3 have the same width. (`400px`).
+Editor 2 and Editor 3 have the same width. (`300px`).

--- a/tests/core/editor/manual/customconfigrace.md
+++ b/tests/core/editor/manual/customconfigrace.md
@@ -1,0 +1,14 @@
+@bender-tags: bug, 4.14.2, 3361
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles
+
+Verify editors width.
+
+## Expected
+
+* Editor 1 and Editor 3 have the same width (`200px`).
+* Editor 2 have different width (`400px`).
+
+## Unexpected
+
+Editor 2 and Editor 3 have the same width. (`400px`).


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3361](https://github.com/ckeditor/ckeditor4/issues/3361): Fixed: Loading multiple [custom editor configurations](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig) is prone to race condition between them.
```

## What changes did you make?

Honestly, I was really wondering about rewriting the whole `customConfig` loading as it could be nicely simplified and the current implementation is pretty bloated. Although, it's not a very good idea to do with a core code 10 years old. I propose simple fix instead, making sure that we won't overwrite cached config functor by a closure race condition. 

## Which issues does your PR resolve?

Closes #3361.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
