### PR TITLE
Keep stylesLoaded out of global context (taken over)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.15.1
 
+Other Changes:
+
+* [#4262](https://github.com/ckeditor/ckeditor4/issues/4262): Removed global reference to `stylesLoaded` variable. Thanks to [Levi Carter](https://github.com/swiftMessenger)!
+
 ## CKEditor 4.15
 
 New features:

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3497,7 +3497,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			return dialog;
 		}
 	} );
-	
+
 	CKEDITOR.plugins.add( 'dialog', {
 		requires: 'dialogui',
 		init: function( editor ) {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3498,7 +3498,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	} );
 	
-	// Dialog related configurations.
 	CKEDITOR.plugins.add( 'dialog', {
 		requires: 'dialogui',
 		init: function( editor ) {
@@ -3514,6 +3513,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 		}
 	} );
 } )();
+
+
+// Dialog related configurations.
 
 /**
  * The color of the dialog background cover. It should be a valid CSS color string.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -66,7 +66,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 
 	var cssLength = CKEDITOR.tools.cssLength,
 		defaultDialogDefinition,
-		currentCover;
+		currentCover,
+		stylesLoaded = false;
 
 	function focusActiveTab( dialog ) {
 		dialog._.tabBarMode = true;
@@ -3496,26 +3497,23 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			return dialog;
 		}
 	} );
-} )();
+	
+	// Dialog related configurations.
+	CKEDITOR.plugins.add( 'dialog', {
+		requires: 'dialogui',
+		init: function( editor ) {
+			if ( !stylesLoaded ) {
+				CKEDITOR.document.appendStyleSheet( this.path + 'styles/dialog.css' );
+				stylesLoaded = true;
+			}
 
-var stylesLoaded = false;
-
-CKEDITOR.plugins.add( 'dialog', {
-	requires: 'dialogui',
-	init: function( editor ) {
-		if ( !stylesLoaded ) {
-			CKEDITOR.document.appendStyleSheet( this.path + 'styles/dialog.css' );
-			stylesLoaded = true;
+			editor.on( 'doubleclick', function( evt ) {
+				if ( evt.data.dialog )
+					editor.openDialog( evt.data.dialog );
+			}, null, null, 999 );
 		}
-
-		editor.on( 'doubleclick', function( evt ) {
-			if ( evt.data.dialog )
-				editor.openDialog( evt.data.dialog );
-		}, null, null, 999 );
-	}
-} );
-
-// Dialog related configurations.
+	} );
+} )();
 
 /**
  * The color of the dialog background cover. It should be a valid CSS color string.

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -81,6 +81,11 @@
 	bender.editor = {};
 
 	bender.test( {
+		// (#4262)
+		'test stylesLoaded is not polluting global context': function() {
+			assert.isUndefined( window.stylesLoaded );
+		},
+
 		'test open dialog from local': function() {
 			var ed = this.editor, tc = this;
 			ed.openDialog( 'testDialog1', function( dialog ) {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Changelog entry should be placed under `Other Changes`.

```
* [#4262](https://github.com/ckeditor/ckeditor4/issues/4262): Removed global reference to `stylesLoaded` variable. Thanks to [
Levi Carter](https://github.com/swiftMessenger)!
```

## What changes did you make?

I've taken over https://github.com/ckeditor/ckeditor4/pull/4194 and since a lot of changed in the base branch, it was much easier to just cherry-pick changes.

## Which issues does your PR resolve?

Closes #4262

