### PR TITLE
Fix: Editor Placeholder plugin throws an error during editor initialization when used with bbcode and fullpage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.15.2
 
+Fixed Issues:
+
+* [#4253](https://github.com/ckeditor/ckeditor4/issues/4253): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/editorplaceholder) plugin throws an error during editor initialization with [fullpage](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-fullPage) enabled when there is no `body` tag in editor content.
+
 ## CKEditor 4.15.1
 
 **Security Updates:**

--- a/plugins/editorplaceholder/plugin.js
+++ b/plugins/editorplaceholder/plugin.js
@@ -74,9 +74,9 @@
 		if ( isFullPage ) {
 			var bodyDataMatched = data.match( fullPageRegex );
 
+			// Check if body element exists in editor HTML (#4253).
 			if ( bodyDataMatched && bodyDataMatched.length > 1 ) {
-				//found data inside `<body>` element
-				data = bodyDataMatched[1];
+				data = bodyDataMatched[ 1 ];
 			}
 		}
 

--- a/plugins/editorplaceholder/plugin.js
+++ b/plugins/editorplaceholder/plugin.js
@@ -72,7 +72,12 @@
 			data = editor.getData();
 
 		if ( isFullPage ) {
-			data = data.match( fullPageRegex )[ 1 ];
+			var bodyDataMatched = data.match( fullPageRegex );
+
+			if ( bodyDataMatched && bodyDataMatched.length > 1 ) {
+				//found data inside `<body>` element
+				data = bodyDataMatched[1];
+			}
 		}
 
 		return data.length === 0;

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -220,8 +220,7 @@
 	};
 
 	// (#4253)
-	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin'] = function() {
-
+	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin' ] = function() {
 		consoleErrorStub = sinon.stub( console, 'error' );
 
 		var runtimeErrorListener = function() {
@@ -232,7 +231,6 @@
 
 		window.addEventListener( 'error', runtimeErrorListener );
 
-
 		bender.editorBot.create( {
 			name: 'bbcodeFailTest',
 			config: {
@@ -241,18 +239,80 @@
 				fullPage: true,
 				on: {
 					instanceReady: function() {
-									resume( function() {
-										assert.isFalse( consoleErrorStub.called, 'There should be no errors during initialization' );
-									} );
-								}
+						resume( function() {
+							assert.isFalse( consoleErrorStub.called, 'There should be no errors during initialization' );
+						} );
+					}
 				}
 			}
 		}, function( bot ) {
 
 		} );
 
-
 		wait();
+	};
+
+	// (#4253)
+	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin and initial content' ] = function() {
+		bender.editorBot.create( {
+			name: 'bbcodeFailTestContent',
+			config: {
+				extraPlugins: 'bbcode',
+				editorplaceholder: 'any',
+				fullPage: true,
+				startupData: '<p>Initialized content</p>'
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			assert.isFalse( editor.editable().hasAttribute( 'data-cke-editorplaceholder' ) );
+		} );
+	};
+
+	// (#4253)
+	tests[ 'test placeholder is visible with data filter to no content' ] = function() {
+		bender.editorBot.create( {
+			name: 'placeholderFilterToNoContent',
+			config: {
+				editorplaceholder: 'any',
+				fullPage: true,
+				startupData: '<p>Initialized content</p>'
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			editor.on( 'toDataFormat', function ( evt ) {
+				evt.data.dataValue = '';
+			}, null, null, 16 );
+
+			editor.fire( 'change' );
+
+			assert.isTrue( editor.editable().hasAttribute( 'data-cke-editorplaceholder' ) );
+		} );
+	};
+
+	// (#4253)
+	tests[ 'test placeholder not visible with data filter to preinitialized content' ] = function() {
+		var preinitializedContent = '<p>Initialized content</p>';
+
+		bender.editorBot.create( {
+			name: 'placeholderFilterPreinitialized',
+			config: {
+				editorplaceholder: 'any',
+				fullPage: true,
+				startupData:preinitializedContent
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			editor.on( 'toDataFormat', function ( evt ) {
+				evt.data.dataValue = preinitializedContent;
+			}, null, null, 16 );
+
+			editor.fire( 'change' );
+
+			assert.isFalse( editor.editable().hasAttribute( 'data-cke-editorplaceholder' ) );
+		} );
 	};
 
 	bender.test( tests );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -289,8 +289,7 @@
 			name: 'placeholderFilterToNoContent',
 			config: {
 				editorplaceholder: 'any',
-				fullPage: true,
-				startupData: '<p>Initialized content</p>'
+				fullPage: true
 			}
 		}, function( bot ) {
 			var editor = bot.editor;

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -205,5 +205,20 @@
 		} );
 	};
 
+	// (#4253)
+	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin'] = function() {
+		bender.editorBot.create( {
+			name: 'bbcodeFailTest',
+			config: {
+				extraPlugins: 'bbcode',
+				editorplaceholder: 'any',
+				fullPage: true
+			}
+		}, function( bot ) {
+			//no errors during editor load - so test can pass
+			assert.isTrue( true );
+		} );
+	};
+
 	bender.test( tests );
 }() );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -261,8 +261,6 @@
 
 	// (#4253)
 	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin and initial content' ] = function() {
-		addErrorAsserts( this );
-
 		bender.editorBot.create( {
 			name: 'bbcodeFailTestContent',
 			config: {
@@ -274,13 +272,8 @@
 		}, function( bot ) {
 			var editor = bot.editor;
 
-			resume(function() {
-				assert.isFalse( editor.editable().hasAttribute( 'data-cke-editorplaceholder' ) );
-			});
-
+			assert.isFalse( editor.editable().hasAttribute( 'data-cke-editorplaceholder' ) );
 		} );
-
-		wait();
 	};
 
 	// (#4253)

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -207,17 +207,41 @@
 
 	// (#4253)
 	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin'] = function() {
+
+		var errorLogStub = sinon.stub( console, 'error' );
+
+		var onErrorStub = function() {
+			resume( function() {
+				assert.fail( 'There should be no RunTime errors!' );
+			} );
+		};
+
+		window.addEventListener( 'error', onErrorStub );
+
+		var instanceReadyCallback = function( e ) {
+			resume( function() {
+				assert.isFalse( errorLogStub.called, 'There should be no errors during initialization' );
+			} );
+		};
+
 		bender.editorBot.create( {
 			name: 'bbcodeFailTest',
 			config: {
 				extraPlugins: 'bbcode',
 				editorplaceholder: 'any',
-				fullPage: true
+				fullPage: true,
+				on: {
+					instanceReady: instanceReadyCallback
+				}
 			}
 		}, function( bot ) {
-			//no errors during editor load - so test can pass
-			assert.isTrue( true );
+
 		} );
+
+		errorLogStub.restore();
+		window.removeEventListener( 'error', onErrorStub );
+
+		wait();
 	};
 
 	bender.test( tests );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -49,12 +49,10 @@
 
 		tearDown: function() {
 			if ( this.consoleErrorStub ) {
-				console.log('cleared errStub');
 				this.consoleErrorStub.restore();
 			}
 
 			if ( this.runtimeErrorListener ) {
-				console.log('cleared window');
 				window.removeEventListener( 'error', this.runtimeErrorListener );
 			}
 		},
@@ -287,7 +285,7 @@
 		}, function( bot ) {
 			var editor = bot.editor;
 
-			editor.on( 'toDataFormat', function ( evt ) {
+			editor.on( 'toDataFormat', function( evt ) {
 				evt.data.dataValue = '';
 			}, null, null, 16 );
 
@@ -306,12 +304,12 @@
 			config: {
 				editorplaceholder: 'any',
 				fullPage: true,
-				startupData:preinitializedContent
+				startupData: preinitializedContent
 			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
-			editor.on( 'toDataFormat', function ( evt ) {
+			editor.on( 'toDataFormat', function( evt ) {
 				evt.data.dataValue = preinitializedContent;
 			}, null, null, 16 );
 

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -223,7 +223,7 @@
 	// (#4253)
 	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin' ] = function() {
 		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
-			// Runtime error try to invoke console.error() which is unavailable for IE9.
+			// Runtime error assert tries to invoke console.error() which is unavailable in IE9.
 			assert.ignore();
 		}
 		addErrorAsserts( this );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -314,7 +314,7 @@
 
 		benderScope.runtimeErrorListener = function() {
 			resume( function() {
-				assert.fail( 'There should be no RunTime errors!' );
+				assert.fail( 'There should be no runtime errors!' );
 			} );
 		};
 

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -252,8 +252,8 @@
 				}
 			}
 		}, function( bot ) {
-			//Don't check if editorplaceholder exists, because of mix bbcode plugin with fullPage config - causing never empty content in editor
-			//Details: https://github.com/ckeditor/ckeditor4/pull/4251#pullrequestreview-481525255
+			// Don't check if editor placeholder was added, since combination of bbcode plugin with fullPage config results
+			// in lack editor placeholder due to https://github.com/ckeditor/ckeditor4/pull/4251#pullrequestreview-481525255 and #4386.
 		} );
 
 		wait();

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -228,21 +228,17 @@
 			config: {
 				extraPlugins: 'bbcode',
 				editorplaceholder: 'any',
-				fullPage: true,
-				on: {
-					instanceReady: function() {
-						resume( function() {
-							assert.isFalse( this.consoleErrorStub.called, 'There should be no errors during initialization' );
-						} );
-					}
-				}
+				fullPage: true
 			}
 		}, function( bot ) {
 			// Don't check if editor placeholder was added, since combination of bbcode plugin with fullPage config results
 			// in lack editor placeholder due to https://github.com/ckeditor/ckeditor4/pull/4251#pullrequestreview-481525255 and #4386.
-		} );
+			if ( bot.testCase.consoleErrorStub ) { // Make sure console stub is there (handle older IEs)
+				assert.isFalse( bot.testCase.consoleErrorStub.called, 'There should be no errors during initialization' );
+			}
 
-		wait();
+			assert.pass( 'Error was not thrown' );
+		} );
 	};
 
 	// (#4253)

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -285,20 +285,20 @@
 
 	// (#4253)
 	tests[ 'test placeholder is not visible with data filter to initial content' ] = function() {
-		var preinitializedContent = '<p>Initialized content</p>';
+		var startupData = '<p>Initialized content</p>';
 
 		bender.editorBot.create( {
 			name: 'placeholderFilterPreinitialized',
 			config: {
 				editorplaceholder: 'any',
 				fullPage: true,
-				startupData: preinitializedContent
+				startupData: startupData
 			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
 			editor.on( 'toDataFormat', function( evt ) {
-				evt.data.dataValue = preinitializedContent;
+				evt.data.dataValue = startupData;
 			}, null, null, 16 );
 
 			editor.fire( 'change' );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -26,18 +26,6 @@
 		}
 	};
 
-	function addErrorAsserts( benderScope ) {
-		benderScope.consoleErrorStub = sinon.stub( console, 'error' );
-
-		benderScope.runtimeErrorListener = function() {
-			resume( function() {
-				assert.fail( 'There should be no RunTime errors!' );
-			} );
-		};
-
-		window.addEventListener( 'error', benderScope.runtimeErrorListener );
-	}
-
 	var tests = {
 
 		setUp: function() {
@@ -320,4 +308,17 @@
 	};
 
 	bender.test( tests );
+
+	function addErrorAsserts( benderScope ) {
+		benderScope.consoleErrorStub = sinon.stub( console, 'error' );
+
+		benderScope.runtimeErrorListener = function() {
+			resume( function() {
+				assert.fail( 'There should be no RunTime errors!' );
+			} );
+		};
+
+		window.addEventListener( 'error', benderScope.runtimeErrorListener );
+	}
+
 }() );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -1,5 +1,6 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: wysiwygarea,editorplaceholder,toolbar,undo */
+/* global console */
 
 ( function() {
 	'use strict';
@@ -237,9 +238,7 @@
 		}, function( bot ) {
 			// Don't check if editor placeholder was added, since combination of bbcode plugin with fullPage config results
 			// in lack editor placeholder due to https://github.com/ckeditor/ckeditor4/pull/4251#pullrequestreview-481525255 and #4386.
-			if ( bot.testCase.consoleErrorStub ) { // Make sure console stub is there (handle older IEs)
-				assert.isFalse( bot.testCase.consoleErrorStub.called, 'There should be no errors during initialization' );
-			}
+			assert.isFalse( bot.testCase.consoleErrorStub.called, 'There should be no errors during initialization' );
 
 			assert.pass( 'Error was not thrown' );
 		} );

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -284,7 +284,7 @@
 	};
 
 	// (#4253)
-	tests[ 'test placeholder not visible with data filter to preinitialized content' ] = function() {
+	tests[ 'test placeholder is not visible with data filter to initial content' ] = function() {
 		var preinitializedContent = '<p>Initialized content</p>';
 
 		bender.editorBot.create( {

--- a/tests/plugins/editorplaceholder/editorplaceholder.js
+++ b/tests/plugins/editorplaceholder/editorplaceholder.js
@@ -221,6 +221,10 @@
 
 	// (#4253)
 	tests[ 'test placeholder loads correctly in full-page editor with bbcode plugin' ] = function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
+			// Runtime error try to invoke console.error() which is unavailable for IE9.
+			assert.ignore();
+		}
 		addErrorAsserts( this );
 
 		bender.editorBot.create( {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?
Bug fix
<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4253](https://github.com/ckeditor/ckeditor4/issues/4253): Prevent index-reading from undefined variable.
```

## What changes did you make?

Check `RegExp` match results before trying access via index.

## Which issues does your PR resolve?

Closes #4253
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
