### PR TITLE
Fix incorrect defaults for colorbutton config variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [#3693](https://github.com/ckeditor/ckeditor4/issues/3693): Fixed: Incorrect default values for several [Color Button](https://ckeditor.com/cke4/addon/colorbutton) config variables in API documentation.
 * [#3795](https://github.com/ckeditor/ckeditor4/issues/3795): Fixed: Setting [`dataIndentationChars`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-dataIndentationChars) config option to an empty string is ignored and replaced by a tab (`\t`) character. Thanks to [Thomas Grinderslev](https://github.com/Znegl)!
 * [#4107](https://github.com/ckeditor/ckeditor4/issues/4107): Fixed: Multiple [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) instances cause keyboard navigation issues.
 * [#4041](https://github.com/ckeditor/ckeditor4/issues/4041): Fixed: [`selection.scrollIntoView`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_selection.html#method-scrollIntoView) method throws an error when editor selection is not set.

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -477,7 +477,7 @@ CKEDITOR.plugins.add( 'colorbutton', {
  *			'FFA07A,FFA500,FFFF00,00FF00,AFEEEE,ADD8E6,DDA0DD,D3D3D3,' +
  *			'FFF0F5,FAEBD7,FFFFE0,F0FFF0,F0FFFF,F0F8FF,E6E6FA,FFF';
  *
- * @cfg {String} [colorButton_colors=see source]
+ * @cfg {String} [colorButton_colors]
  * @member CKEDITOR.config
  */
 CKEDITOR.config.colorButton_colors = '1ABC9C,2ECC71,3498DB,9B59B6,4E5F70,F1C40F,' +
@@ -501,7 +501,7 @@ CKEDITOR.config.colorButton_colors = '1ABC9C,2ECC71,3498DB,9B59B6,4E5F70,F1C40F,
  *			styles: { color: '#(color)' }
  *		};
  *
- * @cfg [colorButton_foreStyle=see source]
+ * @cfg [colorButton_foreStyle]
  * @member CKEDITOR.config
  */
 CKEDITOR.config.colorButton_foreStyle = {
@@ -528,7 +528,7 @@ CKEDITOR.config.colorButton_foreStyle = {
  *			styles: { 'background-color': '#(color)' }
  *		};
  *
- * @cfg [colorButton_backStyle=see source]
+ * @cfg [colorButton_backStyle]
  * @member CKEDITOR.config
  */
 CKEDITOR.config.colorButton_backStyle = {


### PR DESCRIPTION
## What is the purpose of this pull request?

Docs fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3693](https://github.com/ckeditor/ckeditor4/issues/3693): Fixed: incorrect default values for several [Color Button](https://ckeditor.com/cke4/addon/colorbutton) config variables.
```

## What changes did you make?

I've just removed "see source" placeholder and it seems that Umberto took care of it.

## Which issues does your PR resolve?

Closes #3693.
