### PR TITLE
Enhance accessiblity of richcombo label

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [#4493](https://github.com/ckeditor/ckeditor4/issues/4493): Fixed: [Rich Combo](https://ckeditor.com/cke4/addon/richcombo) label does not reflects the current value of the combobox.
 * [#4433](https://github.com/ckeditor/ckeditor4/issues/4433): Fixed: Paragraph before or after a [widget](https://ckeditor.com/cke4/addon/widget) can not be removed. Thanks to [bunglegrind](https://github.com/bunglegrind)!
 * [#4301](https://github.com/ckeditor/ckeditor4/issues/4301): Fixed: Pasted content is overwritten when pasted in initially empty editor with [`div` enter mode](https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html).
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -20,7 +20,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			( CKEDITOR.env.gecko && !CKEDITOR.env.hc ? '' : ' href="javascript:void(\'{titleJs}\')"' ) +
 			' hidefocus="true"' +
 			' role="button"' +
-			' aria-labelledby="{id}_label"' +
+			' aria-labelledby="{id}_label {id}_text"' +
 			' aria-haspopup="listbox"',
 		specialClickHandler = '';
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -20,7 +20,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			( CKEDITOR.env.gecko && !CKEDITOR.env.hc ? '' : ' href="javascript:void(\'{titleJs}\')"' ) +
 			' hidefocus="true"' +
 			' role="button"' +
-			' aria-labelledby="{id}_label {id}_value_label"' +
+			' aria-labelledby="{id}_label"' +
 			' aria-haspopup="listbox"',
 		specialClickHandler = '';
 
@@ -45,7 +45,6 @@ CKEDITOR.plugins.add( 'richcombo', {
 		' onfocus="return CKEDITOR.tools.callFunction({focusFn},event);"' +
 		' onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},this);return false;">' +
 			'<span id="{id}_text" class="cke_combo_text cke_combo_inlinelabel">{label}</span>' +
-			'<span id="{id}_value_label" class="cke_combo_label"></span>' +
 			'<span class="cke_combo_open">' +
 				'<span class="cke_combo_arrow">' +
 				// BLACK DOWN-POINTING TRIANGLE
@@ -320,12 +319,19 @@ CKEDITOR.plugins.add( 'richcombo', {
 					textElement.setText( typeof text != 'undefined' ? text : value );
 				}
 
-				var valueLabel = typeof text != 'undefined' ? text : value,
-					valueLabelElement = this.document.getById( 'cke_' + this.id + '_value_label' ),
-					isEqualToName = valueLabel === this.label;
+				var newLabel = createLabel( typeof text != 'undefined' ? text : value, this.label ),
+					labelElement = this.document.getById( 'cke_' + this.id + '_label' );
 
-				if ( valueLabelElement && !isEqualToName ) {
-					valueLabelElement.setText( valueLabel );
+				if ( labelElement ) {
+					labelElement.setText( newLabel );
+				}
+
+				function createLabel( newLabel, initialLabel ) {
+					if ( newLabel === initialLabel ) {
+						return newLabel;
+					}
+
+					return newLabel + ', ' + initialLabel;
 				}
 			},
 

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -20,7 +20,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 			( CKEDITOR.env.gecko && !CKEDITOR.env.hc ? '' : ' href="javascript:void(\'{titleJs}\')"' ) +
 			' hidefocus="true"' +
 			' role="button"' +
-			' aria-labelledby="{id}_label {id}_text"' +
+			' aria-labelledby="{id}_label {id}_value_label"' +
 			' aria-haspopup="listbox"',
 		specialClickHandler = '';
 
@@ -45,6 +45,7 @@ CKEDITOR.plugins.add( 'richcombo', {
 		' onfocus="return CKEDITOR.tools.callFunction({focusFn},event);"' +
 		' onclick="' + specialClickHandler + 'CKEDITOR.tools.callFunction({clickFn},this);return false;">' +
 			'<span id="{id}_text" class="cke_combo_text cke_combo_inlinelabel">{label}</span>' +
+			'<span id="{id}_value_label" class="cke_combo_label"></span>' +
 			'<span class="cke_combo_open">' +
 				'<span class="cke_combo_arrow">' +
 				// BLACK DOWN-POINTING TRIANGLE
@@ -317,6 +318,14 @@ CKEDITOR.plugins.add( 'richcombo', {
 					}
 
 					textElement.setText( typeof text != 'undefined' ? text : value );
+				}
+
+				var valueLabel = typeof text != 'undefined' ? text : value,
+					valueLabelElement = this.document.getById( 'cke_' + this.id + '_value_label' ),
+					isEqualToName = valueLabel === this.label;
+
+				if ( valueLabelElement && !isEqualToName ) {
+					valueLabelElement.setText( valueLabel );
 				}
 			},
 

--- a/tests/plugins/richcombo/manual/arialabel.html
+++ b/tests/plugins/richcombo/manual/arialabel.html
@@ -1,0 +1,15 @@
+<h2>Classic editor</h2>
+
+<textarea id="editor">
+	<p>I'm CKEditor 4 instance.</p>
+</textarea>
+
+<script>
+	if ( CKEDITOR.env.ie || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/richcombo/manual/arialabel.md
+++ b/tests/plugins/richcombo/manual/arialabel.md
@@ -1,0 +1,28 @@
+@bender-ui: collapsed
+@bender-tags: 4493, 4.16.1, bug
+@bender-ckeditor-plugins: wysiwygarea, stylescombo, toolbar
+
+**Note:** This is the test for screen readers, so open one before testing.
+
+1. Press <kbd>Tab</kbd> key multiple times to move focus to the editor.
+2. Press <kbd>Alt+F10</kbd> to switch focus to the toolbar and navigate to the `Styles` combo.
+
+  **Expected:**
+
+  * Screen reader announces the name of the combo (`Styles`).
+
+  **Unexpected:**
+
+  Screen reader didn't announce the combo's name.
+
+3. Press <kbd>Space</kbd>, move with arrows keys and press <kbd>Space</kbd> to select one of the values.
+
+4. Focus `Styles` combo once more by repeating steps 1 & 2.
+
+  **Expected:**
+
+  * Screen reader announces `Styles <selected value>`.
+
+  **Unexpected:**
+
+  * Screen reader announces only `Styles`.

--- a/tests/plugins/richcombo/manual/arialabel.md
+++ b/tests/plugins/richcombo/manual/arialabel.md
@@ -21,7 +21,7 @@
 
   **Expected:**
 
-  * Screen reader announces `Styles <selected value>`.
+  * Screen reader announces `<selected value>, Styles`.
 
   **Unexpected:**
 

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -89,6 +89,21 @@ bender.test( {
 		} );
 	},
 
+	// (#4493)
+	'test richcombo aria-labelledby attribute points to both name and the value of the combobox': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo' ),
+			comboBtnSelector = '#cke_' + combo.id,
+			comboBtn = CKEDITOR.document.findOne( comboBtnSelector + ' .cke_combo_button' ),
+			comboBtnNameElementId = comboBtnSelector.substr( 1 ) + '_label',
+			comboBtnValueElementId = comboBtnSelector.substr( 1 ) + '_text',
+			expectedLabelledByValue = comboBtnNameElementId + ' ' + comboBtnValueElementId;
+
+		combo.createPanel( editor );
+
+		assert.areEqual( expectedLabelledByValue, comboBtn.getAttribute( 'aria-labelledby' ), 'Aria-labelledby attribute should point to both elements with the combo name and value.' );
+	},
+
 	// (#1477)
 	'test destroy removes combo listeners': function() {
 		var combo = this.editor.ui.get( 'custom_combo' ),

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -129,7 +129,7 @@ bender.test( {
 			expectedLabel = 'ONE, ' + initialLabel;
 
 		combo.createPanel( editor );
-		combo.setValue( 'one' );
+		combo.setValue( 'one', 'ONE' );
 
 		assert.areEqual( expectedLabel, comboBtnLabel.getHtml() );
 	},

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -107,7 +107,7 @@ bender.test( {
 	},
 
 	// (#4493)
-	'test richcombo initial label': function() {
+	'test richcombo label elements contains initial label by default': function() {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo' ),
 			comboBtnSelector = '#cke_' + combo.id,
@@ -120,7 +120,7 @@ bender.test( {
 	},
 
 	// (#4493)
-	'test richcombo label after selecting some option': function() {
+	'test richcombo label element contains text from selected option': function() {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo_with_options' ),
 			comboBtnSelector = '#cke_' + combo.id,
@@ -135,7 +135,7 @@ bender.test( {
 	},
 
 	// (#4493)
-	'test richcombo label after returning to defaul value': function() {
+	'test richcombo label element contains initial label after richcombo returns to default value': function() {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo_with_options' ),
 			comboBtnSelector = '#cke_' + combo.id,

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -1,7 +1,9 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: richcombo,toolbar */
 
-var customCls = 'my_combo';
+var customCls = 'my_combo',
+	initialLabel = 'Combo Label';
+
 bender.editor = {
 	config: {
 		toolbar: [ [ 'custom_combo', 'custom_combo_with_options' ] ],
@@ -16,6 +18,7 @@ bender.editor = {
 
 				ed.ui.addRichCombo( 'custom_combo', {
 					className: customCls,
+					label: initialLabel,
 					panel: {
 						css: [],
 						multiSelect: false
@@ -27,6 +30,7 @@ bender.editor = {
 
 				ed.ui.addRichCombo( 'custom_combo_with_options', {
 					className: customCls,
+					label: initialLabel,
 					panel: {
 						css: [],
 						multiSelect: false
@@ -90,18 +94,59 @@ bender.test( {
 	},
 
 	// (#4493)
-	'test richcombo aria-labelledby attribute points to both name and the value of the combobox': function() {
+	'test richcombo aria-labelledby attribute points to label element of the combobox': function() {
 		var editor = this.editor,
 			combo = editor.ui.get( 'custom_combo' ),
 			comboBtnSelector = '#cke_' + combo.id,
 			comboBtn = CKEDITOR.document.findOne( comboBtnSelector + ' .cke_combo_button' ),
-			comboBtnNameElementId = comboBtnSelector.substr( 1 ) + '_label',
-			comboBtnValueElementId = comboBtnSelector.substr( 1 ) + '_value_label',
-			expectedLabelledByValue = comboBtnNameElementId + ' ' + comboBtnValueElementId;
+			comboBtnLabelElementId = comboBtnSelector.substr( 1 ) + '_label';
 
 		combo.createPanel( editor );
 
-		assert.areEqual( expectedLabelledByValue, comboBtn.getAttribute( 'aria-labelledby' ), 'Aria-labelledby attribute should point to both elements with the combo name and value.' );
+		assert.areEqual( comboBtnLabelElementId, comboBtn.getAttribute( 'aria-labelledby' ), 'Aria-labelledby attribute should point to element with the combo label.' );
+	},
+
+	// (#4493)
+	'test richcombo initial label': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo' ),
+			comboBtnSelector = '#cke_' + combo.id,
+			comboBtnLabelSelector = comboBtnSelector + '_label',
+			comboBtnLabel = CKEDITOR.document.findOne( comboBtnLabelSelector );
+
+		combo.createPanel( editor );
+
+		assert.areEqual( initialLabel, comboBtnLabel.getHtml() );
+	},
+
+	// (#4493)
+	'test richcombo label after selecting some option': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo_with_options' ),
+			comboBtnSelector = '#cke_' + combo.id,
+			comboBtnLabelSelector = comboBtnSelector + '_label',
+			comboBtnLabel = CKEDITOR.document.findOne( comboBtnLabelSelector ),
+			expectedLabel = 'ONE, ' + initialLabel;
+
+		combo.createPanel( editor );
+		combo.setValue( 'one' );
+
+		assert.areEqual( expectedLabel, comboBtnLabel.getHtml() );
+	},
+
+	// (#4493)
+	'test richcombo label after returning to defaul value': function() {
+		var editor = this.editor,
+			combo = editor.ui.get( 'custom_combo_with_options' ),
+			comboBtnSelector = '#cke_' + combo.id,
+			comboBtnLabelSelector = comboBtnSelector + '_label',
+			comboBtnLabel = CKEDITOR.document.findOne( comboBtnLabelSelector );
+
+		combo.createPanel( editor );
+		combo.setValue( 'one' );
+		combo.setValue( '' );
+
+		assert.areEqual( initialLabel, comboBtnLabel.getHtml() );
 	},
 
 	// (#1477)

--- a/tests/plugins/richcombo/richcombo.js
+++ b/tests/plugins/richcombo/richcombo.js
@@ -96,7 +96,7 @@ bender.test( {
 			comboBtnSelector = '#cke_' + combo.id,
 			comboBtn = CKEDITOR.document.findOne( comboBtnSelector + ' .cke_combo_button' ),
 			comboBtnNameElementId = comboBtnSelector.substr( 1 ) + '_label',
-			comboBtnValueElementId = comboBtnSelector.substr( 1 ) + '_text',
+			comboBtnValueElementId = comboBtnSelector.substr( 1 ) + '_value_label',
 			expectedLabelledByValue = comboBtnNameElementId + ' ' + comboBtnValueElementId;
 
 		combo.createPanel( editor );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4493](https://github.com/ckeditor/ckeditor4/issues/4493): Fixed: [Rich Combo](https://ckeditor.com/cke4/addon/richcombo) label does not reflects the current value of the combobox.
```

## What changes did you make?

I've introduced a new element containing the current value of the combobox and linked it alongside the label in combobox's `[aria-labelledby]` attribute.

## Which issues does your PR resolve?

Closes #4493.
