### PR TITLE
Fix incorrect images dimensions in Safari

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [#4183](https://github.com/ckeditor/ckeditor4/issues/4183): [Safari] Fixed: Incorrect images dimensions when using [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin alongside [IFrame Editing Area](https://ckeditor.com/cke4/addon/wysiwygarea) plugin.
 * [#3693](https://github.com/ckeditor/ckeditor4/issues/3693): Fixed: Incorrect default values for several [Color Button](https://ckeditor.com/cke4/addon/colorbutton) config variables in API documentation.
 * [#3795](https://github.com/ckeditor/ckeditor4/issues/3795): Fixed: Setting [`dataIndentationChars`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-dataIndentationChars) config option to an empty string is ignored and replaced by a tab (`\t`) character. Thanks to [Thomas Grinderslev](https://github.com/Znegl)!
 * [#4107](https://github.com/ckeditor/ckeditor4/issues/4107): Fixed: Multiple [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) instances cause keyboard navigation issues.

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -270,7 +270,6 @@
 					function getNaturalWidth( image, callback ) {
 						var $image = image.$;
 
-
 						if ( $image.complete && $image.naturalWidth ) {
 							return callback( $image.naturalWidth );
 						}

--- a/tests/plugins/easyimage/manual/safarizerodimensions.html
+++ b/tests/plugins/easyimage/manual/safarizerodimensions.html
@@ -1,0 +1,31 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<h2>Classic editor</h2>
+<div id="classic">
+	<figure class="easyimage easyimage-full">
+		<img alt="" sizes="100vw" src="../_assets/logo.png" srcset="../_assets/logo.png 350w" width="350" />
+	</figure>
+</div>
+
+<h2>Divarea editor</h2>
+<div id="divarea">
+	<figure class="easyimage easyimage-full">
+		<img alt="" sizes="100vw" src="../_assets/logo.png" srcset="../_assets/logo.png 350w" width="350" />
+	</figure>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.safari ) {
+		bender.ignore();
+	}
+
+	var commonConfig = {
+			cloudServices_uploadUrl: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
+			cloudServices_tokenUrl: easyImageTools.CLOUD_SERVICES_TOKEN_URL
+		};
+
+	CKEDITOR.replace( 'classic', commonConfig );
+	CKEDITOR.replace( 'divarea', CKEDITOR.tools.extend( {
+		extraPlugins: 'divarea'
+	}, commonConfig ) );
+</script>

--- a/tests/plugins/easyimage/manual/safarizerodimensions.md
+++ b/tests/plugins/easyimage/manual/safarizerodimensions.md
@@ -1,0 +1,20 @@
+@bender-tags: 4.14.2, feature, 4183
+@bender-ui: collapsed
+@bender-ckeditor-plugins: sourcearea, wysiwygarea, floatingspace, toolbar, easyimage
+@bender-include: ../_helpers/tools.js
+
+1. Switch editor to source mode.
+2. Switch back.
+	### Expected
+
+	Image is still visible
+
+	### Unexpected
+
+	Image disappeared.
+3. Repeat the procedure several times for every editor.
+4. Remove the image and upload another one. Repeat the procedure.
+
+### Note
+
+Sometimes image is not visible from the start.

--- a/tests/plugins/easyimage/manual/safarizerodimensions.md
+++ b/tests/plugins/easyimage/manual/safarizerodimensions.md
@@ -5,16 +5,18 @@
 
 1. Switch editor to source mode.
 2. Switch back.
-	### Expected
 
-	Image is still visible
+	### Expected:
 
-	### Unexpected
+	Image is visible.
+
+	### Unexpected:
 
 	Image disappeared.
+
 3. Repeat the procedure several times for every editor.
 4. Remove the image and upload another one. Repeat the procedure.
 
-### Note
+### Note:
 
-Sometimes image is not visible from the start.
+Sometimes image is not visible at the beginning. It shouldn't bother you - just proceed with the test.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4183](https://github.com/ckeditor/ckeditor4/issues/4183): [Safari] Fixed: Incorrect images dimensions when using [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin alongside [IFrame Editing Area](https://ckeditor.com/cke4/addon/wysiwygarea) plugin.
```

## What changes did you make?

It's more of a workaround than a proper fix. The solution forces Safari to reload the image if it has zero width.

I haven't added unit tests as I'm not exactly sure how to automate testing the issue 😞.

## Which issues does your PR resolve?

Closes #4183.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
