### PR TITLE
Remove duplicated test, add IE ignore

### DIFF
--- a/tests/plugins/ajax/ajax.js
+++ b/tests/plugins/ajax/ajax.js
@@ -102,27 +102,6 @@
 			assert.isNull( data );
 		},
 
-		test_loadXml_async: function() {
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version > 9 ) {
-				assert.ignore();
-			}
-
-			var callback = function( data ) {
-				resume( function() {
-					assert.isInstanceOf( CKEDITOR.xml, data );
-					assert.isNotNull( data.selectSingleNode( '//list/item' ), 'The loaded data doesn\'t match (null)' );
-					assert.isNotUndefined( data.selectSingleNode( '//list/item' ), 'The loaded data doesn\'t match (undefined)' );
-				} );
-			};
-
-			// Defer loading file, because in some cases on IE7 it's done synchronously, so resume() is called before wait().
-			setTimeout( function() {
-				CKEDITOR.ajax.loadXml( '../../_assets/sample.xml', callback );
-			} );
-
-			wait();
-		},
-
 		test_loadXml_async_404: function() {
 			var callback = function( data ) {
 				resume( function() {
@@ -205,6 +184,10 @@
 
 		// (#1134)
 		'test load async xml': function() {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version > 9 ) {
+				assert.ignore();
+			}
+
 			setTimeout( function() {
 				CKEDITOR.ajax.loadXml( '../../_assets/sample.xml', callback );
 			}, 0 );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Fix failing test for IE
## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Skip
```

## What changes did you make?

*Give an overview…*
There were two tests for loading XML asynchronously.

The oldest one has IE ignore.

The newest one was introduced with PR for fix another bug (#1134 ).

To remove a duplicated test, and preserve bug fix history in code:
- I remove the older test
- I add the same IE ignore, as older test has


## Which issues does your PR resolve?

Closes #4499 
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
