### PR TITLE
Ignore exportPdf cmd in readonly commands test

### DIFF
--- a/tests/core/command/command.js
+++ b/tests/core/command/command.js
@@ -6,7 +6,7 @@
 // This list of commands are to be maintained whenever new commands are added.
 var READ_ONLY_CMDS = [
 	'a11yHelp', 'autogrow', 'about', 'contextMenu', 'copy', 'elementsPathFocus', 'find', 'maximize',
-	'preview', 'print', 'showblocks', 'showborders', 'source', 'toolbarCollapse', 'toolbarFocus', 'selectAll'
+	'preview', 'print', 'showblocks', 'showborders', 'source', 'toolbarCollapse', 'toolbarFocus', 'selectAll', 'exportPdf'
 ];
 
 function assertCommand( editor, cmd, commandDefinition ) {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Test fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Skip.

## What changes did you make?

The cmd is enabled in readonly mode thus should be ingored in this test as it fails now
![image](https://user-images.githubusercontent.com/1061942/91957372-37349100-ed06-11ea-9240-def5ff175eac.png)

## Which issues does your PR resolve?

None.
