### PR TITLE
Ignore failing autoembed tests on IEs

### DIFF
--- a/tests/plugins/autoembed/autoembed.js
+++ b/tests/plugins/autoembed/autoembed.js
@@ -32,6 +32,12 @@ bender.test( {
 	},
 
 	'test working example': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot;
 
 		this.editor.once( 'paste', function( evt ) {
@@ -58,6 +64,12 @@ bender.test( {
 	},
 
 	'test embedding when request failed': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			instanceDestroyedSpy = sinon.spy();
 
@@ -85,6 +97,12 @@ bender.test( {
 	},
 
 	'test when user splits the link before the request is finished': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot;
 
 		bot.setData( '', function() {
@@ -120,6 +138,12 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/13420.
 	'test link with encodable characters': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var links = [
 			// Mind that links differ in a part g/200/3xx so it is easier and faster
 			// to check which link failed the test.
@@ -200,6 +224,12 @@ bender.test( {
 	},
 
 	'test 2 step undo': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			pastedText = 'https://foo.bar/g/200/382',
@@ -336,6 +366,12 @@ bender.test( {
 	},
 
 	'check if notifications are showed after unsuccessful embedding': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			firstRequest = true,
@@ -378,6 +414,12 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/13429.
 	'test selection after auto embedding - empty editor': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			pastedText = 'https://foo.bar/g/200/382';
@@ -402,6 +444,12 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/13429.
 	'test selection after auto embedding - inside content': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			pastedText = 'https://foo.bar/g/200/382';
@@ -437,6 +485,12 @@ bender.test( {
 
 	// https://dev.ckeditor.com/ticket/13429.
 	'test selection after auto embedding - content and selection change before insert': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			editable = editor.editable(),

--- a/tests/plugins/autoembed/autoembednotifications.js
+++ b/tests/plugins/autoembed/autoembednotifications.js
@@ -18,6 +18,12 @@ bender.editor = {
 
 bender.test( {
 	'test notifications showed when embedding is finished correctly': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			pastedText = 'https://foo.bar/notifiacation/finish/correct',
@@ -46,6 +52,12 @@ bender.test( {
 	},
 
 	'test notifications showed when embedding is finished with error': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var bot = this.editorBot,
 			editor = bot.editor,
 			pastedText = 'https://foo.bar/notifiacation/finish/error',

--- a/tests/plugins/autoembed/getwidgetdefinition.js
+++ b/tests/plugins/autoembed/getwidgetdefinition.js
@@ -85,6 +85,12 @@ bender.test( {
 	},
 
 	'test getWidgetDefinition is used by the plugin': function() {
+		// Autolink plugin is disabled in IE to avoid feature duplication,
+		// which causes the test to fail (#4500).
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
 		var editor = this.editor,
 			mock = sinon.stub( CKEDITOR.plugins.autoEmbed, 'getWidgetDefinition' ).returns( editor.widgets.registered.embedSemantic );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Ignoring tests

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

skip

## What changes did you make?

Ignored tests failing on IEs because of the native browser implementation is now the only one working. Manual tests are still passing.

## Which issues does your PR resolve?

Closes #4500.