### PR TITLE
Fix failing "out of view" tests in `/tests/plugins/balloontoolbar/positioning`

### DIFF
--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -93,10 +93,10 @@
 			scrollTop = CKEDITOR.document.getWindow().getScrollPosition().y;
 
 			var expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
-			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
+			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 1 ), 'left align' );
 			// We have to add 1px because of border.
-			assert.areEqual( ( frame.top + frame.height - scrollTop ).toFixed( 2 ),
-				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 2 ), 'top align' );
+			assert.areEqual( ( frame.top + frame.height - scrollTop ).toFixed( 1 ),
+				( rectTop + balloonToolbar.height + balloonToolbar.triangleHeight + 1 ).toFixed( 1 ), 'top align' );
 		},
 
 		'test panel - out of view - hcenter top': function( editor ) {
@@ -130,8 +130,8 @@
 
 			expectedLeft = makeExpectedLeft( frame.left + elementFrame.left + elementFrame.width / 2 - 50 );
 
-			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 2 ), 'left align' );
-			assert.areEqual( ( frame.top - scrollTop ).toFixed( 2 ), ( rectTop - balloonToolbar.triangleHeight ).toFixed( 2 ), 'top align' );
+			assert.areEqual( expectedLeft, balloonToolbarRect.left.toFixed( 1 ), 'left align' );
+			assert.areEqual( ( frame.top - scrollTop ).toFixed( 1 ), ( rectTop - balloonToolbar.triangleHeight ).toFixed( 1 ), 'top align' );
 			balloonToolbar.destroy();
 			balloonToolbar = null;
 		},
@@ -310,9 +310,9 @@
 
 	function makeExpectedLeft( data ) {
 		if ( CKEDITOR.env.ie && CKEDITOR.env.version <= 9 ) {
-			return data.toFixed( 0 ) + '.00';
+			return data.toFixed( 0 ) + '.0';
 		} else {
-			return data.toFixed( 2 );
+			return data.toFixed( 1 );
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Skip

## What changes did you make?

The tests seem to fail because of the roundings. `getClientRect()` method rounds left balloon position of
`48.6953125` to `48.6875` (it's `11/16`) and further in test we round to 2nd decimal place so we have `48.70` vs `48.69` (these values slightly differ depending on browsers and environment - even the change of `0.001px` makes a difference here. That's why it works elsewhere). Since the issue is caused by the accuracy of the measuring tools, we could
1) find better tools (other functions for testing purpose),
2) increase the error margin.

IMHO the difference in measurements is negligible and it would be a waste of time, so I've change testing procedure from 2nd decimal point accordance to 1st decimal point.


## Which issues does your PR resolve?

Closes #4589.
