### PR TITLE
Chinese translation colomns and rows was inversed

### DIFF
--- a/plugins/table/lang/zh.js
+++ b/plugins/table/lang/zh.js
@@ -43,7 +43,7 @@ CKEDITOR.plugins.setLang( 'table', 'zh', {
 		insertAfter: '右方插入行',
 		deleteColumn: '刪除行'
 	},
-	columns: '行',
+	columns: '列',
 	deleteTable: '刪除表格',
 	headers: '頁首',
 	headersBoth: '同時',
@@ -65,7 +65,7 @@ CKEDITOR.plugins.setLang( 'table', 'zh', {
 		insertAfter: '下方插入列',
 		deleteRow: '刪除列'
 	},
-	rows: '列',
+	rows: '行',
 	summary: '總結',
 	title: '表格屬性',
 	toolbar: '表格',


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

In Chinese rows is 行 https://translate.google.com/?sl=zh-CN&tl=en&text=%E8%A1%8C&op=translate and column is 列 https://translate.google.com/?sl=zh-CN&tl=en&text=%E5%88%97&op=translate

And is really confusing for chinese people because is antonym :)

Can be confirm by other translation on other plugin that use the correct translation https://github.com/ckeditor/ckeditor4/blob/17a1555f7fbb0e83f737c9efe27650dca8dff36f/plugins/forms/lang/zh.js#L54

## Did you follow the CKEditor 4 code style guide?

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4547](https://github.com/ckeditor/ckeditor4/issues/4547): Fix chinese translation in table plugin for words _columns_ and _rows_
```

## What changes did you make?

Replace "rows" and "columns" in chinese.

## Which issues does your PR resolve?

Closes #4547
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
