### PR TITLE
Remove block styles when changing format if a new block format doesn't contain them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ CKEditor 4 Changelog
 Fixed Issues:
 
 * [#3961](https://github.com/ckeditor/ckeditor4/issues/3961): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) prevents editing of merged cells.
+* [#3649](https://github.com/ckeditor/ckeditor4/issues/3649): Fixed: Applying a [block format](https://ckeditor.com/docs/ckeditor4/latest/features/format.html) should remove existing block styles.
+
+API Changes:
+
+* [#3649](https://github.com/ckeditor/ckeditor4/issues/3649): Added new [stylesRemove](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-stylesRemove) editor event.
 
 Other Changes:
 

--- a/core/style.js
+++ b/core/style.js
@@ -1659,23 +1659,26 @@ CKEDITOR.STYLE_OBJECT = 3;
 			elementName = style.element;
 
 		// The "*" element name will always be a span for this function.
-		if ( elementName == '*' )
+		if ( elementName == '*' ) {
 			elementName = 'span';
+		}
 
 		// Create the element.
 		el = new CKEDITOR.dom.element( elementName, targetDocument );
 
 		// https://dev.ckeditor.com/ticket/6226: attributes should be copied before the new ones are applied
-		if ( element )
+		if ( element ) {
 			element.copyAttributes( el );
+		}
 
 		el = setupElement( el, style );
 
 		// Avoid ID duplication.
-		if ( targetDocument.getCustomData( 'doc_processing_style' ) && el.hasAttribute( 'id' ) )
+		if ( targetDocument.getCustomData( 'doc_processing_style' ) && el.hasAttribute( 'id' ) ) {
 			el.removeAttribute( 'id' );
-		else
+		} else {
 			targetDocument.setCustomData( 'doc_processing_style', 1 );
+		}
 
 		return el;
 	}

--- a/core/style.js
+++ b/core/style.js
@@ -1686,9 +1686,8 @@ CKEDITOR.STYLE_OBJECT = 3;
 			styles = CKEDITOR.style.getStyleText( def );
 
 		// Assign all defined attributes.
-		if ( attributes ) {
-			for ( var att in attributes )
-				el.setAttribute( att, attributes[ att ] );
+		for ( var att in attributes ) {
+			el.setAttribute( att, attributes[ att ] );
 		}
 
 		// Assign all defined styles.

--- a/core/style.js
+++ b/core/style.js
@@ -1690,7 +1690,7 @@ CKEDITOR.STYLE_OBJECT = 3;
 			el.setAttribute( att, attributes[ att ] );
 		}
 
-		// Assign all defined styles.
+		// Assign all defined styles. If new format doesn't have any styles, remove the existing ones (#3649).
 		if ( styles ) {
 			el.setAttribute( 'style', styles );
 		} else {

--- a/core/style.js
+++ b/core/style.js
@@ -1659,26 +1659,23 @@ CKEDITOR.STYLE_OBJECT = 3;
 			elementName = style.element;
 
 		// The "*" element name will always be a span for this function.
-		if ( elementName == '*' ) {
+		if ( elementName == '*' )
 			elementName = 'span';
-		}
 
 		// Create the element.
 		el = new CKEDITOR.dom.element( elementName, targetDocument );
 
 		// https://dev.ckeditor.com/ticket/6226: attributes should be copied before the new ones are applied
-		if ( element ) {
+		if ( element )
 			element.copyAttributes( el );
-		}
 
 		el = setupElement( el, style );
 
 		// Avoid ID duplication.
-		if ( targetDocument.getCustomData( 'doc_processing_style' ) && el.hasAttribute( 'id' ) ) {
+		if ( targetDocument.getCustomData( 'doc_processing_style' ) && el.hasAttribute( 'id' ) )
 			el.removeAttribute( 'id' );
-		} else {
+		else
 			targetDocument.setCustomData( 'doc_processing_style', 1 );
-		}
 
 		return el;
 	}
@@ -1689,16 +1686,14 @@ CKEDITOR.STYLE_OBJECT = 3;
 			styles = CKEDITOR.style.getStyleText( def );
 
 		// Assign all defined attributes.
-		for ( var att in attributes ) {
-			el.setAttribute( att, attributes[ att ] );
+		if ( attributes ) {
+			for ( var att in attributes )
+				el.setAttribute( att, attributes[ att ] );
 		}
 
-		// Assign all defined styles. If new format doesn't have any styles, remove the existing ones (#3649).
-		if ( styles ) {
+		// Assign all defined styles.
+		if ( styles )
 			el.setAttribute( 'style', styles );
-		} else {
-			el.removeAttribute( 'style' );
-		}
 
 		el.getDocument().removeCustomData( 'doc_processing_style' );
 

--- a/core/style.js
+++ b/core/style.js
@@ -1692,8 +1692,11 @@ CKEDITOR.STYLE_OBJECT = 3;
 		}
 
 		// Assign all defined styles.
-		if ( styles )
+		if ( styles ) {
 			el.setAttribute( 'style', styles );
+		} else {
+			el.removeAttribute( 'style' );
+		}
 
 		el.getDocument().removeCustomData( 'doc_processing_style' );
 

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
@@ -66,6 +66,9 @@ CKEDITOR.plugins.add( 'format', {
 
 				var style = styles[ value ],
 					elementPath = editor.elementPath();
+
+				// (#3649)
+				editor.fire( 'stylesRemove', { type: CKEDITOR.STYLE_BLOCK } );
 
 				// Always apply style, do not allow to toggle it by clicking on corresponding list item (#584).
 				if ( !style.checkActive( elementPath, editor ) ) {

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
@@ -60,6 +60,19 @@
 				stylesList.sort( function( styleA, styleB ) {
 					return styleA._.weight - styleB._.weight;
 				} );
+			} );
+
+			// (#3649)
+			editor.on( 'stylesRemove', function( evt ) {
+				var type = evt.data.type;
+
+				for ( var styleName in styles ) {
+					var style = styles[ styleName ];
+
+					if ( style.type == type ) {
+						editor.removeStyle( style );
+					}
+				}
 			} );
 
 			editor.ui.addRichCombo( 'Styles', {

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -64,12 +64,13 @@
 
 			// (#3649)
 			editor.on( 'stylesRemove', function( evt ) {
-				var type = evt.data.type;
+				var type = evt.data && evt.data.type,
+					allowAll = type === undefined;
 
 				for ( var styleName in styles ) {
 					var style = styles[ styleName ];
 
-					if ( style.type == type ) {
+					if ( allowAll || style.type === type ) {
 						editor.removeStyle( style );
 					}
 				}

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -217,3 +217,20 @@
 		}
 	} );
 } )();
+
+/**
+ * Removes styles from the current editor selection.
+ *
+ * Note that you can pass `type` option to limit removing styles to the given type.
+ *
+ * ```js
+ * editor.fire( 'stylesRemove', { type: CKEDITOR.STYLE_BLOCK } );
+ * ```
+ *
+ * @since 4.15.1
+ * @event stylesRemove
+ * @member CKEDITOR.editor
+ * @param {CKEDITOR.editor} editor This editor instance.
+ * @param data
+ * @param {Number} [data.type] Style type, see {@link CKEDITOR#STYLE_INLINE INLINE}/{@link CKEDITOR#STYLE_BLOCK BLOCK}/{@link CKEDITOR#STYLE_OBJECT OBJECT} style options.
+ */

--- a/tests/plugins/stylescombo/manual/removeblockformat.html
+++ b/tests/plugins/stylescombo/manual/removeblockformat.html
@@ -1,0 +1,7 @@
+<textarea id="editor">
+	<h1>Hello World!</h1>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/stylescombo/manual/removeblockformat.md
+++ b/tests/plugins/stylescombo/manual/removeblockformat.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: bug, 4.14.2, 3649
-@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, format, sourcearea
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, format, sourcearea, link, font
 
 1. Select the entire editor contents.
 1. Change the style to `Italic Title`.

--- a/tests/plugins/stylescombo/manual/removeblockformat.md
+++ b/tests/plugins/stylescombo/manual/removeblockformat.md
@@ -1,0 +1,17 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.14.2, 3649
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, format, sourcearea
+
+1. Select the entire editor contents.
+1. Change the style to `Italic Title`.
+1. Change the format to `Normal`.
+
+  **Expected:** There is an unstyled paragraph in the editor.
+
+  **Unexpected:** Paragraph has an italic style.
+
+1. Go to source mode.
+
+  **Expected:** Source code is `<p>Hello World!</p>`.
+
+  **Unexpected:** Source code is not paragraph or there are some block styles added to it.

--- a/tests/plugins/stylescombo/manual/removeblockformat.md
+++ b/tests/plugins/stylescombo/manual/removeblockformat.md
@@ -1,6 +1,6 @@
 @bender-ui: collapsed
 @bender-tags: bug, 4.14.2, 3649
-@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, format, sourcearea, link, font
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, format, sourcearea, link, font, undo
 
 1. Select the entire editor contents.
 1. Change the style to `Italic Title`.

--- a/tests/plugins/stylescombo/manual/removeblockformat.md
+++ b/tests/plugins/stylescombo/manual/removeblockformat.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: bug, 4.14.2, 3649
+@bender-tags: bug, 4.15.1, 3649
 @bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo, format, sourcearea, link, font, undo
 
 1. Select the entire editor contents.

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -119,6 +119,24 @@
 						'Element with ID: #' + squareOptionId + ', should be displayed.' );
 				} );
 			} );
+		},
+
+		// (#3649)
+		'test removing block style with format combo': function() {
+			bender.editorBot.create( {
+				name: 'removeFormat'
+			}, function( bot ) {
+				bot.setHtmlWithSelection( '<h1>[Hello World!]</h1>' );
+
+				bot.combo( 'Styles', function( combo ) {
+					combo.onClick( 'Italic Title' );
+
+					bot.combo( 'Format', function( combo ) {
+						combo.onClick( 'p' );
+						assert.areEqual( bot.editor.getData(), '<p>Hello World!</p>', 'Editor should contain unformatted paragraph.' );
+					} );
+				} );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -211,7 +211,7 @@
 
 				bot.combo( options.secondCombo, function( combo ) {
 					combo.onClick( options.secondOption );
-					assert.areEqual( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
+					assert.areEqual( options.result, bender.tools.compatHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
 				} );
 			} );
 		} );

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -211,7 +211,7 @@
 
 				bot.combo( options.secondCombo, function( combo ) {
 					combo.onClick( options.secondOption );
-					assert.areEqual( options.result, bender.tools.compatHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
+					assert.beautified.html( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
 				} );
 			} );
 		} );

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -123,20 +123,30 @@
 
 		// (#3649)
 		'test removing block style with format combo': function() {
-			bender.editorBot.create( {
-				name: 'removeFormat'
-			}, function( bot ) {
-				bot.setHtmlWithSelection( '<h1>[Hello World!]</h1>' );
-
-				bot.combo( 'Styles', function( combo ) {
-					combo.onClick( 'Italic Title' );
-
-					bot.combo( 'Format', function( combo ) {
-						combo.onClick( 'p' );
-						assert.areEqual( bot.editor.getData(), '<p>Hello World!</p>', 'Editor should contain unformatted paragraph.' );
-					} );
-				} );
+			testCombos( {
+				firstCombo: 'Styles',
+				firstOption: 'Italic Title',
+				secondCombo: 'Format',
+				secondOption: 'p',
+				result: '<p>Hello World!</p>'
 			} );
 		}
 	} );
+
+	function testCombos( options ) {
+		bender.editorBot.create( {
+			name: 'editor' + ( new Date() ).getTime()
+		}, function( bot ) {
+			bot.setHtmlWithSelection( '<h1>[Hello World!]</h1>' );
+
+			bot.combo( options.firstCombo, function( combo ) {
+				combo.onClick( options.firstOption );
+
+				bot.combo( options.secondCombo, function( combo ) {
+					combo.onClick( options.secondOption );
+					assert.areEqual( bot.editor.getData(), options.result, 'Editor content is incorrect.' );
+				} );
+			} );
+		} );
+	}
 } )();

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -195,7 +195,7 @@
 			bot.combo( options.combo, function( combo ) {
 				combo.onClick( options.option );
 
-				assert.areEqual( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
+				assert.beautified.html( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
 			} );
 		} );
 	}

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -122,18 +122,85 @@
 		},
 
 		// (#3649)
+		'test inline styles are preserved when a format is picked': function() {
+			testOneCombo( {
+				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[Hello World!]</span></h1>',
+				combo: 'Format',
+				option: 'p',
+				result: '<p><span style="font-family:Courier New,Courier,monospace;">Hello World!</span></p>'
+			} );
+		},
+
+		// (#3649)
+		'test applying the style from Styles dropdown replaces the current format': function() {
+			testOneCombo( {
+				html: '<h1>[Hello World!]</h1>',
+				combo: 'Styles',
+				option: 'Italic Title',
+				result: '<h2 style="font-style:italic;">Hello World!</h2>'
+			} );
+		},
+
+		// (#3649)
 		'test removing block style with format combo': function() {
-			testCombos( {
+			testTwoCombos( {
 				firstCombo: 'Styles',
 				firstOption: 'Italic Title',
 				secondCombo: 'Format',
 				secondOption: 'p',
 				result: '<p>Hello World!</p>'
 			} );
+		},
+
+		// (#3649)
+		'test style is removed if the same option is picked twice': function() {
+			testTwoCombos( {
+				firstCombo: 'Styles',
+				firstOption: 'Italic Title',
+				secondCombo: 'Styles',
+				secondOption: 'Italic Title',
+				result: '<p>Hello World!</p>'
+			} );
+		},
+
+		// (#3649)
+		'test inline dropdown style is preserved when a format is picked': function() {
+			testTwoCombos( {
+				firstCombo: 'Styles',
+				firstOption: 'Marker',
+				secondCombo: 'Format',
+				secondOption: 'p',
+				result: '<p><span class="marker">Hello World!</span></p>'
+			} );
+		},
+
+		// (#3649)
+		'test a new style overrides the previous one correctly': function() {
+			testTwoCombos( {
+				firstCombo: 'Styles',
+				firstOption: 'Italic Title',
+				secondCombo: 'Styles',
+				secondOption: 'Special Container',
+				result: '<div style="background:#eeeeee;border:1px solid #cccccc;padding:5px 10px;">Hello World!</div>'
+			} );
 		}
 	} );
 
-	function testCombos( options ) {
+	function testOneCombo( options ) {
+		bender.editorBot.create( {
+			name: 'editor' + ( new Date() ).getTime()
+		}, function( bot ) {
+			bot.setHtmlWithSelection( options.html );
+
+			bot.combo( options.combo, function( combo ) {
+				combo.onClick( options.option );
+
+				assert.areEqual( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
+			} );
+		} );
+	}
+
+	function testTwoCombos( options ) {
 		bender.editorBot.create( {
 			name: 'editor' + ( new Date() ).getTime()
 		}, function( bot ) {
@@ -144,7 +211,7 @@
 
 				bot.combo( options.secondCombo, function( combo ) {
 					combo.onClick( options.secondOption );
-					assert.areEqual( bot.editor.getData(), options.result, 'Editor content is incorrect.' );
+					assert.areEqual( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
 				} );
 			} );
 		} );

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -127,7 +127,7 @@
 				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[Hello World!]</span></h1>',
 				combo: 'Format',
 				option: 'p',
-				result: '<p><span style="font-family:Courier New,Courier,monospace;">Hello World!</span></p>'
+				result: '<p><span style="font-family:courier new,courier,monospace;">hello world!</span></p>'
 			} );
 		},
 
@@ -137,7 +137,7 @@
 				html: '<h1>[Hello World!]</h1>',
 				combo: 'Styles',
 				option: 'Italic Title',
-				result: '<h2 style="font-style:italic;">Hello World!</h2>'
+				result: '<h2 style="font-style:italic;">hello world!</h2>'
 			} );
 		},
 
@@ -148,7 +148,7 @@
 				firstOption: 'Italic Title',
 				secondCombo: 'Format',
 				secondOption: 'p',
-				result: '<p>Hello World!</p>'
+				result: '<p>hello world!</p>'
 			} );
 		},
 
@@ -159,7 +159,7 @@
 				firstOption: 'Italic Title',
 				secondCombo: 'Styles',
 				secondOption: 'Italic Title',
-				result: '<p>Hello World!</p>'
+				result: '<p>hello world!</p>'
 			} );
 		},
 
@@ -170,7 +170,7 @@
 				firstOption: 'Marker',
 				secondCombo: 'Format',
 				secondOption: 'p',
-				result: '<p><span class="marker">Hello World!</span></p>'
+				result: '<p><span class="marker">hello world!</span></p>'
 			} );
 		},
 
@@ -181,7 +181,7 @@
 				firstOption: 'Italic Title',
 				secondCombo: 'Styles',
 				secondOption: 'Special Container',
-				result: '<div style="background:#eeeeee;border:1px solid #cccccc;padding:5px 10px;">Hello World!</div>'
+				result: '<div style="background:#eeeeee;border:1px solid #cccccc;padding:5px 10px;">hello world!</div>'
 			} );
 		}
 	} );
@@ -195,7 +195,7 @@
 			bot.combo( options.combo, function( combo ) {
 				combo.onClick( options.option );
 
-				assert.beautified.html( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
+				assert.beautified.html( options.result, bender.tools.fixHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
 			} );
 		} );
 	}
@@ -211,7 +211,8 @@
 
 				bot.combo( options.secondCombo, function( combo ) {
 					combo.onClick( options.secondOption );
-					assert.beautified.html( options.result, bot.editor.getData(), 'Editor content is incorrect.' );
+
+					assert.beautified.html( options.result, bender.tools.fixHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
 				} );
 			} );
 		} );

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -182,26 +182,6 @@
 		},
 
 		// (#3649)
-		'test custom class is removed when format is applied': function() {
-			testCombo( {
-				html: '<h2 class="red-text">[hello world!]</h2>',
-				combo: 'Format',
-				option: 'p',
-				result: '<p>hello world!</p>'
-			} );
-		},
-
-		// (#3649)
-		'test custom class is removed when style is applied': function() {
-			testCombo( {
-				html: '<h2 class="red-text">[hello world!]</h2>',
-				combo: 'Styles',
-				option: 'Italic Title',
-				result: '<h2 style="font-style:italic;">hello world!</h2>'
-			} );
-		},
-
-		// (#3649)
 		'test custom attribute is not removed when style is applied': function() {
 			testCombo( {
 				html: '<h2 custom-attribute>[hello world!]</h2>',

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -124,7 +124,17 @@
 		// (#3649)
 		'test inline styles are preserved when a format is picked': function() {
 			testOneCombo( {
-				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[Hello World!]</span></h1>',
+				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[hello world!]</span></h1>',
+				combo: 'Format',
+				option: 'p',
+				result: '<p><span style="font-family:courier new,courier,monospace;">hello world!</span></p>'
+			} );
+		},
+
+		// (#3649)
+		'1. test inline styles are preserved when a format is picked': function() {
+			testOneCombo( {
+				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[hello world!]</span></h1>',
 				combo: 'Format',
 				option: 'p',
 				result: '<p><span style="font-family:courier new,courier,monospace;">hello world!</span></p>'
@@ -134,7 +144,7 @@
 		// (#3649)
 		'test applying the style from Styles dropdown replaces the current format': function() {
 			testOneCombo( {
-				html: '<h1>[Hello World!]</h1>',
+				html: '<h1>[hello world!]</h1>',
 				combo: 'Styles',
 				option: 'Italic Title',
 				result: '<h2 style="font-style:italic;">hello world!</h2>'
@@ -142,23 +152,81 @@
 		},
 
 		// (#3649)
-		'test removing block style with format combo': function() {
-			testTwoCombos( {
-				firstCombo: 'Styles',
-				firstOption: 'Italic Title',
-				secondCombo: 'Format',
-				secondOption: 'p',
+		'2. test style is removed when the current format is applied': function() {
+			testOneCombo( {
+				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
+				combo: 'Format',
+				option: 'h2',
+				result: '<h2>hello world!</h2>'
+			} );
+		},
+
+		// (#3649)
+		'3. test style is toggled when reapplied': function() {
+			testOneCombo( {
+				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
+				combo: 'Styles',
+				option: 'Italic Title',
 				result: '<p>hello world!</p>'
 			} );
 		},
 
 		// (#3649)
-		'test style is removed if the same option is picked twice': function() {
-			testTwoCombos( {
-				firstCombo: 'Styles',
-				firstOption: 'Italic Title',
-				secondCombo: 'Styles',
-				secondOption: 'Italic Title',
+		'4. test inline style is untouched when block style is toggled': function() {
+			testOneCombo( {
+				html: '<h2 style="font-style:italic;"><big>[hello world!]</big></h2>',
+				combo: 'Styles',
+				option: 'Italic Title',
+				result: '<p><big>hello world!</big></p>'
+			} );
+		},
+
+		// (#3649)
+		'5. test custom class is removed when format is applied': function() {
+			testOneCombo( {
+				html: '<h2 class="red-text">[hello world!]</h2>',
+				combo: 'Format',
+				option: 'p',
+				result: '<p>hello world!</p>'
+			} );
+		},
+
+		// (#3649)
+		'6. test custom class is removed when style is applied': function() {
+			testOneCombo( {
+				html: '<h2 class="red-text">[hello world!]</h2>',
+				combo: 'Styles',
+				option: 'Italic Title',
+				result: '<h2 style="font-style:italic;">hello world!</h2>'
+			} );
+		},
+
+		// (#3649)
+		'7.1 test custom attribute is not removed when style is applied': function() {
+			testOneCombo( {
+				html: '<h2 custom-attribute>[hello world!]</h2>',
+				combo: 'Styles',
+				option: 'Italic Title',
+				result: '<h2 style="font-style:italic;" custom-attribute>hello world!</h2>'
+			} );
+		},
+
+		// (#3649)
+		'7.2 test custom attribute is not removed when format is applied': function() {
+			testOneCombo( {
+				html: '<h2 custom-attribute>[hello world!]</h2>',
+				combo: 'Format',
+				option: 'p',
+				result: '<p custom-attribute>hello world!</p>'
+			} );
+		},
+
+		// (#3649)
+		'test removing block style with format combo': function() {
+			testOneCombo( {
+				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
+				combo: 'Format',
+				option: 'p',
 				result: '<p>hello world!</p>'
 			} );
 		},
@@ -204,7 +272,7 @@
 		bender.editorBot.create( {
 			name: 'editor' + ( new Date() ).getTime()
 		}, function( bot ) {
-			bot.setHtmlWithSelection( '<h1>[Hello World!]</h1>' );
+			bot.setHtmlWithSelection( '<h1>[hello world!]</h1>' );
 
 			bot.combo( options.firstCombo, function( combo ) {
 				combo.onClick( options.firstOption );

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -122,6 +122,45 @@
 		},
 
 		// (#3649)
+		'test removeStyles event': function() {
+			testCombo( {
+				html: '<p>[hello world!]</p>',
+				combo: 'Styles',
+				option: 'Marker',
+				result: '<p>hello world!</p>',
+				callback: function( editor ) {
+					editor.fire( 'stylesRemove' );
+				}
+			} );
+		},
+
+		// (#3649)
+		'test removeStyles event with specific type': function() {
+			testCombo( {
+				html: '<h1>[hello world!]</h1>',
+				combo: 'Styles',
+				option: 'Italic Title',
+				result: '<p>hello world!</p>',
+				callback: function( editor ) {
+					editor.fire( 'stylesRemove', { type: CKEDITOR.STYLE_BLOCK } );
+				}
+			} );
+		},
+
+		// (#3649)
+		'test removeStyles event with different type': function() {
+			testCombo( {
+				html: '<p>[hello world!]</p>',
+				combo: 'Styles',
+				option: 'Marker',
+				result: '<p><span class="marker">hello world!</span></p>',
+				callback: function( editor ) {
+					editor.fire( 'stylesRemove', { type: CKEDITOR.STYLE_BLOCK } );
+				}
+			} );
+		},
+
+		// (#3649)
 		'test inline styles are preserved when a format is picked': function() {
 			testCombo( {
 				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[hello world!]</span></h1>',
@@ -240,6 +279,10 @@
 
 			bot.combo( options.combo, function( combo ) {
 				combo.onClick( options.option );
+
+				if ( options.callback ) {
+					options.callback( bot.editor );
+				}
 
 				assert.beautified.html( options.result, bender.tools.fixHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
 			} );

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -123,7 +123,7 @@
 
 		// (#3649)
 		'test inline styles are preserved when a format is picked': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[hello world!]</span></h1>',
 				combo: 'Format',
 				option: 'p',
@@ -133,7 +133,7 @@
 
 		// (#3649)
 		'test inline styles are preserved when a style is picked': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[hello world!]</span></h1>',
 				combo: 'Styles',
 				option: 'Italic Title',
@@ -143,7 +143,7 @@
 
 		// (#3649)
 		'test applying the style from Styles dropdown replaces the current format': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h1>[hello world!]</h1>',
 				combo: 'Styles',
 				option: 'Italic Title',
@@ -153,7 +153,7 @@
 
 		// (#3649)
 		'test style is removed when the current format is applied': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
 				combo: 'Format',
 				option: 'h2',
@@ -163,7 +163,7 @@
 
 		// (#3649)
 		'test style is toggled when reapplied': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
 				combo: 'Styles',
 				option: 'Italic Title',
@@ -173,7 +173,7 @@
 
 		// (#3649)
 		'test inline style is untouched when block style is toggled': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 style="font-style:italic;"><big>[hello world!]</big></h2>',
 				combo: 'Styles',
 				option: 'Italic Title',
@@ -183,7 +183,7 @@
 
 		// (#3649)
 		'test custom class is removed when format is applied': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 class="red-text">[hello world!]</h2>',
 				combo: 'Format',
 				option: 'p',
@@ -193,7 +193,7 @@
 
 		// (#3649)
 		'test custom class is removed when style is applied': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 class="red-text">[hello world!]</h2>',
 				combo: 'Styles',
 				option: 'Italic Title',
@@ -203,7 +203,7 @@
 
 		// (#3649)
 		'test custom attribute is not removed when style is applied': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 custom-attribute>[hello world!]</h2>',
 				combo: 'Styles',
 				option: 'Italic Title',
@@ -213,7 +213,7 @@
 
 		// (#3649)
 		'test custom attribute is not removed when format is applied': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 custom-attribute>[hello world!]</h2>',
 				combo: 'Format',
 				option: 'p',
@@ -223,7 +223,7 @@
 
 		// (#3649)
 		'test removing block style with format combo': function() {
-			testOneCombo( {
+			testCombo( {
 				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
 				combo: 'Format',
 				option: 'p',
@@ -233,28 +233,26 @@
 
 		// (#3649)
 		'test inline dropdown style is preserved when a format is picked': function() {
-			testTwoCombos( {
-				firstCombo: 'Styles',
-				firstOption: 'Marker',
-				secondCombo: 'Format',
-				secondOption: 'p',
+			testCombo( {
+				html: '<h1><span class="marker">[hello world!]</span></h1>',
+				combo: 'Format',
+				option: 'p',
 				result: '<p><span class="marker">hello world!</span></p>'
 			} );
 		},
 
 		// (#3649)
 		'test a new style overrides the previous one correctly': function() {
-			testTwoCombos( {
-				firstCombo: 'Styles',
-				firstOption: 'Italic Title',
-				secondCombo: 'Styles',
-				secondOption: 'Special Container',
+			testCombo( {
+				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
+				combo: 'Styles',
+				option: 'Special Container',
 				result: '<div style="background:#eeeeee;border:1px solid #cccccc;padding:5px 10px;">hello world!</div>'
 			} );
 		}
 	} );
 
-	function testOneCombo( options ) {
+	function testCombo( options ) {
 		bender.editorBot.create( {
 			name: 'editor' + ( new Date() ).getTime()
 		}, function( bot ) {
@@ -264,24 +262,6 @@
 				combo.onClick( options.option );
 
 				assert.beautified.html( options.result, bender.tools.fixHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
-			} );
-		} );
-	}
-
-	function testTwoCombos( options ) {
-		bender.editorBot.create( {
-			name: 'editor' + ( new Date() ).getTime()
-		}, function( bot ) {
-			bot.setHtmlWithSelection( '<h1>[hello world!]</h1>' );
-
-			bot.combo( options.firstCombo, function( combo ) {
-				combo.onClick( options.firstOption );
-
-				bot.combo( options.secondCombo, function( combo ) {
-					combo.onClick( options.secondOption );
-
-					assert.beautified.html( options.result, bender.tools.fixHtml( bot.editor.getData() ), 'Editor content is incorrect.' );
-				} );
 			} );
 		} );
 	}

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -132,12 +132,12 @@
 		},
 
 		// (#3649)
-		'1. test inline styles are preserved when a format is picked': function() {
+		'test inline styles are preserved when a style is picked': function() {
 			testOneCombo( {
 				html: '<h1><span style="font-family:Courier New,Courier,monospace;">[hello world!]</span></h1>',
-				combo: 'Format',
-				option: 'p',
-				result: '<p><span style="font-family:courier new,courier,monospace;">hello world!</span></p>'
+				combo: 'Styles',
+				option: 'Italic Title',
+				result: '<h2 style="font-style:italic;"><span style="font-family:courier new,courier,monospace;">hello world!</span></h2>'
 			} );
 		},
 
@@ -152,7 +152,7 @@
 		},
 
 		// (#3649)
-		'2. test style is removed when the current format is applied': function() {
+		'test style is removed when the current format is applied': function() {
 			testOneCombo( {
 				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
 				combo: 'Format',
@@ -162,7 +162,7 @@
 		},
 
 		// (#3649)
-		'3. test style is toggled when reapplied': function() {
+		'test style is toggled when reapplied': function() {
 			testOneCombo( {
 				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
 				combo: 'Styles',
@@ -172,7 +172,7 @@
 		},
 
 		// (#3649)
-		'4. test inline style is untouched when block style is toggled': function() {
+		'test inline style is untouched when block style is toggled': function() {
 			testOneCombo( {
 				html: '<h2 style="font-style:italic;"><big>[hello world!]</big></h2>',
 				combo: 'Styles',
@@ -182,7 +182,7 @@
 		},
 
 		// (#3649)
-		'5. test custom class is removed when format is applied': function() {
+		'test custom class is removed when format is applied': function() {
 			testOneCombo( {
 				html: '<h2 class="red-text">[hello world!]</h2>',
 				combo: 'Format',
@@ -192,7 +192,7 @@
 		},
 
 		// (#3649)
-		'6. test custom class is removed when style is applied': function() {
+		'test custom class is removed when style is applied': function() {
 			testOneCombo( {
 				html: '<h2 class="red-text">[hello world!]</h2>',
 				combo: 'Styles',
@@ -202,7 +202,7 @@
 		},
 
 		// (#3649)
-		'7.1 test custom attribute is not removed when style is applied': function() {
+		'test custom attribute is not removed when style is applied': function() {
 			testOneCombo( {
 				html: '<h2 custom-attribute>[hello world!]</h2>',
 				combo: 'Styles',
@@ -212,7 +212,7 @@
 		},
 
 		// (#3649)
-		'7.2 test custom attribute is not removed when format is applied': function() {
+		'test custom attribute is not removed when format is applied': function() {
 			testOneCombo( {
 				html: '<h2 custom-attribute>[hello world!]</h2>',
 				combo: 'Format',

--- a/tests/plugins/stylescombo/stylescombo.js
+++ b/tests/plugins/stylescombo/stylescombo.js
@@ -262,6 +262,11 @@
 
 		// (#3649)
 		'test a new style overrides the previous one correctly': function() {
+			// IE produces different HTML for colors.
+			if ( CKEDITOR.env.ie ) {
+				assert.ignore();
+			}
+
 			testCombo( {
 				html: '<h2 style="font-style:italic;">[hello world!]</h2>',
 				combo: 'Styles',


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3649](https://github.com/ckeditor/ckeditor4/issues/3649): Fixed: Applying a [block format](https://ckeditor.com/docs/ckeditor4/latest/features/format.html) should remove existing block styles.
```

## What changes did you make?

The fix works in the way described in https://github.com/ckeditor/ckeditor4/issues/3649#issuecomment-633466405, so if a new block format is applied, the old block styles are removed (even if no new ones are added). The inline styles remain intact.

Please note that this fix seems to be suspiciously simple, so even though all the current tests are passing it should be treated with a big attention.

## Which issues does your PR resolve?

Closes #3649.
In a way it also closes #3207 - not exactly what I meant while creating that issue, but this PR gives an intuitive way of clearing the formatting, so I'd be satisfied with it.
