### PR TITLE
Fix CKEDITOR.inlineAll inlining also elements with editor already attached to them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [#4293](https://github.com/ckeditor/ckeditor4/issues/4293): Fixed: [`CKEDITOR.inlineAll()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inlineAll) method tries to initialize inline editor also on elements with editor already attached to them.
 * [#3961](https://github.com/ckeditor/ckeditor4/issues/3961): Fixed: [Table Resize](https://ckeditor.com/cke4/addon/tableresize) prevents editing of merged cells.
 
 Other Changes:

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -135,7 +135,8 @@
 			for ( var i = 0, len = elements.count(); i < len; i++ ) {
 				el = elements.getItem( i );
 
-				if ( el.getAttribute( 'contenteditable' ) == 'true' ) {
+				// Check if element is editable and if there isn't an editor attached to it already (#4293).
+				if ( el.getAttribute( 'contenteditable' ) == 'true' && !el.getEditor() ) {
 					// Fire the "inline" event, making it possible to customize
 					// the instance settings and eventually cancel the creation.
 

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -122,12 +122,12 @@
 	};
 
 	/**
-	 * Calls {@link CKEDITOR#inline} for all page elements with
-	 * the `contenteditable` attribute set to `true`.
-	 *
+	 * Calls {@link CKEDITOR#inline `CKEDITOR.inline()`} method for all page elements with the `contenteditable` attribute set to `true`
+	 * that are allowed in the {@link `CKEDITOR.dtd#$editable`} object.
 	 */
 	CKEDITOR.inlineAll = function() {
-		var el, data;
+		var el,
+			data;
 
 		for ( var name in CKEDITOR.dtd.$editable ) {
 			var elements = CKEDITOR.document.getElementsByTag( name );
@@ -145,8 +145,9 @@
 						config: {}
 					};
 
-					if ( CKEDITOR.fire( 'inline', data ) !== false )
+					if ( CKEDITOR.fire( 'inline', data ) !== false ) {
 						CKEDITOR.inline( el, data.config );
+					}
 				}
 			}
 		}

--- a/tests/core/creators/inlineallonalreadyinlined.html
+++ b/tests/core/creators/inlineallonalreadyinlined.html
@@ -1,0 +1,3 @@
+<div id="editorInlined">
+	<p>Lorem ipsum</p>
+</div>

--- a/tests/core/creators/inlineallonalreadyinlined.js
+++ b/tests/core/creators/inlineallonalreadyinlined.js
@@ -1,8 +1,8 @@
 /* bender-tags: editor */
 
-bender.editor = {};
-
 'use strict';
+
+bender.editor = {};
 
 bender.test( {
 	// (#4293)

--- a/tests/core/creators/inlineallonalreadyinlined.js
+++ b/tests/core/creators/inlineallonalreadyinlined.js
@@ -1,0 +1,32 @@
+/* bender-tags: editor */
+
+bender.editor = {};
+
+'use strict';
+
+bender.test( {
+	// (#4293)
+	'test invoke CKEDITOR.inlineAll after creating some editor': function() {
+		var spy = sinon.spy( CKEDITOR, 'error' ),
+			elementId = 'editorInlined',
+			element = CKEDITOR.document.getById( elementId );
+
+		element.$.contentEditable = true;
+
+		CKEDITOR.inline( elementId, {
+			on: {
+				instanceReady: function() {
+					resume( function() {
+						spy.restore();
+						assert.areSame( 0, spy.callCount, 'Error count' );
+					} );
+				}
+			}
+		} );
+
+		// We simulate running it after asynchronously loading CKEditor (e.g. in framework integration).
+		CKEDITOR.inlineAll();
+
+		wait();
+	}
+} );

--- a/tests/core/creators/inlineallonalreadyinlined.js
+++ b/tests/core/creators/inlineallonalreadyinlined.js
@@ -11,6 +11,7 @@ bender.test( {
 			elementId = 'editorInlined',
 			element = CKEDITOR.document.getById( elementId );
 
+		// Make sure the element won't be inlined on CKEDITOR.domReady.
 		element.$.contentEditable = true;
 
 		CKEDITOR.inline( elementId, {

--- a/tests/core/creators/manual/inlineallonalreadyinlined.html
+++ b/tests/core/creators/manual/inlineallonalreadyinlined.html
@@ -1,0 +1,23 @@
+<p>
+	<button id="inlineAll">Inline all</button>
+</p>
+
+<div id="editor1">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<div id="editor2">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.inline( 'editor1', {
+		readOnly: false
+	} );
+
+	CKEDITOR.document.getById( 'inlineAll' ).on( 'click', function() {
+		CKEDITOR.document.getById( 'editor2' ).$.contentEditable = true;
+
+		CKEDITOR.inlineAll();
+	} );
+</script>

--- a/tests/core/creators/manual/inlineallonalreadyinlined.html
+++ b/tests/core/creators/manual/inlineallonalreadyinlined.html
@@ -16,6 +16,7 @@
 	} );
 
 	CKEDITOR.document.getById( 'inlineAll' ).on( 'click', function() {
+		// Make sure the element won't be inlined on CKEDITOR.domReady.
 		CKEDITOR.document.getById( 'editor2' ).$.contentEditable = true;
 
 		CKEDITOR.inlineAll();

--- a/tests/core/creators/manual/inlineallonalreadyinlined.md
+++ b/tests/core/creators/manual/inlineallonalreadyinlined.md
@@ -1,0 +1,16 @@
+@bender-tags: bug, 4.15.1, 4293
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+1. Open the console.
+2. Press "Inline all" button.
+
+## Expected
+
+1. There are no errors in the console.
+2. The second editor is created.
+
+## Unexpected
+
+1. There are errors in the console, especially `editor-element-conflict` one.
+2. The second editor is not created.

--- a/tests/core/creators/manual/inlineallonalreadyinlined.md
+++ b/tests/core/creators/manual/inlineallonalreadyinlined.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.15.1, 4293
+@bender-tags: 4.15.1, bug, 4293
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4293](https://github.com/ckeditor/ckeditor4/issues/4293): Fixed: [`CKEDITOR.inlineAll`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inlineAll) tries to inline also elements with editor already attached to them.
```

## What changes did you make?

I've just added a simple check if the element has an attached editor, using `element#getEditor()`.

## Which issues does your PR resolve?

Closes #4267.
Closes #4293.
