### PR TITLE
Fix overwriting text on paste

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CKEditor 4 Changelog
 Fixed Issues:
 
 * [#4433](https://github.com/ckeditor/ckeditor4/issues/4433): Fixed: Paragraph before or after a [widget](https://ckeditor.com/cke4/addon/widget) can not be removed. Thanks to [bunglegrind](https://github.com/bunglegrind)!
+* [#4301](https://github.com/ckeditor/ckeditor4/issues/4301): Fixed: Pasted content is overwritten when pasted in initially empty editor with [`div` enter mode](https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html).
 
 ## CKEditor 4.16
 

--- a/core/editable.js
+++ b/core/editable.js
@@ -1648,11 +1648,8 @@
 		function insert( editable, type, data, range ) {
 			var editor = editable.editor,
 				dontFilter = false,
-				html = editable.getHtml(),
-				// Instead of getData method, we directly check the HTML
-				// due to the fact that internal getData operates on latest snapshot,
-				// not the current content (#4301).
-				isEmptyEditable = html === '' || html.match( emptyParagraphRegexp );
+				html,
+				isEmptyEditable;
 
 			if ( type == 'unfiltered_html' ) {
 				type = 'html';
@@ -1689,6 +1686,14 @@
 				};
 
 			prepareRangeToDataInsertion( that );
+
+			html = editable.getHtml(),
+			// Instead of getData method, we directly check the HTML
+			// due to the fact that internal getData operates on latest snapshot,
+			// not the current content.
+			// Checking it after clearing the range's content will give the
+			// most correct results (#4301).
+			isEmptyEditable = html === '' || html.match( emptyParagraphRegexp );
 
 			// When enter mode is set to div and content wrapped with div is pasted,
 			// we must ensure that no additional divs are created (#2751).

--- a/core/editable.js
+++ b/core/editable.js
@@ -1650,7 +1650,7 @@
 				dontFilter = false,
 				html = editable.getHtml(),
 				// Instead of getData method, we directly check the HTML
-				// due to the fact that interal getData operates on latest snapshot,
+				// due to the fact that internal getData operates on latest snapshot,
 				// not the current content (#4301).
 				isEmptyEditable = html === '' || html.match( emptyParagraphRegexp );
 
@@ -1691,7 +1691,7 @@
 			prepareRangeToDataInsertion( that );
 
 			// When enter mode is set to div and content wrapped with div is pasted,
-			// we must ensure that no additional divs are created (#2751, #3379).
+			// we must ensure that no additional divs are created (#2751).
 			if ( editor.enterMode === CKEDITOR.ENTER_DIV && isEmptyEditable ) {
 				clearEditable( editable, range );
 			}

--- a/core/editable.js
+++ b/core/editable.js
@@ -1647,7 +1647,12 @@
 		// guarantee it's result to be a valid DOM tree.
 		function insert( editable, type, data, range ) {
 			var editor = editable.editor,
-				dontFilter = false;
+				dontFilter = false,
+				html = editable.getHtml(),
+				// Instead of getData method, we directly check the HTML
+				// due to the fact that interal getData operates on latest snapshot,
+				// not the current content (#4301).
+				isEmptyEditable = html === '' || html.match( emptyParagraphRegexp );
 
 			if ( type == 'unfiltered_html' ) {
 				type = 'html';
@@ -1687,7 +1692,7 @@
 
 			// When enter mode is set to div and content wrapped with div is pasted,
 			// we must ensure that no additional divs are created (#2751, #3379).
-			if ( editor.enterMode === CKEDITOR.ENTER_DIV && editor.getData( true ) === '' ) {
+			if ( editor.enterMode === CKEDITOR.ENTER_DIV && isEmptyEditable ) {
 				clearEditable( editable, range );
 			}
 

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -28,6 +28,7 @@ var tests = {
 	'test insert two divs wrapped in another div': testInsertHtml( '<div><div>foo</div><div>bar</div></div>' )
 };
 
+tests = CKEDITOR.tools.object.merge( tests, generateEmptyParagraphsTests() );
 tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
 
 // (#2751, #4301)
@@ -83,4 +84,49 @@ function testInsertHtml( htmlString ) {
 			assert.areSame( htmlString, editor.getData() );
 		} );
 	};
+}
+
+function generateEmptyParagraphsTests() {
+	var tags = [
+			'p',
+			'div',
+			'address',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'center',
+			'pre'
+		],
+		contents = [
+			'<br>',
+			'&nbsp;',
+			'\u00A0',
+			'&#160;'
+		];
+
+	return CKEDITOR.tools.array.reduce( tags, function( tests, tag ) {
+		var tagTests = CKEDITOR.tools.array.reduce( contents, function( tests, content ) {
+			var test = {};
+
+			test[ 'empty paragraph test: ' + tag + ' with ' + CKEDITOR.tools.htmlEncode( content ) ] = function( editor ) {
+				var html = '<div>foo</div><div>bar</div>';
+
+				editor.editable().setHtml( generateEmptyParagraph( tag, content ) );
+				editor.insertHtml( html );
+
+				assert.areSame( html, editor.getData() );
+			};
+
+			return CKEDITOR.tools.object.merge( tests, test );
+		}, {} );
+
+		return CKEDITOR.tools.object.merge( tests, tagTests );
+	}, {} );
+
+	function generateEmptyParagraph( tag, content ) {
+		return '<' + tag + '>' + content + '</' + tag + '>';
+	}
 }

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -40,6 +40,24 @@ tests[ 'test getData call (p enter mode)' ] = function() {
 	} );
 };
 
+// (#4301)
+tests[ 'test multiple paste into empty editor' ] = function() {
+	bender.editorBot.create( {
+		name: 'multiple_paste',
+		config: {
+			enterMode: CKEDITOR.ENTER_DIV
+		}
+	}, function( bot ) {
+		var html = 'Lorem ipsum',
+			editor = bot.editor;
+
+		editor.insertHtml( html );
+		editor.insertHtml( html );
+
+		assert.areSame( '<div>' + html + html + '</div>', editor.getData() );
+	} );
+};
+
 bender.test( tests );
 
 function testInsertHtml( htmlString ) {

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -25,20 +25,10 @@ var tests = {
 	'test insert two divs': testInsertHtml( '<div>foo</div><div>bar</div>' ),
 
 	// (#2751)
-	'test insert two divs wrapped in another div': testInsertHtml( '<div><div>foo</div><div>bar</div></div>' ),
-
-	// (#3379)
-	'test getData call (div enter mode)': testGetData()
+	'test insert two divs wrapped in another div': testInsertHtml( '<div><div>foo</div><div>bar</div></div>' )
 };
 
 tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
-
-// (#3379)
-tests[ 'test getData call (p enter mode)' ] = function() {
-	bender.editorBot.create( {}, function( bot ) {
-		testGetData()( bot.editor, bot );
-	} );
-};
 
 // (#4301)
 tests[ 'test multiple paste into empty editor' ] = function() {
@@ -65,27 +55,6 @@ function testInsertHtml( htmlString ) {
 		bot.setData( '', function() {
 			editor.insertHtml( htmlString );
 			assert.areSame( htmlString, editor.getData() );
-		} );
-	};
-}
-
-function testGetData() {
-	return function( editor, bot ) {
-		bot.setData( '', function() {
-			var i = 0,
-				listener = editor.on( 'beforeGetData', function() {
-					++i;
-				} ),
-				spy = sinon.spy( CKEDITOR.editor.prototype, 'getData' ),
-				expectedGetDataCount = Number( editor.config.enterMode === CKEDITOR.ENTER_DIV );
-
-			editor.insertHtml( 'hublabubla' );
-
-			listener.removeListener();
-			spy.restore();
-
-			assert.areSame( expectedGetDataCount, spy.callCount, 'getData count' );
-			assert.areSame( 0, i, 'beforeGetData count' );
 		} );
 	};
 }

--- a/tests/core/editable/enterdiv.js
+++ b/tests/core/editable/enterdiv.js
@@ -30,6 +30,32 @@ var tests = {
 
 tests = bender.tools.createTestsForEditors( CKEDITOR.tools.object.keys( bender.editors ), tests );
 
+// (#2751, #4301)
+tests[ 'reinsert the current data' ] = function() {
+	var html = '<div>This is some sample text.</div><div>New line.</div>';
+
+	bender.editorBot.create( {
+		name: 'reinsert',
+		startupData: html,
+		config: {
+			plugins: 'selectall',
+			enterMode: CKEDITOR.ENTER_DIV
+		}
+	}, function( bot ) {
+		var editor = bot.editor,
+			range;
+
+		// Using Select All plugin ensures that the selection is emulating
+		// real user selection well.
+		editor.execCommand( 'selectAll' );
+		range = editor.getSelection().getRanges()[ 0 ];
+
+		editor.insertHtml( html, 'html', range );
+
+		assert.areSame( html, editor.getData() );
+	} );
+};
+
 // (#4301)
 tests[ 'test multiple paste into empty editor' ] = function() {
 	bender.editorBot.create( {

--- a/tests/core/editable/manual/enterdivemptypaste.html
+++ b/tests/core/editable/manual/enterdivemptypaste.html
@@ -1,0 +1,8 @@
+<div>Lorem ipsum dolor sit amet</div>
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		enterMode: CKEDITOR.ENTER_DIV
+	} );
+</script>

--- a/tests/core/editable/manual/enterdivemptypaste.md
+++ b/tests/core/editable/manual/enterdivemptypaste.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.15.1, bug, 4301
+@bender-ui: collapsed
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea
+
+## For each editor
+
+1. Copy anything (e.g. text above the editor).
+2. Paste it in the editor.
+3. Without moving selection, paste it once more.
+
+## Expected
+
+The text is pasted twice.
+
+## Unexpected
+
+The text is pasted once.

--- a/tests/core/editable/manual/enterdivemptypaste.md
+++ b/tests/core/editable/manual/enterdivemptypaste.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.15.1, bug, 4301
+@bender-tags: 4.15.2, bug, 4301
 @bender-ui: collapsed
 @bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea
 

--- a/tests/core/editable/manual/enterdivemptypaste.md
+++ b/tests/core/editable/manual/enterdivemptypaste.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.15.2, bug, 4301
+@bender-tags: 4.16.1, bug, 4301
 @bender-ui: collapsed
 @bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, sourcearea
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4301](https://github.com/ckeditor/ckeditor4/issues/4301): Fixed: pasted content overwritten when pasted in initially empty editor with [`div` enter mode](https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html).
```

## What changes did you make?

I've removed the invocation of `getData()` and replaced it with direct checking of editable's HTML.

## Which issues does your PR resolve?

Closes #4301.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
