### PR TITLE
Change stale label for stalebot

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -15,8 +15,8 @@ jobs:
         stale-pr-message: "It's been a while since we last heard from you. We are marking this pull request as stale due to inactivity. Please provide the requested feedback or the pull request will be closed after next 7 days."
         close-issue-message: "There was no activity regarding this issue in the last 14 days. We're closing it for now. Still, feel free to provide us with requested feedback so that we can reopen it."
         close-pr-message: "There was no activity regarding this pull request in the last 14 days. We're closing it for now. Still, feel free to provide us with requested feedback so that we can reopen it."
-        stale-issue-label: 'status:stale'
-        stale-pr-label: 'pr:stale :moyai:'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
         exempt-issue-labels: 'status:confirmed'
         close-issue-label: 'resolution:expired'
         close-pr-label: 'pr:frozen ❄'


### PR DESCRIPTION
Let's check if it will work correctly without `:` character. I see that closing labels has been normally added so it's probably safe to leave them for now.

Please, when merging this PR, also rename `status:stale` label to `stale`.