### PR TITLE
Fix #3757. Image copied in clipboard is not insterted as base64 when not using uploadimage plugin

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -158,7 +158,7 @@
 						dataTransfer = dataObj.dataTransfer;
 
 					// If data empty check for image content inside data transfer. https://dev.ckeditor.com/ticket/16705
-					if ( !data && dataObj.method == 'paste' && isFileData( dataTransfer ) ) {
+					if ( !data && dataObj.method == 'paste' && isFileData( dataTransfer , latestId ) ) {
 						var file = dataTransfer.getFile( 0 );
 
 						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) != -1 ) {
@@ -192,15 +192,18 @@
 
 			// Only dataTransfer objects containing only file should be considered
 			// to image pasting (#3585, #3625).
-			function isFileData( dataTransfer ) {
+			function isFileData( dataTransfer, latestId ) {
 				if ( !dataTransfer || latestId === dataTransfer.id ) {
 					return false;
 				}
+				
+				var types = dataTransfer.getTypes();
+				var isFileOnly = types.length === 1 && types[ 0 ] === 'Files';
+				var containsFile = dataTransfer.getFilesCount() === 1;
 
-				var types = dataTransfer.getTypes(),
-					isFileOnly = types.length === 1 && types[ 0 ] === 'Files',
-					containsFile = dataTransfer.getFilesCount() === 1;
-
+				if (types.length == 0 && containsFile) {
+					return true;
+				}
 				return isFileOnly && containsFile;
 			}
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -197,9 +197,9 @@
 					return false;
 				}
 				
-				var types = dataTransfer.getTypes();
-				var isFileOnly = types.length === 1 && types[ 0 ] === 'Files';
-				var containsFile = dataTransfer.getFilesCount() === 1;
+				var types = dataTransfer.getTypes(), 
+				    isFileOnly = types.length === 1 && types[ 0 ] === 'Files',
+				    containsFile = dataTransfer.getFilesCount() === 1;
 
 				if (types.length == 0 && containsFile) {
 					return true;


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?
Fix a regression pasting images in Firefox, view #3757

In 4.13.0 and before you can paste an image in standard Ckeditor with Firefox and that image was inserted as base64. In 4.13.1 this functionality was lost (by changes in  pull request #3639)

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

Sorry, no test included.
I've manually test:
  * pasting images in Firefox was recovered, 
  * fix for pasting Office contents (#3639) is working.

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3757](https://github.com/ckeditor/ckeditor4/issues/3757): Fix pasing images as base64 in Firefox
```

## What changes did you make?
Pass a lost parameter "latestId", and allow pasting as image if and empty types was provided (I checked it by debugging the code when pasting an image) 

*Give an overview…*

## Which issues does your PR resolve?

Closes #3757.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
