### PR TITLE
Fix incorrect high contrast mode detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#4253](https://github.com/ckeditor/ckeditor4/issues/4253): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/editorplaceholder) plugin throws an error during editor initialization with [fullpage](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-fullPage) enabled when there is no `body` tag in editor content.
 * [#4372](https://github.com/ckeditor/ckeditor4/issues/4372): Fixed: [Autogrow](https://ckeditor.com/cke4/addon/autogrow) plugin changes editor's width when used with absolute [`config.width`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-width) value.
+* [#4379](https://github.com/ckeditor/ckeditor4/issues/4379): [Edge] Fixed: Incorrect detection of high contrast mode.
 
 ## CKEditor 4.15.1
 

--- a/core/_bootstrap.js
+++ b/core/_bootstrap.js
@@ -8,31 +8,26 @@
  */
 
 ( function() {
-	// Disable HC detection in WebKit. (https://dev.ckeditor.com/ticket/5429)
-	if ( CKEDITOR.env.webkit )
+	// Check whether high contrast is active by creating a colored border.
+	var hcDetect = CKEDITOR.dom.element.createFromHtml( '<div style="width:0;height:0;position:absolute;left:-10000px;' +
+		'border:1px solid;border-color:red blue"></div>', CKEDITOR.document );
+
+	hcDetect.appendTo( CKEDITOR.document.getHead() );
+
+	// Update CKEDITOR.env.
+	// Catch exception needed sometimes for FF. (https://dev.ckeditor.com/ticket/4230)
+	try {
+		var top = hcDetect.getComputedStyle( 'border-top-color' ),
+			right = hcDetect.getComputedStyle( 'border-right-color' );
+
+		// We need to check if getComputedStyle returned any value, because on FF
+		// it returnes empty string if CKEditor is loaded in hidden iframe. (https://dev.ckeditor.com/ticket/11121)
+		CKEDITOR.env.hc = !!( top && top == right );
+	} catch ( e ) {
 		CKEDITOR.env.hc = false;
-	else {
-		// Check whether high contrast is active by creating a colored border.
-		var hcDetect = CKEDITOR.dom.element.createFromHtml( '<div style="width:0;height:0;position:absolute;left:-10000px;' +
-			'border:1px solid;border-color:red blue"></div>', CKEDITOR.document );
-
-		hcDetect.appendTo( CKEDITOR.document.getHead() );
-
-		// Update CKEDITOR.env.
-		// Catch exception needed sometimes for FF. (https://dev.ckeditor.com/ticket/4230)
-		try {
-			var top = hcDetect.getComputedStyle( 'border-top-color' ),
-				right = hcDetect.getComputedStyle( 'border-right-color' );
-
-			// We need to check if getComputedStyle returned any value, because on FF
-			// it returnes empty string if CKEditor is loaded in hidden iframe. (https://dev.ckeditor.com/ticket/11121)
-			CKEDITOR.env.hc = !!( top && top == right );
-		} catch ( e ) {
-			CKEDITOR.env.hc = false;
-		}
-
-		hcDetect.remove();
 	}
+
+	hcDetect.remove();
 
 	if ( CKEDITOR.env.hc )
 		CKEDITOR.env.cssClass += ' cke_hc';

--- a/tests/core/ckeditor/manual/_assets/hctest.html
+++ b/tests/core/ckeditor/manual/_assets/hctest.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>HC Detection test</title>
+</head>
+<body>
+	<div id="editor">
+		<p>Lorem ipsum dolor sit amet</p>
+	</div>
+
+	<script>
+		( function() {
+			window.CKEDITOR_BASEPATH = '/apps/ckeditor/';
+
+			var request = new XMLHttpRequest();
+
+			request.responseType = 'text';
+			request.onreadystatechange = function() {
+				if ( request.readyState !== 4) {
+					return;
+				}
+
+				var script = document.createElement( 'script' );
+
+				script.textContent = request.responseText;
+
+				document.body.appendChild( script );
+
+				setTimeout( function() {
+					CKEDITOR.replace( 'editor', {
+						width: 600,
+						height: 400,
+						removePlugins: [ 'exportpdf', 'wsc', 'scayt' ]
+					} );
+				}, 500 );
+			};
+
+			request.open( 'GET', '/apps/ckeditor/ckeditor.js' );
+			request.send();
+		} )();
+	</script>
+</body>
+</html>

--- a/tests/core/ckeditor/manual/hcdetection.html
+++ b/tests/core/ckeditor/manual/hcdetection.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/ckeditor/manual/hcdetection.html
+++ b/tests/core/ckeditor/manual/hcdetection.html
@@ -3,6 +3,7 @@
 		border-radius: 5px;
 		display: inline-block;
 		padding: 0.5em;
+		border: 2px solid #000;
 	}
 	.on {
 		background: green;

--- a/tests/core/ckeditor/manual/hcdetection.html
+++ b/tests/core/ckeditor/manual/hcdetection.html
@@ -1,7 +1,30 @@
+<style>
+	#indicator {
+		border-radius: 5px;
+		display: inline-block;
+		padding: 0.5em;
+	}
+	.on {
+		background: green;
+	}
+	.off {
+		background: red;
+	}
+</style>
+<p>
+	<span id="indicator"></span>
+</p>
 <div id="editor">
 	<p>Lorem ipsum dolor sit amet</p>
 </div>
 
-<script>
+<script>( function() {
 	CKEDITOR.replace( 'editor' );
+
+	var indicator = CKEDITOR.document.getById( 'indicator' ),
+		state = CKEDITOR.env.hc ? 'on' : 'off'
+
+	indicator.addClass( state );
+	indicator.setText( 'HC is ' + state );
+} )();
 </script>

--- a/tests/core/ckeditor/manual/hcdetection.md
+++ b/tests/core/ckeditor/manual/hcdetection.md
@@ -14,4 +14,13 @@
 	## Unexpected
 
 	Buttons in the UI are displayed with icons.
+3. Check the information above the editor.
+
+	## Expected
+
+	It says "HC is on".
+
+	## Unexpected
+
+	It says "HC is off".
 

--- a/tests/core/ckeditor/manual/hcdetection.md
+++ b/tests/core/ckeditor/manual/hcdetection.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard, basicstyles, about, stylescombo, format, link, image
 
-**Note**: this test is dedicated for OSes that **DOES** support high contrast mode.
+**Note**: this test is dedicated for OSes that **DOES** support high contrast mode (Windows mostly). You can see if HC Mode is correctly detected based on test indicator (`HC is on`).
 
 1. Enable high contrast mode in your OS.
 2. Check the editor.
@@ -14,13 +14,3 @@
 	## Unexpected
 
 	Buttons in the UI are displayed with icons.
-3. Check the information above the editor.
-
-	## Expected
-
-	It says "HC is on".
-
-	## Unexpected
-
-	It says "HC is off".
-

--- a/tests/core/ckeditor/manual/hcdetection.md
+++ b/tests/core/ckeditor/manual/hcdetection.md
@@ -2,16 +2,16 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard, basicstyles, about, stylescombo, format, link, image
 
+**Note**: this test is dedicated for OSes that **DOES** support high contrast mode.
+
 1. Enable high contrast mode in your OS.
 2. Check the editor.
 
 	## Expected
 
-	* If the current OS and browser support high contrast: Buttons in the UI are replaced by text labels.
-	* If the current OS and browser don't support high contrast: Buttons in the UI are displayed with icons.
+	Buttons in the UI are replaced by text labels.
 
 	## Unexpected
 
-	* If the current OS and browser support high contrast: Buttons in the UI are displayed with icons.
-	* If the current OS and browser don't support high contrast: Buttons in the UI are replaced by text labels.
+	Buttons in the UI are displayed with icons.
 

--- a/tests/core/ckeditor/manual/hcdetection.md
+++ b/tests/core/ckeditor/manual/hcdetection.md
@@ -1,0 +1,17 @@
+@bender-tags: feature, 4.15.2, 4379
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard, basicstyles, about, stylescombo, format, link, image
+
+1. Enable high contrast mode in your OS.
+2. Check the editor.
+
+	## Expected
+
+	* If the current OS and browser support high contrast: Buttons in the UI are replaced by text labels.
+	* If the current OS and browser don't support high contrast: Buttons in the UI are displayed with icons.
+
+	## Unexpected
+
+	* If the current OS and browser support high contrast: Buttons in the UI are displayed with icons.
+	* If the current OS and browser don't support high contrast: Buttons in the UI are replaced by text labels.
+

--- a/tests/core/ckeditor/manual/hcdetectionajax.html
+++ b/tests/core/ckeditor/manual/hcdetectionajax.html
@@ -1,0 +1,11 @@
+<iframe id="editorframe" frameborder="0" width="100%" height="410"></iframe>
+
+<script>
+	( function() {
+		if ( CKEDITOR.version === '%VERSION%' || !CKEDITOR.env.webkit ) {
+			return bender.ignore();
+		}
+
+		CKEDITOR.document.getById( 'editorframe' ).setAttribute( 'src', '%BASE_PATH%core/ckeditor/manual/_assets/hctest.html' );
+	} )();
+</script>

--- a/tests/core/ckeditor/manual/hcdetectionajax.md
+++ b/tests/core/ckeditor/manual/hcdetectionajax.md
@@ -1,0 +1,16 @@
+@bender-tags: feature, 4.15.2, 4379
+@bender-ui: collapsed
+
+Note: this test works only on a built version of CKEDitor 4.
+
+1. Disable hight contrast mode in your OS.
+2. Check the editor.
+
+	## Expected
+
+	Buttons in the UI are displayed with icons.
+
+	## Unexpected
+
+	Buttons in the UI are replaced by text labels.
+3. Repeat the test several times, reloading the page before each test.

--- a/tests/core/ckeditor/manual/hcdetectionajax.md
+++ b/tests/core/ckeditor/manual/hcdetectionajax.md
@@ -1,9 +1,7 @@
 @bender-tags: feature, 4.15.2, 4379
 @bender-ui: collapsed
 
-Note: this test works only on a built version of CKEDitor 4.
-
-1. Disable hight contrast mode in your OS.
+1. Run the test with disableb high contrast mode in your OS.
 2. Check the editor.
 
 	## Expected

--- a/tests/core/ckeditor/manual/hcdetectionunsupported.html
+++ b/tests/core/ckeditor/manual/hcdetectionunsupported.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/ckeditor/manual/hcdetectionunsupported.html
+++ b/tests/core/ckeditor/manual/hcdetectionunsupported.html
@@ -1,7 +1,31 @@
+<style>
+	#indicator {
+		border-radius: 5px;
+		display: inline-block;
+		padding: 0.5em;
+		border: 2px solid #000;
+	}
+	.on {
+		background: green;
+	}
+	.off {
+		background: red;
+	}
+</style>
+<p>
+	<span id="indicator"></span>
+</p>
 <div id="editor">
 	<p>Lorem ipsum dolor sit amet</p>
 </div>
 
-<script>
+<script>( function() {
 	CKEDITOR.replace( 'editor' );
+
+	var indicator = CKEDITOR.document.getById( 'indicator' ),
+		state = CKEDITOR.env.hc ? 'on' : 'off'
+
+	indicator.addClass( state );
+	indicator.setText( 'HC is ' + state );
+} )();
 </script>

--- a/tests/core/ckeditor/manual/hcdetectionunsupported.md
+++ b/tests/core/ckeditor/manual/hcdetectionunsupported.md
@@ -1,0 +1,16 @@
+@bender-tags: feature, 4.15.2, 4379
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard, basicstyles, about, stylescombo, format, link, image
+
+**Note**: this test is dedicated for OSes that does **NOT** support high contrast mode.
+
+1. Check the editor.
+
+	## Expected
+
+	Buttons in the UI are displayed with icons.
+
+	## Unexpected
+
+	Buttons in the UI are replaced by text labels.
+

--- a/tests/core/ckeditor/manual/hcdetectionunsupported.md
+++ b/tests/core/ckeditor/manual/hcdetectionunsupported.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard, basicstyles, about, stylescombo, format, link, image
 
-**Note**: this test is dedicated for OSes that does **NOT** support high contrast mode.
+**Note**: this test is dedicated for OSes that **DOES NOT** support high contrast mode. You can see if HC Mode is disabled based on test indicator (`HC is off`).
 
 1. Check the editor.
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4379](https://github.com/ckeditor/ckeditor4/issues/4379): [Edge] Fixed: incorrect detection of the high contrast mode.
```

## What changes did you make?

I've enabled detecting HC also in Webkit/Blink. Additionally added the manual test for https://dev.ckeditor.com/ticket/5429

I didn't create unit tests as HC mode is really hard to detect programatically.

## Which issues does your PR resolve?

Closes #4379.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
