### PR TITLE
Fix resize table with rowspan cells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.15.1
 
+Fixed Issues:
+
+* [#3961](https://github.com/ckeditor/ckeditor4/issues/3961): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) prevents editing of merged cells.
+
 Other Changes:
 
 * [#4262](https://github.com/ckeditor/ckeditor4/issues/4262): Removed global reference to `stylesLoaded` variable. Thanks to [Levi Carter](https://github.com/swiftMessenger)!

--- a/core/tools.js
+++ b/core/tools.js
@@ -2199,6 +2199,27 @@
 				}
 
 				return false;
+			},
+
+			/**
+			 * Zips corresponding objects from two arrays into a single array of object pairs.
+			 *
+			 * ```js
+			 * var zip = CKEDITOR.tools.array.zip( [ 'foo', 'bar', 'baz' ], [ 1, 2, 3 ] );
+			 * console.log( zip );
+			 * // Logs: [ [ 'foo', 1 ], [ 'bar', 2 ], [ 'baz', 3 ] ];
+			 * ```
+			 *
+			 * @since 4.15.1
+			 * @member CKEDITOR.tools.array
+			 * @param {Array} array1
+			 * @param {Array} array2
+			 * @returns {Array} Two dimensional array of object pairs.
+			 */
+			zip: function( array1, array2 ) {
+				return CKEDITOR.tools.array.map( array1, function( value, index ) {
+					return [ value, array2[ index ] ];
+				} );
 			}
 		},
 

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -93,7 +93,7 @@
 					x = table.getDocumentPosition().x;
 
 					if ( rtl ) {
-						pillarLeft = x
+						pillarLeft = x;
 					} else {
 						pillarRight = x + table.$.offsetWidth;
 					}

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -43,11 +43,11 @@
 			pillarIndexMap = {},
 			rtl = table.getComputedStyle( 'direction' ) === 'rtl',
 			// We are building table map to expand row spans (#3961).
-			rows = CKEDITOR.tools.array.zip( Array.prototype.slice.apply( table.$.rows ),
+			rows = CKEDITOR.tools.array.zip( new CKEDITOR.dom.nodeList( table.$.rows ).toArray(),
 				CKEDITOR.tools.buildTableMap( table ) );
 
 		CKEDITOR.tools.array.forEach( rows, function( item ) {
-			var $tr = item[ 0 ],
+			var $tr = item[ 0 ].$,
 				cells = item[ 1 ],
 				pillarIndex = -1,
 				pillarHeight = 0,

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -41,12 +41,14 @@
 	function buildTableColumnPillars( table ) {
 		var pillars = [],
 			pillarIndexMap = {},
-			rtl = table.getComputedStyle( 'direction' ) === 'rtl';
-
-		var rows = table.$.rows;
+			rtl = table.getComputedStyle( 'direction' ) === 'rtl',
+			// We are building table map to expand row spans (#3961).
+			rows = CKEDITOR.tools.array.zip( Array.prototype.slice.apply( table.$.rows ),
+				CKEDITOR.tools.buildTableMap( table ) );
 
 		CKEDITOR.tools.array.forEach( rows, function( item ) {
-			var $tr = item,
+			var $tr = item[ 0 ],
+				cells = item[ 1 ],
 				pillarIndex = -1,
 				pillarHeight = 0,
 				pillarPosition = null,
@@ -58,11 +60,11 @@
 			pillarPosition = pillarDimensions.position;
 
 			// Loop thorugh all cells, building pillars after each one of them.
-			for ( var i = 0, len = $tr.cells.length; i < len; i++ ) {
+			for ( var i = 0; i < cells.length; i++ ) {
 				// Both the current cell and the successive one will be used in the
 				// pillar size calculation.
-				var td = new CKEDITOR.dom.element( $tr.cells[ i ] ),
-					nextTd = $tr.cells[ i + 1 ] && new CKEDITOR.dom.element( $tr.cells[ i + 1 ] ),
+				var td = new CKEDITOR.dom.element( cells[ i ] ),
+					nextTd = cells[ i + 1 ] && new CKEDITOR.dom.element( cells[ i + 1 ] ),
 					pillar,
 					pillarLeft,
 					pillarRight,

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -41,7 +41,7 @@
 	function buildTableColumnPillars( table ) {
 		var pillars = [],
 			pillarIndexMap = {},
-			rtl = ( table.getComputedStyle( 'direction' ) == 'rtl' );
+			rtl = table.getComputedStyle( 'direction' ) === 'rtl';
 
 		var rows = table.$.rows;
 
@@ -63,29 +63,40 @@
 				// pillar size calculation.
 				var td = new CKEDITOR.dom.element( $tr.cells[ i ] ),
 					nextTd = $tr.cells[ i + 1 ] && new CKEDITOR.dom.element( $tr.cells[ i + 1 ] ),
-					pillar;
+					pillar,
+					pillarLeft,
+					pillarRight,
+					pillarWidth,
+					x = td.getDocumentPosition().x;
 
 				pillarIndex += td.$.colSpan || 1;
 
-				// Calculate the pillar boundary positions.
-				var pillarLeft, pillarRight, pillarWidth;
-
-				var x = td.getDocumentPosition().x;
-
 				// Calculate positions based on the current cell.
-				rtl ? pillarRight = x + getBorderWidth( td, 'left' ) : pillarLeft = x + td.$.offsetWidth - getBorderWidth( td, 'right' );
+				if ( rtl ) {
+					pillarRight = x + getBorderWidth( td, 'left' );
+				} else {
+					pillarLeft = x + td.$.offsetWidth - getBorderWidth( td, 'right' );
+				}
 
 				// Calculate positions based on the next cell, if available.
 				if ( nextTd ) {
 					x = nextTd.getDocumentPosition().x;
 
-					rtl ? pillarLeft = x + nextTd.$.offsetWidth - getBorderWidth( nextTd, 'right' ) : pillarRight = x + getBorderWidth( nextTd, 'left' );
+					if ( rtl ) {
+						pillarLeft = x + nextTd.$.offsetWidth - getBorderWidth( nextTd, 'right' );
+					} else {
+						pillarRight = x + getBorderWidth( nextTd, 'left' );
+					}
 				}
 				// Otherwise calculate positions based on the table (for last cell).
 				else {
 					x = table.getDocumentPosition().x;
 
-					rtl ? pillarLeft = x : pillarRight = x + table.$.offsetWidth;
+					if ( rtl ) {
+						pillarLeft = x
+					} else {
+						pillarRight = x + table.$.offsetWidth;
+					}
 				}
 
 				pillarWidth = Math.max( pillarRight - pillarLeft, 3 );

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -45,10 +45,9 @@
 
 		var rows = table.$.rows;
 
-		CKEDITOR.tools.array.forEach( rows, function( item, index ) {
+		CKEDITOR.tools.array.forEach( rows, function( item ) {
 			var $tr = item,
 				pillarIndex = -1,
-				pillarRow,
 				pillarHeight = 0,
 				pillarPosition = null,
 				pillarDimensions = setPillarDimensions( $tr ),
@@ -67,7 +66,6 @@
 					pillar;
 
 				pillarIndex += td.$.colSpan || 1;
-				pillarRow = index;
 
 				// Calculate the pillar boundary positions.
 				var pillarLeft, pillarRight, pillarWidth;

--- a/tests/core/tools/array.js
+++ b/tests/core/tools/array.js
@@ -214,6 +214,16 @@
 				assert.areSame( testArray, array );
 				assert.areSame( testThis, this );
 			}, testThis );
+		},
+
+		'test array.zip method': function() {
+			var array1 = [ 'foo', 'bar', 'baz' ],
+				array2 = [ 1, 2, 3 ],
+				expected = [ [ 'foo', 1 ], [ 'bar', 2 ], [ 'baz', 3 ] ];
+
+			arrayAssert.itemsAreEquivalent( expected, this.array.zip( array1, array2 ), function( arr1, arr2 ) {
+				return arr1[ 0 ] === arr2[ 0 ] && arr1[ 1 ]  === arr2[ 1 ];
+			} );
 		}
 	} );
 

--- a/tests/plugins/tableresize/manual/rowspan.html
+++ b/tests/plugins/tableresize/manual/rowspan.html
@@ -1,0 +1,33 @@
+<div id="editor">
+	<table border="1" cellspacing="1" cellpadding="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td rowspan="3" colspan="1"></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableresize/manual/rowspan.md
+++ b/tests/plugins/tableresize/manual/rowspan.md
@@ -1,0 +1,17 @@
+@bender-ui: collapsed
+@bender-tags: bug, 3961, 4.15.1
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, basicstyles, undo, sourcearea, tableselection
+
+1. Resize merged cell starting from both left and right.
+
+  **Expected** Vertical pillar is correctly rendered during resize.
+
+  **Unexpected** Vertical pillar is much wider than expected or it's impossible to resize cell.
+
+2. Focus merged cell multiple times by clicking near cell borders.
+
+  **Expected** It's possible to focus cell.
+
+  **Unexpected** Clicking renders resizing pillar preventing cell focus.
+
+3. Play a bit with row span in different cell range and check if it resizes properly.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3961](https://github.com/ckeditor/ckeditor4/issues/3961): Table resize prevents editing merged cells.
```

## What changes did you make?

Rowspans are not taken into consideration when calculating resize pillars. To fix the issue, I'm using `tools.buildTableMap` helper, so if a row has fewer cells due to rowspan neighbor, it will be extended with shared cells.

Writing unit tests for this issue is a pain because the whole interaction is done via mouse. I'm not really sure if we will be able to write any sensible automatic test for that, so let's check if these changes are correct before jumping to unit tests as they seem hard to write (and re-write).

## Which issues does your PR resolve?

Closes #3961
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
