### PR TITLE
When using bbcode plugin smileys are broken after look the source #4365

### DIFF
--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -51,9 +51,18 @@
 
 	// Maintain the map of smiley-to-description.
 	// jscs:disable maximumLineLength
-	var smileyMap = { smiley: ':)', sad: ':(', wink: ';)', laugh: ':D', cheeky: ':P', blush: ':*)', surprise: ':-o', indecision: ':|', angry: '>:(', angel: 'o:)', cool: '8-)', devil: '>:-)', crying: ';(', kiss: ':-*' },
+	if (CKEDITOR.config.smiley_textual_descriptions.length == CKEDITOR.config.smiley_descriptions.length) {
+		var smileyMap = {};
+
+		CKEDITOR.config.smiley_descriptions.forEach((item, index) => {
+			smileyMap[item] = CKEDITOR.config.smiley_textual_descriptions[index];
+		})
+	} else {
+		var smileyMap = { smiley: ':)', sad: ':(', wink: ';)', laugh: ':D', cheeky: ':P', blush: ':*)', surprise: ':-o', indecision: ':|', angry: '>:(', angel: 'o:)', cool: '8-)', devil: '>:-)', crying: ';(', kiss: ':-*' };
+	}
+
 	// jscs:enable maximumLineLength
-		smileyReverseMap = {},
+	var smileyReverseMap = {},
 		smileyRegExp = [];
 
 	// Build regexp for the list of smiley text.

--- a/plugins/smiley/plugin.js
+++ b/plugins/smiley/plugin.js
@@ -96,3 +96,18 @@ CKEDITOR.config.smiley_descriptions = [
  * @cfg {Number} [smiley_columns=8]
  * @member CKEDITOR.config
  */
+
+/**
+ * The smiley code which should be used for each smiley when using bbcode plugin. Each entry in this array list
+ * must match its relative pair in the {@link CKEDITOR.config#smiley_descriptions}
+ * setting.
+ *
+ *		config.smiley_columns = 6;
+ *
+ * @since 3.15.2
+ * @cfg]
+ * @member CKEDITOR.config
+ */
+CKEDITOR.config.smiley_textual_descriptions = [
+	':)', ':(', ';)', ':D', ':P', ':*)', ':-o', ':|',  '>:(', 'o:)',  '8-)',  '>:-)',  ';(', ':-*'
+];


### PR DESCRIPTION
## What is the purpose of this pull request?

The list of smilies is hardcoded into the plugin bbcode, so this change let the possibility to customize list of smilies via configuration settings.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4365](https://github.com/ckeditor/ckeditor4/issues/4365): The list of smilies is hardcoded into the plugin bbcode, so this change let the possibility to customize list of smilies via configuration settings.
```

## What changes did you make?

Add a new setting in the smiley plugin and in the bbcode plugin remove hardcoded list of smilies by replacing by a way which are recreated by reading configuration settings.

## Which issues does your PR resolve?

Closes #<ISSUE_NUMBER>.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
