### PR TITLE
Add `bender.loadExternalPlugin` helper

### DIFF
--- a/tests/_benderjs/ckeditor/static/extensions.js
+++ b/tests/_benderjs/ckeditor/static/extensions.js
@@ -44,6 +44,23 @@
 	}
 
 	/*
+	 * Load the given plugin via `CKEDITOR.plugins.addExternal` call when tests are run
+	 * from an external repository. If tests are run from main `ckeditor4` repository,
+	 * the given plugin is simply loaded automatically and there is no need for `CKEDITOR.plugins.addExternal` call.
+	 *
+	 * It uses the fact that bender labels all tests in `./plugins/tests/`
+	 * directory as `External Plugins` for detection, which happens only in `ckeditor4` repository.
+	 *
+	 * @param {String} name Name of the plugin to be loaded.
+	 * @param {String} path Path to the plugin directory.
+	 */
+	bender.loadExternalPlugin = function( name, path ) {
+		if ( bender.testData.group !== 'External Plugins' ) {
+			CKEDITOR.plugins.addExternal( name, path, 'plugin.js' );
+		}
+	};
+
+	/*
 	 * @param {RegExp} expected RegExp that must be matched.
 	 * @param {String} actual String value to be tested.
 	 * @param {String} [message]


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Skip.

## What changes did you make?

Introduced `bender.loadExternalPlugins` helper which should be used by external plugins in tests so test can be both run from external repo and main `ckeditor4` / `ckeditor4-presets` repo when plugin is added to plugins directory.

### How to test it?

#### `ckeditor4` repository

1. Switch to this branch.
2. Checkout Export to PDF plugin repo (`t/79` branch) and build dist version (`npm i && npm build`).
3. Copy plugin dist folder and tests to `ckeditor4/plugins/` like:
    * `cp -r ../../ckeditor4-plugin-pdfexport/dist exportpdf`
    * `cp -r ../../ckeditor4-plugin-pdfexport/tests/ exportpdf/tests/`
4. Run bender tests.

All unit and manual tests should pass the same way they pass when run from external repo (so basically just pass).

#### `ckeditor4-presets` repository

See https://github.com/ckeditor/ckeditor4-presets/pull/39.

~After having the above steps completed, go to `ckeditor4-presets` and build `full all -t` preset using local `ckediotr4` folder - since `exportpdf` plugin is already in `ckeditor4` repo it will be also included in full build. Then again check if tests are passing.~

~WIP, it seems build script messes up and doesn't copy tests from `./ckeditor/plugins/*/tests/` folder so probably needs some modification.~

## Which issues does your PR resolve?

Part of the broader issue adding ability to tests external plugins from main `ckediotr4` repo.
