### PR TITLE
Explicit Ajax helpers for new response types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ API Changes:
 * [#3782](https://github.com/ckeditor/ckeditor4/issues/3782): Moved [`CKEDITOR.plugins.pastetool.filters.word.images`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_pastetools_filters_word_images.html) filters to [`CKEDITOR.plugins.pastetools.filters.image`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_pastetools_filters_image.html) namespace.
 * [#4297](https://github.com/ckeditor/ckeditor4/issues/4297): All [`CKEDITOR.plugins.pastetools.filters`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_pastetools_filters.html) are now available under [`CKEDITOR.pasteTools`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#property-pasteTools) alias.
 * [#4358](https://github.com/ckeditor/ckeditor4/issues/4358): Introduced [`CKEDITOR.tools.color`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_color.html) class which adds colors validation and methods for converting colors between various formats: named colors, HEX, RGB, RGBA, HSL and HSLA.
+* [#4394](https://github.com/ckeditor/ckeditor4/issues/4394): Introduced [`CKEDITOR.ajax`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ajax.html) specialized loading methods for loading binary ([`CKEDITOR.ajax.loadBinary()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ajax.html#method-loadBinary)) and text ([`CKEDITOR.ajax.loadText()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ajax.html#method-loadText)) data.
 
 ## CKEditor 4.15.2
 

--- a/plugins/ajax/plugin.js
+++ b/plugins/ajax/plugin.js
@@ -192,6 +192,12 @@
 			 */
 			loadXml: function( url, callback ) {
 				return load( url, callback, 'xml' );
+			},
+			loadText: function( url, callback ) {
+				return load( url, callback, 'text' );
+			},
+			loadBinary: function( url, callback ) {
+				return load( url, callback, 'arraybuffer' );
 			}
 		};
 	} )();

--- a/plugins/ajax/plugin.js
+++ b/plugins/ajax/plugin.js
@@ -193,9 +193,43 @@
 			loadXml: function( url, callback ) {
 				return load( url, callback, 'xml' );
 			},
+			/**
+			 * Loads data from a URL as text.
+			 *
+			 *		// Load text synchronously.
+			 *		var text = CKEDITOR.ajax.loadText( 'somedata.txt' );
+			 *		alert( text );
+			 *
+			 *		// Load text asynchronously.
+			 *		var data = CKEDITOR.ajax.loadText( 'somedata.txt', function( textData ) {
+			 *			alert( textData );
+			 *		} );
+			 * @param {String} url The URL from which the data is loaded.
+			 * @param {Function} [callback] A callback function to be called on
+			 * data load. If not provided, the data will be loaded synchronously.
+			 * @returns {String} String storing the loaded data. For asynchronous requests, an
+			 * empty string. For invalid requests, `null`.
+			 */
 			loadText: function( url, callback ) {
 				return load( url, callback, 'text' );
 			},
+			/**
+			 * Loads data from a URL as binary data: typed array.
+			 *
+			 *		// Load data synchronously.
+			 *		var binaryData = CKEDITOR.ajax.loadBinary( 'somedata.png' );
+			 *		alert( binaryData );
+			 *
+			 *		// Load data asynchronously.
+			 *		var data = CKEDITOR.ajax.loadBinary( 'somedata.png', function( binaryData ) {
+			 *			alert( binaryData );
+			 *		} );
+			 * @param {String} url The URL from which the data is loaded.
+			 * @param {Function} [callback] A callback function to be called on
+			 * data load. If not provided, the data will be loaded synchronously.
+			 * @returns {ArrayBuffer} ArrayBuffer storing the loaded data. For asynchronous requests, an
+			 * empty string. For invalid requests, `null`.
+			 */
 			loadBinary: function( url, callback ) {
 				return load( url, callback, 'arraybuffer' );
 			}

--- a/plugins/ajax/plugin.js
+++ b/plugins/ajax/plugin.js
@@ -122,7 +122,7 @@
 
 		return {
 			/**
-			 * Loads data from a URL as plain text.
+			 * Loads data from a given URL.
 			 *
 			 *		// Load data synchronously.
 			 *		var data = CKEDITOR.ajax.load( 'somedata.txt' );
@@ -135,12 +135,11 @@
 			 *
 			 * @param {String} url The URL from which the data is loaded.
 			 * @param {Function} [callback] A callback function to be called on
-			 * data load. If not provided, the data will be loaded
-			 * synchronously. Please notice that only text data might be loaded synchronously.
+			 * data load. If not provided, the data will be loaded synchronously.
 			 * @param {String} [responseType='text'] Defines type of returned data.
-			 * Currently supports: `text`, `xml`, `arraybuffer`. This parameter was added in 4.16.0.
-			 * @returns {String/null} The loaded data. For asynchronous requests, an
-			 * empty string. For invalid requests, `null`.
+			 * Currently supports: `text`, `xml`, `arraybuffer`. This parameter was introduced in `4.16.0`.
+			 * @returns {String/null} The loaded data for synchronous request. For asynchronous requests -
+			 * empty string. For invalid requests - `null`.
 			 */
 			load: function( url, callback, responseType ) {
 				responseType = responseType || 'text';
@@ -173,7 +172,7 @@
 			},
 
 			/**
-			 * Loads data from a URL as XML.
+			 * Loads data from a given URL as XML.
 			 *
 			 *		// Load XML synchronously.
 			 *		var xml = CKEDITOR.ajax.loadXml( 'somedata.xml' );
@@ -187,14 +186,15 @@
 			 * @param {String} url The URL from which the data is loaded.
 			 * @param {Function} [callback] A callback function to be called on
 			 * data load. If not provided, the data will be loaded synchronously.
-			 * @returns {CKEDITOR.xml} An XML object storing the loaded data. For asynchronous requests, an
-			 * empty string. For invalid requests, `null`.
+			 * @returns {CKEDITOR.xml} An XML object storing the loaded data for synchronous
+			 * request. For asynchronous requests - empty string. For invalid requests - `null`.
 			 */
 			loadXml: function( url, callback ) {
 				return load( url, callback, 'xml' );
 			},
+
 			/**
-			 * Loads data from a URL as text.
+			 * Loads data from a given URL as text.
 			 *
 			 *		// Load text synchronously.
 			 *		var text = CKEDITOR.ajax.loadText( 'somedata.txt' );
@@ -204,17 +204,19 @@
 			 *		var data = CKEDITOR.ajax.loadText( 'somedata.txt', function( textData ) {
 			 *			alert( textData );
 			 *		} );
+			 *
 			 * @param {String} url The URL from which the data is loaded.
 			 * @param {Function} [callback] A callback function to be called on
 			 * data load. If not provided, the data will be loaded synchronously.
-			 * @returns {String} String storing the loaded data. For asynchronous requests, an
-			 * empty string. For invalid requests, `null`.
+			 * @returns {String} String storing the loaded data for synchronous
+			 * request. For asynchronous requests - empty string. For invalid requests - `null`.
 			 */
 			loadText: function( url, callback ) {
 				return load( url, callback, 'text' );
 			},
+
 			/**
-			 * Loads data from a URL as binary data: typed array.
+			 * Loads data from a given URL as binary data.
 			 *
 			 *		// Load data synchronously.
 			 *		var binaryData = CKEDITOR.ajax.loadBinary( 'somedata.png' );
@@ -224,11 +226,12 @@
 			 *		var data = CKEDITOR.ajax.loadBinary( 'somedata.png', function( binaryData ) {
 			 *			alert( binaryData );
 			 *		} );
+			 *
 			 * @param {String} url The URL from which the data is loaded.
 			 * @param {Function} [callback] A callback function to be called on
 			 * data load. If not provided, the data will be loaded synchronously.
-			 * @returns {ArrayBuffer} ArrayBuffer storing the loaded data. For asynchronous requests, an
-			 * empty string. For invalid requests, `null`.
+			 * @returns {ArrayBuffer} ArrayBuffer storing the loaded data for synchronous
+			 * request. For asynchronous requests - empty string. For invalid requests - `null`.
 			 */
 			loadBinary: function( url, callback ) {
 				return load( url, callback, 'arraybuffer' );

--- a/tests/plugins/ajax/ajax.js
+++ b/tests/plugins/ajax/ajax.js
@@ -234,15 +234,14 @@
 		},
 
 		// (#4394)
-		'test load async binary': function() {
+		'test load image async as binary gets ArrayBuffer object': function() {
 			setTimeout( function() {
 				CKEDITOR.ajax.loadBinary( '../../_assets/test_icon.png', callback );
 			}, 0 );
 			wait();
-
 			function callback( data ) {
 				resume( function() {
-					assert.areSame( new ArrayBuffer(), data, 'The loaded data doesn\'t match' );
+					assert.areSame( ArrayBuffer, data.constructor , 'The loaded data doesn\'t match' );
 				} );
 			}
 		}

--- a/tests/plugins/ajax/ajax.js
+++ b/tests/plugins/ajax/ajax.js
@@ -231,6 +231,20 @@
 					assert.areSame( 'Sample Text', data, 'The loaded data doesn\'t match' );
 				} );
 			}
+		},
+
+		// (#4394)
+		'test load async binary': function() {
+			setTimeout( function() {
+				CKEDITOR.ajax.loadBinary( '../../_assets/test_icon.png', callback );
+			}, 0 );
+			wait();
+
+			function callback( data ) {
+				resume( function() {
+					assert.areSame( new ArrayBuffer(), data, 'The loaded data doesn\'t match' );
+				} );
+			}
 		}
 	} );
 } )();

--- a/tests/plugins/ajax/ajax.js
+++ b/tests/plugins/ajax/ajax.js
@@ -182,7 +182,7 @@
 			wait();
 		},
 
-		// (#1134)
+		// (#1134) (#4394)
 		'test load async arraybuffer': function() {
 			if ( typeof Blob !== 'function' || typeof Uint8Array !== 'function' || typeof URL !== 'function' ) {
 				assert.ignore();
@@ -198,7 +198,7 @@
 			}
 
 			setTimeout( function() {
-				CKEDITOR.ajax.load( blobUrl, cb, 'arraybuffer' );
+				CKEDITOR.ajax.loadBinary( blobUrl, cb );
 			}, 0 );
 			wait();
 		},
@@ -206,7 +206,7 @@
 		// (#1134)
 		'test load async xml': function() {
 			setTimeout( function() {
-				CKEDITOR.ajax.load( '../../_assets/sample.xml', callback, 'xml' );
+				CKEDITOR.ajax.loadXml( '../../_assets/sample.xml', callback );
 			}, 0 );
 			wait();
 
@@ -219,29 +219,16 @@
 			}
 		},
 
-		// (#1134)
+		// (#1134) (#4394)
 		'test load async text': function() {
 			setTimeout( function() {
-				CKEDITOR.ajax.load( '../../_assets/sample.txt', callback, 'text' );
+				CKEDITOR.ajax.loadText( '../../_assets/sample.txt', callback );
 			}, 0 );
 			wait();
 
 			function callback( data ) {
 				resume( function() {
 					assert.areSame( 'Sample Text', data, 'The loaded data doesn\'t match' );
-				} );
-			}
-		},
-
-		// (#4394)
-		'test load image async as binary gets ArrayBuffer object': function() {
-			setTimeout( function() {
-				CKEDITOR.ajax.loadBinary( '../../_assets/test_icon.png', callback );
-			}, 0 );
-			wait();
-			function callback( data ) {
-				resume( function() {
-					assert.areSame( ArrayBuffer, data.constructor , 'The loaded data doesn\'t match' );
 				} );
 			}
 		}


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

New feature - according to #4394 

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4394 ](https://github.com/ckeditor/ckeditor4/issues/4394): Added ajax predefined loading methods for: binary - `loadBinary` and text - `loadText`.
```

## What changes did you make?

*Give an overview…*

Added two methods:
- loadText
- loadBinary
based on the current `load` method.

Rename ajax load methods in tests. For those called `load` with `rsponseType` set to 'text' or 'arraybuffer' - I replace them with newly created `loadText` and `loadBinary`. Since it's a new API with predefined `responseType` - tests can be based on the newest changes. Also, add issue markers for tests based on `loadText` and `loadBinary`.

## Which issues does your PR resolve?

Closes #4394 
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
