### PR TITLE
Fix issue #848, arabic text not being "bound" correctly when pasting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Fixed Issues:
 * [#4273](https://github.com/ckeditor/ckeditor4/issues/4273): Fixed: memory leak in [`CKEDITOR.domReady()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-domReady) connected with not removing `load` event listeners. Thanks to [rohit1](https://github.com/rohit1)!
 * [#1330](https://github.com/ckeditor/ckeditor4/issues/1330): Fixed: Incomplete CSS margin parsing if "auto" or "0" value is used.
 * [#4286](https://github.com/ckeditor/ckeditor4/issues/4286): Fixed: The [Auto Grow](https://ckeditor.com/cke4/addon/autogrow) plugin causes editor's width to be set to 0 on editor resize.
+* [#848](https://github.com/ckeditor/ckeditor4/issues/848): Fixed: Arabic text not being "bound" correctly when pasting. Thanks to [Thomas Hunkapiller](https://github.com/devoidfury) and [J. Ivan Duarte Rodríguez](https://github.com/jidrone-mbm)!
 
 API Changes:
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -2030,7 +2030,7 @@
 			while ( ( node = that.mergeCandidates.pop() ) )
 				node.mergeSiblings();
 
-			range.startPath().block.$.normalize()
+			range.startPath().block.$.normalize();
 			range.moveToBookmark( bm );
 
 			// Rule 3.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1219,6 +1219,7 @@
 
 						if ( range.collapsed ) {
 							if ( !mergeBlocksCollapsedSelection( editor, range, backspace, startPath ) )
+								startPath.block.$.normalize();
 								return;
 						} else {
 							if ( !mergeBlocksNonCollapsedSelection( editor, range, startPath ) )
@@ -2029,7 +2030,7 @@
 			while ( ( node = that.mergeCandidates.pop() ) )
 				node.mergeSiblings();
 
-			range.root.$.normalize && range.root.$.normalize();
+			range.startPath().block.$.normalize()
 			range.moveToBookmark( bm );
 
 			// Rule 3.

--- a/core/editable.js
+++ b/core/editable.js
@@ -2029,6 +2029,7 @@
 			while ( ( node = that.mergeCandidates.pop() ) )
 				node.mergeSiblings();
 
+			range.root.$.normalize && range.root.$.normalize();
 			range.moveToBookmark( bm );
 
 			// Rule 3.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1218,9 +1218,12 @@
 							startPath = range.startPath();
 
 						if ( range.collapsed ) {
-							if ( !mergeBlocksCollapsedSelection( editor, range, backspace, startPath ) )
-								startPath.block.$.normalize();
+							if ( !mergeBlocksCollapsedSelection( editor, range, backspace, startPath ) ) {
+								if ( startPath.block ) {
+									startPath.block.$.normalize();
+								}
 								return;
+							}
 						} else {
 							if ( !mergeBlocksNonCollapsedSelection( editor, range, startPath ) )
 								return;
@@ -2030,7 +2033,9 @@
 			while ( ( node = that.mergeCandidates.pop() ) )
 				node.mergeSiblings();
 
-			range.startPath().block.$.normalize();
+			if ( range.startPath().block ) {
+				range.startPath().block.$.normalize();
+			}
 			range.moveToBookmark( bm );
 
 			// Rule 3.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1219,9 +1219,6 @@
 
 						if ( range.collapsed ) {
 							if ( !mergeBlocksCollapsedSelection( editor, range, backspace, startPath ) ) {
-								if ( startPath.block ) {
-									startPath.block.$.normalize();
-								}
 								return;
 							}
 						} else {
@@ -2030,8 +2027,9 @@
 			}
 
 			// Eventually merge identical inline elements.
-			while ( ( node = that.mergeCandidates.pop() ) )
+			while ( ( node = that.mergeCandidates.pop() ) ) {
 				node.mergeSiblings();
+			}
 
 			if ( range.startPath().block ) {
 				range.startPath().block.$.normalize();

--- a/core/editable.js
+++ b/core/editable.js
@@ -2032,31 +2032,21 @@
 				node.mergeSiblings();
 			}
 
-			range.moveToBookmark( bm );
-
 			// Normalize text nodes (#848).
 			if ( CKEDITOR.env.webkit && range.startPath() ) {
-				var path = range.startPath(),
-					container = null;
+				var path = range.startPath();
 
-				// Get parent block element.
 				if ( path.block ) {
-					container = path.block;
+					path.block.$.normalize();
 				} else if ( path.blockLimit ) {
 					// Handle ENTER_BR mode when text is direct root/body child.
 					// This will call native `normalize` on entire editor content in this case
 					// normalizing text nodes in entire editor content.
-					container = path.blockLimit;
-				}
-
-				if ( container ) {
-					var bookmark = range.createBookmark2( true );
-
-					container.$.normalize();
-
-					range.moveToBookmark( bookmark );
+					path.blockLimit.$.normalize();
 				}
 			}
+
+			range.moveToBookmark( bm );
 
 			// Rule 3.
 			// Shrink range to the BEFOREEND of previous innermost editable node in source order.

--- a/core/editable.js
+++ b/core/editable.js
@@ -1222,8 +1222,9 @@
 								return;
 							}
 						} else {
-							if ( !mergeBlocksNonCollapsedSelection( editor, range, startPath ) )
+							if ( !mergeBlocksNonCollapsedSelection( editor, range, startPath ) ) {
 								return;
+							}
 						}
 
 						// Scroll to the new position of the caret (https://dev.ckeditor.com/ticket/11960).

--- a/core/editable.js
+++ b/core/editable.js
@@ -2049,35 +2049,12 @@
 					container = path.blockLimit;
 				}
 
-				// Get text child node which holds current selection.
-				if ( container && container.type == CKEDITOR.NODE_ELEMENT && container.getChildCount() > 0 ) {
-					var childNode = container.getChild( range.startOffset - 1 );
+				if ( container ) {
+					var bookmark = range.createBookmark2( true );
 
-					if ( childNode.type == CKEDITOR.NODE_TEXT ) {
-						var prevSibling = childNode,
-							textNode = null;
+					container.$.normalize();
 
-						while ( prevSibling && prevSibling.type == CKEDITOR.NODE_TEXT ) {
-							textNode = prevSibling;
-							prevSibling = prevSibling.getPrevious();
-						}
-
-						if ( textNode ) {
-							var bm2 = range.createBookmark2( true );
-
-							var nextSibling = textNode.getNext();
-							while ( nextSibling && nextSibling.type == CKEDITOR.NODE_TEXT ) {
-								textNode.setText(
-									textNode.getText().replace( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE, '' ) +
-									nextSibling.getText().replace( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE, '' ) );
-
-								nextSibling.setText( '' );
-								nextSibling = nextSibling.getNext();
-							}
-
-							range.moveToBookmark( bm2 );
-						}
-					}
+					range.moveToBookmark( bookmark );
 				}
 			}
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -2031,9 +2031,12 @@
 				node.mergeSiblings();
 			}
 
-			if ( range.startPath().block ) {
-				range.startPath().block.$.normalize();
+			// Normalize text nodes (#848).
+			if ( CKEDITOR.env.webkit && range.startPath() ) {
+				var path = range.startPath();
+				path.block && path.block.$.normalize();
 			}
+
 			range.moveToBookmark( bm );
 
 			// Rule 3.

--- a/core/editable.js
+++ b/core/editable.js
@@ -2035,7 +2035,15 @@
 			// Normalize text nodes (#848).
 			if ( CKEDITOR.env.webkit && range.startPath() ) {
 				var path = range.startPath();
-				path.block && path.block.$.normalize();
+
+				if ( path.block ) {
+					path.block.$.normalize();
+				} else if ( path.blockLimit ) {
+					// Handle ENTER_BR mode when text is direct root/body child.
+					// This will call native `normalize` on entire editor content in this case
+					// normalizing text nodes in entire editor content.
+					path.blockLimit.$.normalize();
+				}
 			}
 
 			range.moveToBookmark( bm );

--- a/tests/core/editable/manual/pastearabic.html
+++ b/tests/core/editable/manual/pastearabic.html
@@ -11,6 +11,10 @@
 </textarea>
 
 <script type="text/javascript">
+	if ( !CKEDITOR.env.webkit || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor1', {
 		removePlugins: 'divarea'
 	} );

--- a/tests/core/editable/manual/pastearabic.html
+++ b/tests/core/editable/manual/pastearabic.html
@@ -1,0 +1,21 @@
+<textarea name="editor1">
+	<p>Paste here: </p>
+</textarea>
+<hr />
+<textarea name="editor2">
+	<p>Paste here: </p>
+</textarea>
+<hr />
+<textarea name="editor3">
+	<p>Paste here: </p>
+</textarea>
+
+<script type="text/javascript">
+	CKEDITOR.replace( 'editor1', {
+		removePlugins: 'divarea'
+	} );
+
+	CKEDITOR.replace( 'editor2' );
+
+	CKEDITOR.inline( 'editor3' );
+</script>

--- a/tests/core/editable/manual/pastearabic.md
+++ b/tests/core/editable/manual/pastearabic.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.15.1, bug, 848
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, divarea, floatingspace
+
+## Test scenario
+
+1. Copy the following text: عام
+1. For each editor:
+	1. Focus editor.
+	1. Paste copied text 3 times.
+
+## Expected result
+
+The pasted text is merged into single entity عامعامعام.
+
+## Unexpected
+
+3 separate words are inserted like عام عام عام (with or without spaces in-between).

--- a/tests/core/editable/manual/pastearabic.md
+++ b/tests/core/editable/manual/pastearabic.md
@@ -2,8 +2,6 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, divarea, floatingspace
 
-## Test scenario
-
 1. Copy the following text: عام
 1. For each editor:
 	1. Focus editor.

--- a/tests/core/editable/manual/pastearabicenterbr.html
+++ b/tests/core/editable/manual/pastearabicenterbr.html
@@ -1,0 +1,30 @@
+<textarea name="editor1">
+	Paste here:
+</textarea>
+<hr />
+<textarea name="editor2">
+	Paste here:
+</textarea>
+<hr />
+<textarea name="editor3">
+	Paste here:
+</textarea>
+
+<script type="text/javascript">
+	if ( !CKEDITOR.env.webkit || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1', {
+		removePlugins: 'divarea',
+		enterMode: CKEDITOR.ENTER_BR
+	} );
+
+	CKEDITOR.replace( 'editor2', {
+		enterMode: CKEDITOR.ENTER_BR
+	} );
+
+	CKEDITOR.inline( 'editor3', {
+		enterMode: CKEDITOR.ENTER_BR
+	} );
+</script>

--- a/tests/core/editable/manual/pastearabicenterbr.md
+++ b/tests/core/editable/manual/pastearabicenterbr.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.15.1, bug, 848
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, divarea, floatingspace
+
+1. Copy the following text: عام
+1. For each editor:
+	1. Focus editor.
+	1. Paste copied text 3 times.
+
+## Expected result
+
+The pasted text is merged into single entity عامعامعام.
+
+## Unexpected
+
+3 separate words are inserted like عام عام عام (with or without spaces in-between).

--- a/tests/core/editable/manual/typeime.html
+++ b/tests/core/editable/manual/typeime.html
@@ -1,0 +1,20 @@
+<textarea name="editor1">
+	<p>Type here: </p>
+</textarea>
+<hr />
+<textarea name="editor2">
+	<p>Type here: </p>
+</textarea>
+<hr />
+<p>Native textarea:</p>
+<textarea rows="10" cols="40">
+Type here:
+</textarea>
+
+<script type="text/javascript">
+	CKEDITOR.replace( 'editor1', {
+		removePlugins: 'divarea'
+	} );
+
+	CKEDITOR.replace( 'editor2' );
+</script>

--- a/tests/core/editable/manual/typeime.html
+++ b/tests/core/editable/manual/typeime.html
@@ -12,6 +12,10 @@ Type here:
 </textarea>
 
 <script type="text/javascript">
+	if ( !CKEDITOR.env.webkit || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor1', {
 		removePlugins: 'divarea'
 	} );

--- a/tests/core/editable/manual/typeime.html
+++ b/tests/core/editable/manual/typeime.html
@@ -7,7 +7,7 @@
 </textarea>
 <hr />
 <p>Native textarea:</p>
-<textarea rows="10" cols="40">
+<textarea id="native" rows="10" cols="40" style="font-size: 16px;">
 Type here:
 </textarea>
 
@@ -20,5 +20,15 @@ Type here:
 		removePlugins: 'divarea'
 	} );
 
-	CKEDITOR.replace( 'editor2' );
+	CKEDITOR.replace( 'editor2', {
+		on: {
+			// Set the native textarea font-family to the same as inline editor
+			// to ease the comparison.
+			instanceReady: function( evt ) {
+				var fontFamily = evt.editor.container.getComputedStyle( 'font-family' );
+
+				CKEDITOR.document.getById( 'native' ).setStyle( 'font-family', fontFamily );
+			}
+		}
+	} );
 </script>

--- a/tests/core/editable/manual/typeime.md
+++ b/tests/core/editable/manual/typeime.md
@@ -2,8 +2,6 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, divarea
 
-## Test scenario
-
 **Perform below steps for both editors**.
 
 1. Switch OS keyboard to language requiring composition (Japanese, Chinese, Arabic).
@@ -22,4 +20,4 @@
 * Composition stops unexpectedly.
 * IME panel becomes unresponsive.
 
-**Note**: to check the expected result of composition you may check how it works in native `textarea`.
+**Note**: To check the expected result of composition you may check how it works in native `textarea`.

--- a/tests/core/editable/manual/typeime.md
+++ b/tests/core/editable/manual/typeime.md
@@ -1,0 +1,25 @@
+@bender-tags: 4.15.1, bug, 848
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, divarea
+
+## Test scenario
+
+**Perform below steps for both editors**.
+
+1. Switch OS keyboard to language requiring composition (Japanese, Chinese, Arabic).
+1. Focus editor.
+1. Type some text.
+
+## Expected result
+
+* Characters are merged correctly during typing.
+* IME panel doesn't hide or hangs unexpectedly.
+* Composition works correctly.
+
+## Unexpected
+
+* Characters aren't composed as they should be.
+* Composition stops unexpectedly.
+* IME panel becomes unresponsive.
+
+**Note**: to check the expected result of composition you may check how it works in native `textarea`.

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -36,7 +36,7 @@
 		'arabic text should be composed correctly on insertion (case 1)': function() {
 			var editor = this.editors.enterp;
 
-			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
 
 			editor.insertText( 'عام' );
 			editor.insertText( 'عام' );
@@ -50,7 +50,7 @@
 		'arabic text should be composed correctly on insertion (case 2)': function() {
 			var editor = this.editors.enterp;
 
-			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
 
 			editor.insertText( 'عام' );
 			editor.insertText( 'عام' );
@@ -65,7 +65,7 @@
 		'arabic text should be composed correctly on insertion (enter_br, case 1)': function() {
 			var editor = this.editors.enterbr;
 
-			setHtmlWithSelection( editor, 'Text: ^' );
+			setHtmlWithSelection( editor, 'Text:&nbsp;^' );
 
 			editor.insertText( 'عام' );
 			editor.insertText( 'عام' );
@@ -79,7 +79,7 @@
 		'arabic text should be composed correctly on insertion (enter_br, case 2)': function() {
 			var editor = this.editors.enterbr;
 
-			setHtmlWithSelection( editor, 'Foo Bar<div>Text: ^</div>' );
+			setHtmlWithSelection( editor, 'Foo Bar<div>Text:&nbsp;^</div>' );
 
 			editor.insertText( 'عام' );
 			editor.insertText( 'عام' );
@@ -93,7 +93,7 @@
 		'regular text should be normalized': function() {
 			var editor = this.editors.enterp;
 
-			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
 
 			editor.insertText( '123' );
 			editor.insertText( ' 456' );
@@ -107,7 +107,7 @@
 		'regular text should be normalized (enter_br)': function() {
 			var editor = this.editors.enterbr;
 
-			setHtmlWithSelection( editor, 'Text: ^' );
+			setHtmlWithSelection( editor, 'Text:&nbsp;^' );
 
 			editor.insertText( '123' );
 			editor.insertText( ' 456' );
@@ -121,7 +121,7 @@
 		'text nodes in other block elements should not be touched (before)': function() {
 			var editor = this.editors.enterp;
 
-			setHtmlWithSelection( editor, '<p>Foo Bar Baz</p><p>Text2: ^</p>' );
+			setHtmlWithSelection( editor, '<p>Foo Bar Baz</p><p>Text2:&nbsp;^</p>' );
 
 			var paragraph1 = editor.editable().find( 'p' ).getItem( 0 );
 
@@ -144,7 +144,7 @@
 		'text nodes in other block elements should not be touched (after)': function() {
 			var editor = this.editors.enterp;
 
-			setHtmlWithSelection( editor, '<p>Text1: ^</p><p>Foo Bar Baz</p>' );
+			setHtmlWithSelection( editor, '<p>Text1:&nbsp;^</p><p>Foo Bar Baz</p>' );
 
 			var paragraph2 = editor.editable().find( 'p' ).getItem( 1 );
 
@@ -167,7 +167,7 @@
 		'text nodes in other block elements will be touched for root text (enter_br, after)': function() {
 			var editor = this.editors.enterbr;
 
-			setHtmlWithSelection( editor, 'Text1: ^<div>Foo Bar Baz</div>' );
+			setHtmlWithSelection( editor, 'Text1:&nbsp;^<div>Foo Bar Baz</div>' );
 
 			var div = editor.editable().find( 'div' ).getItem( 0 );
 
@@ -190,7 +190,7 @@
 		'composable text which is not normally merged should not be merged due to normalization': function() {
 			var editor = this.editors.enterp;
 
-			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
 
 			editor.insertText( 'ｈ' );
 			editor.insertText( 'え' );
@@ -216,7 +216,10 @@
 		// creating correct arabic text (I guess that's how correct unicode handling should work)
 		// so we need to return and compare array where each item represents single text node contents.
 		var nonEmptyTextNodes = CKEDITOR.tools.array.filter( element.getChildren().toArray(), function( child ) {
-			// Filter non-text nodes, empty text nodes and text nodes containing "filling char sequence" only.
+			// Filter:
+			// * non-text nodes
+			// * empty text nodes
+			// * text nodes containing "filling char sequence" only
 			return child.type === CKEDITOR.NODE_TEXT && child.getText() !== CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
 		} );
 

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -64,34 +64,6 @@
 		},
 
 		// (#848).
-		'test arabic text should be composed correctly on insertion (middle)': function() {
-			var editor = this.editors.enterp;
-
-			setHtmlWithSelection( editor, '<p>Text:&nbsp;عامعا^معام</p>' );
-
-			editor.insertText( 'عام' );
-
-			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
-
-			assertTextNormalization( paragraph, 'Text: عامعاعاممعام' );
-			assertCaretPosition( '<p>Text:&nbsp;عامعاعام^معام</p>', editor );
-		},
-
-		// (#848).
-		'test arabic text should be composed correctly on insertion (beginning)': function() {
-			var editor = this.editors.enterp;
-
-			setHtmlWithSelection( editor, '<p>Text:&nbsp;^عامعامعام</p>' );
-
-			editor.insertText( 'عام' );
-
-			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
-
-			assertTextNormalization( paragraph, 'Text: عامعامعامعام' );
-			assertCaretPosition( '<p>Text:&nbsp;عام^عامعامعام</p>', editor );
-		},
-
-		// (#848).
 		'test arabic text should be composed correctly on insertion (enter_br, case 1)': function() {
 			var editor = this.editors.enterbr;
 

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -33,7 +33,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (end, case 1)': function() {
+		'test arabic text should be composed correctly on insertion (end, case 1)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
@@ -48,7 +48,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (end, case 2)': function() {
+		'test arabic text should be composed correctly on insertion (end, case 2)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
@@ -64,7 +64,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (middle)': function() {
+		'test arabic text should be composed correctly on insertion (middle)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;عامعا^معام</p>' );
@@ -78,7 +78,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (beginning)': function() {
+		'test arabic text should be composed correctly on insertion (beginning)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^عامعامعام</p>' );
@@ -92,7 +92,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (enter_br, case 1)': function() {
+		'test arabic text should be composed correctly on insertion (enter_br, case 1)': function() {
 			var editor = this.editors.enterbr;
 
 			setHtmlWithSelection( editor, 'Text:&nbsp;^' );
@@ -107,7 +107,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (enter_br, case 2)': function() {
+		'test arabic text should be composed correctly on insertion (enter_br, case 2)': function() {
 			var editor = this.editors.enterbr;
 
 			setHtmlWithSelection( editor, 'Foo Bar<div>Text:&nbsp;^</div>' );
@@ -122,7 +122,7 @@
 		},
 
 		// (#848).
-		'regular text should be normalized': function() {
+		'test regular text should be normalized': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
@@ -137,7 +137,7 @@
 		},
 
 		// (#848).
-		'regular text should be normalized (enter_br)': function() {
+		'test regular text should be normalized (enter_br)': function() {
 			var editor = this.editors.enterbr;
 
 			setHtmlWithSelection( editor, 'Text:&nbsp;^' );
@@ -152,7 +152,7 @@
 		},
 
 		// (#848).
-		'text nodes in other block elements should not be touched (before)': function() {
+		'test text nodes in other block elements should not be touched (before)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Foo Bar Baz</p><p>Text2:&nbsp;^</p>' );
@@ -176,7 +176,7 @@
 		},
 
 		// (#848).
-		'text nodes in other block elements should not be touched (after)': function() {
+		'test text nodes in other block elements should not be touched (after)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text1:&nbsp;^</p><p>Foo Bar Baz</p>' );
@@ -200,7 +200,7 @@
 		},
 
 		// (#848).
-		'text nodes in other block elements will be touched for root text (enter_br, after)': function() {
+		'test text nodes in other block elements will be touched for root text (enter_br, after)': function() {
 			var editor = this.editors.enterbr;
 
 			setHtmlWithSelection( editor, 'Text1:&nbsp;^<div>Foo Bar Baz</div>' );
@@ -224,7 +224,7 @@
 		},
 
 		// (#848).
-		'composable text which is not normally merged should not be merged due to normalization': function() {
+		'test composable text which is not normally merged should not be merged due to normalization': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -18,6 +18,7 @@
 			}
 		},
 
+		// (#848).
 		'arabic text should be composed correctly on insertion (case 1)': function() {
 			var editor = this.editor;
 
@@ -31,6 +32,7 @@
 			assertTextNormalization( paragraph, 'Text: عامعام' );
 		},
 
+		// (#848).
 		'arabic text should be composed correctly on insertion (case 2)': function() {
 			var editor = this.editor;
 
@@ -45,6 +47,7 @@
 			assertTextNormalization( paragraph, 'Text: عامعامعام' );
 		},
 
+		// (#848).
 		'regular text should be normalized': function() {
 			var editor = this.editor;
 
@@ -58,6 +61,7 @@
 			assertTextNormalization( paragraph, 'Text: 123 456' );
 		},
 
+		// (#848).
 		'text nodes in other block elements should not be touched (before)': function() {
 			var editor = this.editor;
 
@@ -80,6 +84,7 @@
 			assertTextNormalization( paragraph2, 'Text2: Bax Bay' );
 		},
 
+		// (#848).
 		'text nodes in other block elements should not be touched (after)': function() {
 			var editor = this.editor;
 
@@ -102,6 +107,7 @@
 			assertTextNormalization( paragraph1, 'Text1: Bax Bay' );
 		},
 
+		// (#848).
 		'composable text which is not normally merged should not be merged due to normalization': function() {
 			var editor = this.editor;
 

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -73,7 +73,7 @@
 
 			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
 
-			assertTextNormalization( paragraph, 'Text:&nbsp;عامعاعاممعام' );
+			assertTextNormalization( paragraph, 'Text: عامعاعاممعام' );
 			assertCaretPosition( '<p>Text:&nbsp;عامعاعام^معام</p>', editor );
 		},
 
@@ -200,7 +200,7 @@
 		},
 
 		// (#848).
-		'test text nodes in other block elements will be touched for root text (enter_br, after)': function() {
+		'test text nodes in other block elements will not be touched for root text (enter_br, after)': function() {
 			var editor = this.editors.enterbr;
 
 			setHtmlWithSelection( editor, 'Text1:&nbsp;^<div>Foo Bar Baz</div>' );
@@ -218,7 +218,7 @@
 
 			var body = editor.editable();
 
-			assertTextNodes( div, [ 'Foo Bar Baz' ] );
+			assertTextNodes( div, [ 'Foo Bar', ' Baz' ] );
 			assertTextNormalization( body, 'Text1: Bax Bay' );
 			assertCaretPosition( 'Text1:&nbsp;Bax&nbsp;Bay^<div>Foo Bar Baz</div>', editor );
 		},
@@ -263,7 +263,8 @@
 			// * non-text nodes
 			// * empty text nodes
 			// * text nodes containing "filling char sequence" only
-			return child.type === CKEDITOR.NODE_TEXT && child.getText() !== CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE;
+			return child.type === CKEDITOR.NODE_TEXT &&
+				( child.getText() !== CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE && child.getText().length > 0 );
 		} );
 
 		return CKEDITOR.tools.array.map( nonEmptyTextNodes, function( textNode ) {

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -200,7 +200,7 @@
 		},
 
 		// (#848).
-		'test text nodes in other block elements will not be touched for root text (enter_br, after)': function() {
+		'test text nodes in other block elements will be touched for root text (enter_br, after)': function() {
 			var editor = this.editors.enterbr;
 
 			setHtmlWithSelection( editor, 'Text1:&nbsp;^<div>Foo Bar Baz</div>' );
@@ -218,7 +218,7 @@
 
 			var body = editor.editable();
 
-			assertTextNodes( div, [ 'Foo Bar', ' Baz' ] );
+			assertTextNodes( div, [ 'Foo Bar Baz' ] );
 			assertTextNormalization( body, 'Text1: Bax Bay' );
 			assertCaretPosition( 'Text1:&nbsp;Bax&nbsp;Bay^<div>Foo Bar Baz</div>', editor );
 		},

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -33,7 +33,7 @@
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (case 1)': function() {
+		'arabic text should be composed correctly on insertion (end, case 1)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
@@ -44,10 +44,11 @@
 			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
 
 			assertTextNormalization( paragraph, 'Text: عامعام' );
+			assertCaretPosition( '<p>Text:&nbsp;عامعام^</p>', editor );
 		},
 
 		// (#848).
-		'arabic text should be composed correctly on insertion (case 2)': function() {
+		'arabic text should be composed correctly on insertion (end, case 2)': function() {
 			var editor = this.editors.enterp;
 
 			setHtmlWithSelection( editor, '<p>Text:&nbsp;^</p>' );
@@ -59,6 +60,35 @@
 			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
 
 			assertTextNormalization( paragraph, 'Text: عامعامعام' );
+			assertCaretPosition( '<p>Text:&nbsp;عامعامعام^</p>', editor );
+		},
+
+		// (#848).
+		'arabic text should be composed correctly on insertion (middle)': function() {
+			var editor = this.editors.enterp;
+
+			setHtmlWithSelection( editor, '<p>Text:&nbsp;عامعا^معام</p>' );
+
+			editor.insertText( 'عام' );
+
+			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNormalization( paragraph, 'Text:&nbsp;عامعاعاممعام' );
+			assertCaretPosition( '<p>Text:&nbsp;عامعاعام^معام</p>', editor );
+		},
+
+		// (#848).
+		'arabic text should be composed correctly on insertion (beginning)': function() {
+			var editor = this.editors.enterp;
+
+			setHtmlWithSelection( editor, '<p>Text:&nbsp;^عامعامعام</p>' );
+
+			editor.insertText( 'عام' );
+
+			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNormalization( paragraph, 'Text: عامعامعامعام' );
+			assertCaretPosition( '<p>Text:&nbsp;عام^عامعامعام</p>', editor );
 		},
 
 		// (#848).
@@ -73,6 +103,7 @@
 			var body = editor.editable();
 
 			assertTextNormalization( body, 'Text: عامعام' );
+			assertCaretPosition( 'Text:&nbsp;عامعام^', editor );
 		},
 
 		// (#848).
@@ -87,6 +118,7 @@
 			var div = editor.editable().find( 'div' ).getItem( 0 );
 
 			assertTextNormalization( div, 'Text: عامعام' );
+			assertCaretPosition( 'Foo Bar<div>Text:&nbsp;عامعام^</div>', editor );
 		},
 
 		// (#848).
@@ -101,6 +133,7 @@
 			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
 
 			assertTextNormalization( paragraph, 'Text: 123 456' );
+			assertCaretPosition( '<p>Text:&nbsp;123&nbsp;456^</p>', editor );
 		},
 
 		// (#848).
@@ -115,6 +148,7 @@
 			var paragraph = editor.editable();
 
 			assertTextNormalization( paragraph, 'Text: 123 456' );
+			assertCaretPosition( 'Text:&nbsp;123&nbsp;456^', editor );
 		},
 
 		// (#848).
@@ -138,6 +172,7 @@
 
 			assertTextNodes( paragraph1, [ 'Foo ', 'Bar Baz' ] );
 			assertTextNormalization( paragraph2, 'Text2: Bax Bay' );
+			assertCaretPosition( '<p>Foo Bar Baz</p><p>Text2:&nbsp;Bax&nbsp;Bay^</p>', editor );
 		},
 
 		// (#848).
@@ -161,6 +196,7 @@
 
 			assertTextNodes( paragraph2, [ 'Foo Bar', ' Baz' ] );
 			assertTextNormalization( paragraph1, 'Text1: Bax Bay' );
+			assertCaretPosition( '<p>Text1:&nbsp;Bax&nbsp;Bay^</p><p>Foo Bar Baz</p>', editor );
 		},
 
 		// (#848).
@@ -184,6 +220,7 @@
 
 			assertTextNodes( div, [ 'Foo Bar Baz' ] );
 			assertTextNormalization( body, 'Text1: Bax Bay' );
+			assertCaretPosition( 'Text1:&nbsp;Bax&nbsp;Bay^<div>Foo Bar Baz</div>', editor );
 		},
 
 		// (#848).
@@ -198,11 +235,16 @@
 			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
 
 			assertTextNormalization( paragraph, 'Text: ｈえ' );
+			assertCaretPosition( '<p>Text:&nbsp;ｈえ^</p>', editor );
 		}
 	} );
 
 	function assertTextNormalization( element, expectedText ) {
 		assertTextNodes( element, [ expectedText ] );
+	}
+
+	function assertCaretPosition( expected, editor ) {
+		assert.areSame( expected, normalizeText( bender.tools.getHtmlWithSelection( editor ) ) );
 	}
 
 	function assertTextNodes( element, textNodesContents ) {
@@ -225,10 +267,14 @@
 		} );
 
 		return CKEDITOR.tools.array.map( nonEmptyTextNodes, function( textNode ) {
-			// Replace "&nbsp;" and "filling char sequence" for easy text nodes comparison.
-			return textNode.getText()
-				.replace( /\u00a0/g, ' ' )
-				.replace( new RegExp( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE, 'g' ), '' );
+			return normalizeText( textNode.getText() );
 		} );
+	}
+
+	function normalizeText( str ) {
+		// Replace "&nbsp;" and "filling char sequence" for easy text nodes comparison.
+		return str
+			.replace( /\u00a0/g, ' ' )
+			.replace( new RegExp( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE, 'g' ), '' );
 	}
 } )();

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -215,6 +215,7 @@
 		// If the mapped array is joined (to create single text entry) it also merges text
 		// creating correct arabic text (I guess that's how correct unicode handling should work)
 		// so we need to return and compare array where each item represents single text node contents.
+
 		var nonEmptyTextNodes = CKEDITOR.tools.array.filter( element.getChildren().toArray(), function( child ) {
 			// Filter:
 			// * non-text nodes
@@ -224,6 +225,7 @@
 		} );
 
 		return CKEDITOR.tools.array.map( nonEmptyTextNodes, function( textNode ) {
+			// Replace "&nbsp;" and "filling char sequence" for easy text nodes comparison.
 			return textNode.getText()
 				.replace( /\u00a0/g, ' ' )
 				.replace( new RegExp( CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE, 'g' ), '' );

--- a/tests/core/editable/textnormalization.js
+++ b/tests/core/editable/textnormalization.js
@@ -1,0 +1,137 @@
+/* bender-tags: editor,insertion */
+
+( function() {
+	'use strict';
+
+	var setHtmlWithSelection = bender.tools.setHtmlWithSelection;
+
+	bender.editor = {
+		config: {
+			allowedContent: true
+		}
+	};
+
+	bender.test( {
+		setUp: function() {
+			if ( !CKEDITOR.env.webkit ) {
+				assert.ignore();
+			}
+		},
+
+		'arabic text should be composed correctly on insertion (case 1)': function() {
+			var editor = this.editor;
+
+			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+
+			editor.insertText( 'عام' );
+			editor.insertText( 'عام' );
+
+			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNormalization( paragraph, 'Text: عامعام' );
+		},
+
+		'arabic text should be composed correctly on insertion (case 2)': function() {
+			var editor = this.editor;
+
+			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+
+			editor.insertText( 'عام' );
+			editor.insertText( 'عام' );
+			editor.insertText( 'عام' );
+
+			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNormalization( paragraph, 'Text: عامعامعام' );
+		},
+
+		'regular text should be normalized': function() {
+			var editor = this.editor;
+
+			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+
+			editor.insertText( '123' );
+			editor.insertText( ' 456' );
+
+			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNormalization( paragraph, 'Text: 123 456' );
+		},
+
+		'text nodes in other block elements should not be touched (before)': function() {
+			var editor = this.editor;
+
+			setHtmlWithSelection( editor, '<p>Foo Bar Baz</p><p>Text2: ^</p>' );
+
+			var paragraph1 = editor.editable().find( 'p' ).getItem( 0 );
+
+			// Split single text node into few separate text nodes in first paragraph.
+			paragraph1.getChild( 0 ).split( 4 );
+
+			assertTextNodes( paragraph1, [ 'Foo ', 'Bar Baz' ] );
+
+			// Insert text which triggers normalization.
+			editor.insertText( 'Bax' );
+			editor.insertText( ' Bay' );
+
+			var paragraph2 = editor.editable().find( 'p' ).getItem( 1 );
+
+			assertTextNodes( paragraph1, [ 'Foo ', 'Bar Baz' ] );
+			assertTextNormalization( paragraph2, 'Text2: Bax Bay' );
+		},
+
+		'text nodes in other block elements should not be touched (after)': function() {
+			var editor = this.editor;
+
+			setHtmlWithSelection( editor, '<p>Text1: ^</p><p>Foo Bar Baz</p>' );
+
+			var paragraph2 = editor.editable().find( 'p' ).getItem( 1 );
+
+			// Split single text node into few separate text nodes in first paragraph.
+			paragraph2.getChild( 0 ).split( 7 );
+
+			assertTextNodes( paragraph2, [ 'Foo Bar', ' Baz' ] );
+
+			// Insert text which triggers normalization.
+			editor.insertText( 'Bax' );
+			editor.insertText( ' Bay' );
+
+			var paragraph1 = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNodes( paragraph2, [ 'Foo Bar', ' Baz' ] );
+			assertTextNormalization( paragraph1, 'Text1: Bax Bay' );
+		},
+
+		'composable text which is not normally merged should not be merged due to normalization': function() {
+			var editor = this.editor;
+
+			setHtmlWithSelection( editor, '<p>Text: ^</p>' );
+
+			editor.insertText( 'ｈ' );
+			editor.insertText( 'え' );
+
+			var paragraph = editor.editable().find( 'p' ).getItem( 0 );
+
+			assertTextNormalization( paragraph, 'Text: ｈえ' );
+		}
+	} );
+
+	function assertTextNormalization( element, expectedText ) {
+		assertTextNodes( element, [ expectedText ] );
+	}
+
+	function assertTextNodes( element, textNodesContents ) {
+		// Even native innerHTML() method normalizes text nodes when called
+		// so we have to check text contents manually by iterating over text nodes.
+		objectAssert.areDeepEqual( textNodesContents, getTextNodesContents( element ) );
+	}
+
+	function getTextNodesContents( element ) {
+		// If the mapped array is joined (to create single text entry) it also merges text
+		// creating correct arabic text (I guess that's how correct unicode handling should work)
+		// so we need to return and compare array where each item represents single text node contents.
+		return CKEDITOR.tools.array.map( element.getChildren().toArray(), function( child ) {
+			return child.getText().replace( /\u00a0/g, ' ' );
+		} );
+	}
+} )();


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#848](https://github.com/ckeditor/ckeditor4/issues/848): Fixes arabic text not being "bound" correctly when pasting.
```

## What changes did you make?

Edit by @f1ames:

> This change uses the native Element.prototype.normalize method to merge sibling TextNodes automatically, if the method is available.
> Should cause Chrome to trigger ligatures/"bounding" correctly.

I have rework the fix to only normalize text node in Chrome since it is Chrome only issue. Since this is a core change, the changes should be precise to not touch browsers where it works fine.

> I'm not entirely clear on how to add a test here, since it purely addresses a rendering bug in chrome.

I have added manual tests (one for #848 and one IME generic) and also unit tests.

As mentioned, this fix touches core mechanics. I haven't found any issues and other IMEs seems to also work fine. Still it should be checked and tested thoroughly. 

## Which issues does your PR resolve?

Closes #848.
