### PR TITLE
ContextMenu: Enable Native Spellcheck for mis-spelled words

### DIFF
--- a/plugins/contextmenu/plugin.js
+++ b/plugins/contextmenu/plugin.js
@@ -48,7 +48,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 				 * @param {Boolean} [nativeContextMenuOnCtrl] Whether to open native context menu if the
 				 * <kbd>Ctrl</kbd> key is held on opening the context menu. See {@link CKEDITOR.config#browserContextMenuOnCtrl}.
 				 */
-				addTarget: function( element, nativeContextMenuOnCtrl ) {
+				addTarget: function( element, contextMenuSwitchingEnabled, nativeContextMenuOnByDefault) {
 					var holdCtrlKey,
 						keystrokeActive;
 
@@ -59,8 +59,15 @@ CKEDITOR.plugins.add( 'contextmenu', {
 								// which make this property unreliable. (https://dev.ckeditor.com/ticket/4826)
 								( CKEDITOR.env.webkit ? holdCtrlKey : ( CKEDITOR.env.mac ? domEvent.$.metaKey : domEvent.$.ctrlKey ) );
 
-						if ( nativeContextMenuOnCtrl && isCtrlKeyDown ) {
+						if ( contextMenuSwitchingEnabled ) {
 							return;
+							if ( nativeContextMenuOnByDefault && !isCtrlKeyDown ) {
+								return;
+							}
+							
+							if ( !nativeContextMenuOnByDefault  && isCtrlKeyDown ) {
+								return;
+							}
 						}
 
 						// Cancel the browser context menu.
@@ -163,7 +170,7 @@ CKEDITOR.plugins.add( 'contextmenu', {
 		var contextMenu = editor.contextMenu = new CKEDITOR.plugins.contextMenu( editor );
 
 		editor.on( 'contentDom', function() {
-			contextMenu.addTarget( editor.editable(), editor.config.browserContextMenuOnCtrl !== false );
+			contextMenu.addTarget( editor.editable(), editor.config.contextMenuSwitchingEnabled !== false ,editor.config.nativeContextMenuOnByDefault == false );
 		} );
 
 		editor.addCommand( 'contextMenu', {

--- a/tests/plugins/contextmenu/manual/enabledNativeSpellChecker.html
+++ b/tests/plugins/contextmenu/manual/enabledNativeSpellChecker.html
@@ -1,0 +1,16 @@
+<h2>Spell Check Manual Test - Right Click should use native browser spell check when disableNativeSpellChecker is false (native spell checker enabled).</h2>
+<textarea id="editor1">&lt;p&gt;The more a thing tends to be permanent, the more it tends to be lifeleess.&lt;/p&gt;</textarea>
+
+<script>
+	// No console support on mobiles (without connecting to another device).
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	( function() {
+			editor1 = CKEDITOR.replace( 'editor1', {
+				resize_dir: 'both',
+				disableNativeSpellChecker: false
+			} );
+		}() );
+</script>

--- a/tests/plugins/contextmenu/manual/enabledNativeSpellChecker.md
+++ b/tests/plugins/contextmenu/manual/enabledNativeSpellChecker.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.5.0, enhancement
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, resize
+
+This test checks whether, when a word is misspelled, that when right clicking, suggestions will appear.
+
+1. Misspell word.
+2. Right click.
+3. Locate correctly spelled word.
+4. Choose correctly spelled word.
+
+**Expected result:** After choosing correctly spelled word, spell check suggestion disappears.


### PR DESCRIPTION
## What is the purpose of this pull request?
The documented feature request is here: https://github.com/ckeditor/ckeditor4/issues/3336
This is extending current functionality if disableNativeSpellChecker = false, then it should display the native context menu for mis-spelled words. This is not net new functionality (per-se) however a change to enable native context menu's ONLY when clicking on mis-spelled words. 

## Does your PR contain necessary tests?
Yes, it contains a manual test because we were unable to accomplish _mis-spelled word_ automatic test validation, at this time we could only accomplish test validation/verification with manual tests. 

### This PR contains

- [x ] Unit tests (Existing from the context menu) 
- [x ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?
https://github.com/ckeditor/ckeditor4/issues/3336
```
* [#3336](https://github.com/ckeditor/ckeditor4/issues/3336
```

## What changes did you make?
Added an extra parameter to the context menu plugin and use it to switch what context menu is shown by default.  This is accomplished via setting disableNativeSpellChecker to false or enable the NativeSpellChecker for only right mouse clicks on mis-spelled words. 

## Which issues does your PR resolve?
Closes #3336.