### PR TITLE
Tests for table selection in Safari

### DIFF
--- a/tests/plugins/tableselection/integrations/tabletools/tabletools.js
+++ b/tests/plugins/tableselection/integrations/tabletools/tabletools.js
@@ -1,7 +1,7 @@
 /* bender-tags: tableselection, tabletools */
 /* bender-ckeditor-plugins: entities,dialog,tableselection,toolbar,undo,floatingspace */
 /* bender-include: ../../_helpers/tableselection.js,../../../undo/_helpers/tools.js */
-/* global tableSelectionHelpers, doCommandTest */
+/* global doCommandTest */
 
 ( function() {
 	'use strict';
@@ -96,7 +96,11 @@
 		'test delete nested cells': function( editor, bot ) {
 			doCommandTest( bot, 'cellDelete', { 'case': 'delete-nested-cells', cells: [ 1, 2 ], skipCheckingSelection: true } );
 			doCommandTest( bot, 'cellDelete', { 'case': 'delete-nested-cells-2', cells: [ 2, 3 ], skipCheckingSelection: true } );
-			doCommandTest( bot, 'cellDelete', { 'case': 'delete-nested-cells-3', cells: [ 1, 2, 3, 4 ], skipCheckingSelection: true } );
+
+			// Test fails due to issue in the Safari (#4306).
+			if ( !CKEDITOR.env.safari ) {
+				doCommandTest( bot, 'cellDelete', { 'case': 'delete-nested-cells-3', cells: [ 1, 2, 3, 4 ], skipCheckingSelection: true } );
+			}
 		},
 
 		// To reproduce https://dev.ckeditor.com/ticket/11058 we need 4 rows

--- a/tests/plugins/tableselection/manual/safaritheadlastcolumn.html
+++ b/tests/plugins/tableselection/manual/safaritheadlastcolumn.html
@@ -1,0 +1,61 @@
+<p><button id="select">Select the last column</button></p>
+
+<div id="editor">
+	<table border="1">
+		<thead>
+			<tr>
+				<th scope="col">Column 1</th>
+				<th scope="col">Column 2</th>
+				<th scope="col">Column 3</th>
+				<th scope="col">Column 4</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<th scope="row">Cell 1.1</th>
+				<td>Cell 1.2</td>
+				<td>Cell 1.3</td>
+				<td>Cell 1.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 2.1</th>
+				<td>Cell 2.2</td>
+				<td>Cell 2.3</td>
+				<td>Cell 2.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 3.1</th>
+				<td>Cell 3.2</td>
+				<td>Cell 3.3</td>
+				<td>Cell 3.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 4.1</th>
+				<td>Cell 4.2</td>
+				<td>Cell 4.3</td>
+				<td>Cell 4.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 5.1</th>
+				<td>Cell 5.2</td>
+				<td>Cell 5.3</td>
+				<td>Cell 5.4</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script src="../_helpers/tableselection.js"></script>
+<script>
+	if ( !CKEDITOR.env.safari ) {
+		bender.ignore();
+	}
+
+	var editor = CKEDITOR.replace( 'editor' );
+
+	CKEDITOR.document.getById( 'select' ).on( 'click', function() {
+		var ranges = tableSelectionHelpers.getRangesForCells( editor, [ 3, 7, 11, 15, 19, 23 ] );
+
+		editor.getSelection().selectRanges( ranges );
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/safaritheadlastcolumn.md
+++ b/tests/plugins/tableselection/manual/safaritheadlastcolumn.md
@@ -1,0 +1,25 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.15.1, 4306
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, undo, elementspath
+
+Note: this test checks if the [upstream issue in WebKit](https://bugs.webkit.org/show_bug.cgi?id=217221) is still present.
+
+1. Click the "Select the last column" button.
+
+	### Expected
+
+	The last column is selected.
+
+	### Unexpected
+
+	The last column can't be selected.
+
+2. Try to select the last column with mouse.
+
+	### Expected
+
+	The last column is selected.
+
+	### Unexpected
+
+	The last column can't be selected.

--- a/tests/plugins/tableselection/manual/safaritheadlastcolumnmouse.html
+++ b/tests/plugins/tableselection/manual/safaritheadlastcolumnmouse.html
@@ -43,7 +43,6 @@
 	</table>
 </div>
 
-<script src="../_helpers/tableselection.js"></script>
 <script>
 	if ( !CKEDITOR.env.safari || bender.tools.env.mobile ) {
 		bender.ignore();

--- a/tests/plugins/tableselection/manual/safaritheadlastcolumnmouse.html
+++ b/tests/plugins/tableselection/manual/safaritheadlastcolumnmouse.html
@@ -1,0 +1,53 @@
+<div id="editor">
+	<table border="1">
+		<thead>
+			<tr>
+				<th scope="col">Column 1</th>
+				<th scope="col">Column 2</th>
+				<th scope="col">Column 3</th>
+				<th scope="col">Column 4</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<th scope="row">Cell 1.1</th>
+				<td>Cell 1.2</td>
+				<td>Cell 1.3</td>
+				<td>Cell 1.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 2.1</th>
+				<td>Cell 2.2</td>
+				<td>Cell 2.3</td>
+				<td>Cell 2.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 3.1</th>
+				<td>Cell 3.2</td>
+				<td>Cell 3.3</td>
+				<td>Cell 3.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 4.1</th>
+				<td>Cell 4.2</td>
+				<td>Cell 4.3</td>
+				<td>Cell 4.4</td>
+			</tr>
+			<tr>
+				<th scope="row">Cell 5.1</th>
+				<td>Cell 5.2</td>
+				<td>Cell 5.3</td>
+				<td>Cell 5.4</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script src="../_helpers/tableselection.js"></script>
+<script>
+	if ( !CKEDITOR.env.safari || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/tableselection/manual/safaritheadlastcolumnmouse.md
+++ b/tests/plugins/tableselection/manual/safaritheadlastcolumnmouse.md
@@ -4,11 +4,11 @@
 
 Note: this test checks if the [upstream issue in WebKit](https://bugs.webkit.org/show_bug.cgi?id=217221) is still present.
 
-1. Click the "Select the last column" button.
+1. Try to select the last column with mouse.
 
 	### Expected
 
-	The last column can't be selected or wrong cells become selected.
+	The last column can't be selected.
 
 	### Unexpected
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Not needed

## What changes did you make?

I've ignored the unit test that fails in Safari and added a manual one to check if the upstream issue is still present.

## Which issues does your PR resolve?

Closes #4287.
Closes #4306.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
