### PR TITLE
Prevent formaction attribute XSS in the editable area

### DIFF
--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -565,9 +565,10 @@
 	// These rules will also be applied to non-editable content.
 	var defaultDataFilterRulesForAll = {
 		attributeNames: [
-			// Event attributes (onXYZ) must not be directly set. They can become
-			// active in the editing area (IE|WebKit).
+			// Event attributes (onXYZ) and formaction attributes must not be
+			// directly set. They can become active in the editing area (IE|WebKit).
 			[ ( /^on/ ), 'data-cke-pa-on' ],
+			[ ( /^formaction/ ), 'data-cke-pa-formaction' ],
 
 			// Prevent iframe's srcdoc attribute from being evaluated in the editable.
 			[ ( /^srcdoc/ ), 'data-cke-pa-srcdoc' ],

--- a/tests/core/htmldataprocessor/htmldataprocessor.js
+++ b/tests/core/htmldataprocessor/htmldataprocessor.js
@@ -336,6 +336,15 @@
 			assert.areSame( output, bender.tools.fixHtml( dataProcessor.toHtml( input ) ) );
 		},
 
+		test_formaction_attribute_transformation: function() {
+			var dataProcessor = this.editor.dataProcessor;
+
+			var input = '<form><button formaction="javascript:alert(document.domain)">Preview Form</button></form>',
+				output = '<form><button data-cke-pa-formaction="javascript:alert(document.domain)">Preview Form</button></form>';
+
+			assert.areSame( output, dataProcessor.toHtml( input ) );
+		},
+
 		// Spaces between filler brs should be ignored.(https://dev.ckeditor.com/ticket/4344)
 		test_spaces_between_filler_br: function() {
 			var dataProcessor = this.editor.dataProcessor;
@@ -1334,7 +1343,6 @@
 		'<p><iframe src="' + getDataString( 'window.top.%xss%', '   dAtA' ) + '"></iframe></p>', false );
 	addXssTC( tcs, 'iframe with src=data 3',
 		'<p><iframe src="' + getDataString( 'window.top.%xss%', 'd     ata' ) + '"></iframe></p>', false );
-
 
 
 	// False positive cases.


### PR DESCRIPTION
## What is the purpose of this pull request?

When you have `allowedContent` set to `true` in your config, formaction attributes can serve as a vector for XSS in the editable area. You can easily test by using this snippet in the source editor:
```html
<form>
  <button formaction="javascript:alert(document.domain)">Preview Form</button>
</form>
```

The fix in this PR is basically the same solution already implemented for onclick handlers.

## Does your PR contain necessary tests?

I added a test for the attribute transformation with `test_formaction_attribute_transformation`. However, I had trouble creating a test to confirm the actual XSS. This is what I had so far (mostly lifting logic from `addXssTC`):
```js
test_formaction_xss: function() {
	var editor = this.editors.editor2,
		xssed = false,
		input = '<form><button id="test-button" formaction="javascript:testXss()">Preview Form</button></form>',
		output = '<form><button id="test-button" data-cke-pa-formaction="javascript:testXss()">Preview Form</button></form>',
		leftMouseButton = CKEDITOR.tools.normalizeMouseButton( CKEDITOR.MOUSE_BUTTON_LEFT, true );

	window.testXss = function() {
		xssed = true;
	};

	this.editorBots.editor2.setData( input, function() {
		// Wait, because onxxx may not be synchronous.
		var buttonElement = CKEDITOR.document.getById( 'test-button' );
		buttonElement.fireEventHandler( 'click' );

		wait( function() {
			assert.isFalse( xssed, 'XSSed!' );
			if ( output !== false )
				assert.areSame( output.toLowerCase(), editor.editable().getHtml().toLowerCase(), 'output is not ok' );
		}, 10 );
	} );
},
```
I couldn't simply reuse `addXssTC`, because while those tests trigger XSS on page load, this XSS is triggered by a click. With what I wrote so far, when I run the test without the fix in place, it triggers the error as expected. However, when the fix is in place, a click redirects the page. I wasn't quite sure how to get around that while still effectively testing the XSS.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<ISSUE_NUMBER>](https://github.com/ckeditor/ckeditor4/issues/<ISSUE_NUMBER>): Prevent formaction attributes from firing javascript in the editable area.
```

## What changes did you make?

I added "formaction" as one of the default data filter rules so that it will transform into "data-cke-pa-formaction" and not trigger any javascript.

## Which issues does your PR resolve?

No open issues that I know of.
