### PR TITLE
Keep stylesLoaded out of global context

### DIFF
--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3498,7 +3498,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	} );
 	
-	// Dialog related configurations.
 	CKEDITOR.plugins.add( 'dialog', {
 		requires: 'dialogui',
 		init: function( editor ) {
@@ -3514,6 +3513,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	} );
 } )();
+
+
+// Dialog related configurations.
 
 /**
  * The color of the dialog background cover. It should be a valid CSS color string.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -66,7 +66,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 	var cssLength = CKEDITOR.tools.cssLength,
 		defaultDialogDefinition,
-		currentCover;
+		currentCover,
+		stylesLoaded = false;
 
 	function focusActiveTab( dialog ) {
 		dialog._.tabBarMode = true;
@@ -3496,26 +3497,23 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			return dialog;
 		}
 	} );
-} )();
+	
+	// Dialog related configurations.
+	CKEDITOR.plugins.add( 'dialog', {
+		requires: 'dialogui',
+		init: function( editor ) {
+			if ( !stylesLoaded ) {
+				CKEDITOR.document.appendStyleSheet( this.path + 'styles/dialog.css' );
+				stylesLoaded = true;
+			}
 
-var stylesLoaded = false;
-
-CKEDITOR.plugins.add( 'dialog', {
-	requires: 'dialogui',
-	init: function( editor ) {
-		if ( !stylesLoaded ) {
-			CKEDITOR.document.appendStyleSheet( this.path + 'styles/dialog.css' );
-			stylesLoaded = true;
+			editor.on( 'doubleclick', function( evt ) {
+				if ( evt.data.dialog )
+					editor.openDialog( evt.data.dialog );
+			}, null, null, 999 );
 		}
-
-		editor.on( 'doubleclick', function( evt ) {
-			if ( evt.data.dialog )
-				editor.openDialog( evt.data.dialog );
-		}, null, null, 999 );
-	}
-} );
-
-// Dialog related configurations.
+	} );
+} )();
 
 /**
  * The color of the dialog background cover. It should be a valid CSS color string.


### PR DESCRIPTION
Moved the dialog plugin's stylesLoaded variable into the IIFE to prevent the stylesLoaded variable from being included (and editable) in the global context. This also required moving the "CKEDITOR.plugins.add( 'dialog', { ..." call into the IIFE - where it should have been to begin with.

## What is the purpose of this pull request?

Bug fix. The stylesLoaded variable referenced by the dialog plugin was placed on the global scope, which creates two major issues:
1) It could interfere with other scripts attempting to utilize a variable of the same name on the global scope thereby creating bugs in other code.
2) Other scripts could easily accidentally change the value of the scriptsLoaded variable, potentially causing the dialog styles to be loaded multiple times if multiple editors are present.

## Does your PR contain necessary tests?

This PR does NOT contain tests. The ideal test should check for the existence of ANY non-essential global variables after fully loading CKEditor (including all plugins and non-core code) - passing if there are none and failing if there are any. This may need to be a manual test for now

### This PR contains

- 0 Unit tests
- 0 Manual tests

## Did you follow the CKEditor 4 code style guide?

PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Moved stylesLoaded variable out of the global context
```

## What changes did you make?

Moved all relevant code for the dialog plugin into the IIFE to prevent global context contamination.

## Which issues does your PR resolve?

Unknown if it closes any existing issues. This was just an issue caught by my local testing and it was easy to fix so I created a PR for it.
