### PR TITLE
Fix Images in docs does not displaying correctly (due to Easy Image)

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2897,7 +2897,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * start in the top left-hand corner of the selection and end in the bottom right-hand corner.
 		 * Possible cases when the returned rectangle does not fully cover ranges are presented below:
 		 *
-		 * <img src="https://33333.cdn.cke-cs.com/rc1DFuFpHqcR3Mah6y0e/images/90893fcc6c323c10023e73ebfc1fbaa622b48b29c066f7af_ie-rects.png">
+		 * <img src="../assets/img/dom-range-selection-fix.png" alt="range selection fix">
 		 *
 		 * @since 4.10.0
 		 * @param {Boolean} [isAbsolute] The function will retrieve an absolute rectangle of the element,

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2897,7 +2897,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * start in the top left-hand corner of the selection and end in the bottom right-hand corner.
 		 * Possible cases when the returned rectangle does not fully cover ranges are presented below:
 		 *
-		 * <img src="../assets/img/dom-range-selection.png" alt="range selection fix">
+		 * <img src="../assets/img/dom-range-selection.png" alt="Possible incorrect cases.">
 		 *
 		 * @since 4.10.0
 		 * @param {Boolean} [isAbsolute] The function will retrieve an absolute rectangle of the element,

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2897,7 +2897,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * start in the top left-hand corner of the selection and end in the bottom right-hand corner.
 		 * Possible cases when the returned rectangle does not fully cover ranges are presented below:
 		 *
-		 * <img src="../assets/img/dom-range-selection-fix.png" alt="range selection fix">
+		 * <img src="../assets/img/dom-range-selection.png" alt="range selection fix">
 		 *
 		 * @since 4.10.0
 		 * @param {Boolean} [isAbsolute] The function will retrieve an absolute rectangle of the element,


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Bug fix
## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4300 ](https://github.com/ckeditor/ckeditor4/issues/4300):Fix Images in docs does not displaying correctly (due to Easy Image)
```

## What changes did you make?

*Give an overview…*
Update API comments for dom/range: `https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-getClientRects`. Change EasyImagesource link to documentation image link.
The image was recovered from  EasyImage CDN server and placed in ckeditor4-docs (https://github.com/ckeditor/ckeditor4-docs/pull/339)

## Which issues does your PR resolve?

Closes #4300 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
