### PR TITLE
Fix failing tests/plugins/autogrow/autogrow test

### DIFF
--- a/tests/plugins/autogrow/_helpers/tools.js
+++ b/tests/plugins/autogrow/_helpers/tools.js
@@ -1,0 +1,14 @@
+/* exported autogrowTools */
+
+var autogrowTools = ( function() {
+	function getEditorSize( editor ) {
+		return {
+			width: parseInt( editor.getResizable().getComputedStyle( 'width' ), 10 ),
+			height: parseInt( editor.getResizable().getComputedStyle( 'height' ), 10 )
+		};
+	}
+
+	return {
+		getEditorSize: getEditorSize
+	};
+} )();

--- a/tests/plugins/autogrow/_helpers/tools.js
+++ b/tests/plugins/autogrow/_helpers/tools.js
@@ -8,7 +8,19 @@ var autogrowTools = ( function() {
 		};
 	}
 
+	function getTestContent( numberOfParagraphs ) {
+		var html = '',
+			paragraphsCount = numberOfParagraphs || 1;
+
+		for ( var i = 0; i < paragraphsCount; i++ ) {
+			html += '<p>test ' + i + '</p>';
+		}
+
+		return html;
+	}
+
 	return {
+		getTestContent: getTestContent,
 		getEditorSize: getEditorSize
 	};
 } )();

--- a/tests/plugins/autogrow/autogrow.js
+++ b/tests/plugins/autogrow/autogrow.js
@@ -9,35 +9,28 @@
 	bender.editor = {};
 
 	bender.test( {
-		// #4286
+		// (#4286)
 		'test autogrow': function() {
 			if ( bender.env.ie && bender.env.version < 9 ) {
 				assert.ignore();
 			}
 
 			var editor = this.editor,
-				bot = this.editorBot;
+				bot = this.editorBot,
+				initialEditorSize = autogrowTools.getEditorSize( editor );
 
-			var html = '',
-				initialEditorWidth = autogrowTools.getEditorSize( editor ).width,
-				initialEditorHeight = autogrowTools.getEditorSize( editor ).height;
-
-			for ( var i = 0; i < 8; i++ ) {
-				html += '<p>test ' + i + '</p>';
-			}
-
-			bot.setData( html, function() {
+			bot.setData( autogrowTools.getTestContent( 8 ), function() {
 				editor.once( 'afterCommandExec', function() {
 					resume( function() {
-						var editorWidth = autogrowTools.getEditorSize( editor ).width,
-							editorHeight = autogrowTools.getEditorSize( editor ).height;
+						var editorSize = autogrowTools.getEditorSize( editor );
 
-						assert.isTrue( editorHeight > initialEditorHeight, 'editor height should increase' );
-						assert.areEqual( editorWidth, initialEditorWidth, 'editor width should not change' );
+						assert.isTrue( editorSize.height > initialEditorSize.height, 'editor height should increase' );
+						assert.areEqual( editorSize.width, initialEditorSize.width, 'editor width should not change' );
 					} );
 				} );
 
 				editor.execCommand( 'autogrow' );
+
 				wait();
 			} );
 		}

--- a/tests/plugins/autogrow/autogrow.js
+++ b/tests/plugins/autogrow/autogrow.js
@@ -65,7 +65,7 @@
 
 						assert.isTrue( editorHeight > initialEditorHeight, 'editor height should increase' );
 						assert.isTrue( editorWidth > 0, 'editor width should be greater than zero' );
-						assert.areEqual( editorWidth, initialEditorWidth, 'editor width should not change' );
+						assert.areEqual( initialEditorWidth, editorWidth, 'editor width should not change' );
 					} );
 				} );
 
@@ -77,8 +77,8 @@
 
 	function getEditorSize( editor ) {
 		return {
-			width: parseInt( editor.editable().getComputedStyle( 'width' ), 10 ),
-			height: parseInt( editor.editable().getComputedStyle( 'height' ), 10 )
+			width: parseInt( editor.getResizable().getComputedStyle( 'width' ), 10 ),
+			height: parseInt( editor.getResizable().getComputedStyle( 'height' ), 10 )
 		};
 	}
 } )();

--- a/tests/plugins/autogrow/autogrowborderless.js
+++ b/tests/plugins/autogrow/autogrowborderless.js
@@ -12,41 +12,33 @@
 
 	bender.test( {
 		init: function() {
-			// Remove border for borderless editor.
-			var borderlessEditor = CKEDITOR.document.getById( 'cke_borderless' );
-			borderlessEditor.setStyle( 'border', 'none' );
+			// Remove border for borderless editor (#4286).
+			CKEDITOR.document.getById( 'cke_borderless' ).setStyle( 'border', 'none' );
 		},
 
-		// #4286
+		// (#4286)
 		'test autogrow with borderless editor': function() {
 			if ( bender.env.ie && bender.env.version < 9 ) {
 				assert.ignore();
 			}
 
-			var editor = this.editors.borderless,
-				bot = this.editorBots.borderless;
+			var editor = this.editor,
+				bot = this.editorBot,
+				initialEditorSize = autogrowTools.getEditorSize( editor );
 
-			var html = '',
-				initialEditorWidth = autogrowTools.getEditorSize( editor ).width,
-				initialEditorHeight = autogrowTools.getEditorSize( editor ).height;
-
-			for ( var i = 0; i < 6; i++ ) {
-				html += '<p>test ' + i + '</p>';
-			}
-
-			bot.setData( html, function() {
+			bot.setData( autogrowTools.getTestContent( 8 ), function() {
 				editor.once( 'afterCommandExec', function() {
 					resume( function() {
-						var editorWidth = autogrowTools.getEditorSize( editor ).width,
-							editorHeight = autogrowTools.getEditorSize( editor ).height;
+						var editorSize = autogrowTools.getEditorSize( editor );
 
-						assert.isTrue( editorHeight > initialEditorHeight, 'editor height should increase' );
-						assert.isTrue( editorWidth > 0, 'editor width should be greater than zero' );
-						assert.areEqual( initialEditorWidth, editorWidth, 'editor width should not change' );
+						assert.isTrue( editorSize.height > initialEditorSize.height, 'editor height should increase' );
+						assert.isTrue( editorSize.width > 0, 'editor width should be greater than zero' );
+						assert.areEqual( editorSize.width, initialEditorSize.width, 'editor width should not change' );
 					} );
 				} );
 
 				editor.execCommand( 'autogrow' );
+
 				wait();
 			} );
 		}

--- a/tests/plugins/autogrow/autogrowborderless.js
+++ b/tests/plugins/autogrow/autogrowborderless.js
@@ -22,8 +22,8 @@
 				assert.ignore();
 			}
 
-			var editor = this.editor,
-				bot = this.editorBot,
+			var editor = this.editors.borderless,
+				bot = this.editorBots.borderless,
 				initialEditorSize = autogrowTools.getEditorSize( editor );
 
 			bot.setData( autogrowTools.getTestContent( 8 ), function() {

--- a/tests/plugins/autogrow/autogrowborderless.js
+++ b/tests/plugins/autogrow/autogrowborderless.js
@@ -6,23 +6,31 @@
 ( function() {
 	'use strict';
 
-	bender.editor = {};
+	bender.editors = {
+		borderless: {}
+	};
 
 	bender.test( {
+		init: function() {
+			// Remove border for borderless editor.
+			var borderlessEditor = CKEDITOR.document.getById( 'cke_borderless' );
+			borderlessEditor.setStyle( 'border', 'none' );
+		},
+
 		// #4286
-		'test autogrow': function() {
+		'test autogrow with borderless editor': function() {
 			if ( bender.env.ie && bender.env.version < 9 ) {
 				assert.ignore();
 			}
 
-			var editor = this.editor,
-				bot = this.editorBot;
+			var editor = this.editors.borderless,
+				bot = this.editorBots.borderless;
 
 			var html = '',
 				initialEditorWidth = autogrowTools.getEditorSize( editor ).width,
 				initialEditorHeight = autogrowTools.getEditorSize( editor ).height;
 
-			for ( var i = 0; i < 8; i++ ) {
+			for ( var i = 0; i < 6; i++ ) {
 				html += '<p>test ' + i + '</p>';
 			}
 
@@ -33,7 +41,8 @@
 							editorHeight = autogrowTools.getEditorSize( editor ).height;
 
 						assert.isTrue( editorHeight > initialEditorHeight, 'editor height should increase' );
-						assert.areEqual( editorWidth, initialEditorWidth, 'editor width should not change' );
+						assert.isTrue( editorWidth > 0, 'editor width should be greater than zero' );
+						assert.areEqual( initialEditorWidth, editorWidth, 'editor width should not change' );
 					} );
 				} );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Skip

## What changes did you make?

The reason for tests failure on Firefox (btw I also reproduced it on Chrome and Safari) were vertical scrollbars in two places: in the editor itself and in the browser. 
As for the first issue, there was a race condition (because the scrollbar was visible just for a moment), so to resolve it I changed the object that was measured: from `editor.getEditable()` to `editor.getResizable()` - the latter doesn't change it's value no matter if scrollbar is visible or not (the same was the reason I couldn't use `editor.getViewPaneSize()`).
The second problem was solved by extracting tests to separate files - now the editors content always fits the browser viewport, so scrollbar doesn't show up.
Since IE8 doesn't support the way the width or height are calculated and there was no reliable way to replace it, I ignored it.

## Which issues does your PR resolve?

Closes #4323.