### PR TITLE
Fix for incorrect drag & drop handling for widgets and nested editables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#1572](https://github.com/ckeditor/ckeditor4/issues/1572): Fixed: Paragraph before or after a [widget](https://ckeditor.com/cke4/addon/widget) can not be removed. Thanks to [bunglegrind](https://github.com/bunglegrind)!
 * [#4301](https://github.com/ckeditor/ckeditor4/issues/4301): Fixed: Pasted content is overwritten when pasted in initially empty editor with [`div` enter mode](https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html).
 * [#4351](https://github.com/ckeditor/ckeditor4/issues/4351): Fixed: Incorrect values for RGBA/HSLA colors in [Color Dialog](https://ckeditor.com/cke4/addon/colordialog).
+* [#4509](https://github.com/ckeditor/ckeditor4/issues/4509): Fixed: Incorrect handling of drag & drop inside [widgets](https://ckeditor.com/cke4/addon/widget) and nested editables.
 
 ## CKEditor 4.16
 

--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -303,6 +303,24 @@
 				context: context,
 				enterMode: enterMode || this.editor.enterMode
 			} ).dataValue;
+		},
+
+		/**
+		 * @since 4.16.1
+		 * @private
+		 * @param {String} data
+		 */
+		protectSource: function( data ) {
+			return protectSource( data, this.editor );
+		},
+
+		/**
+		 * @since 4.16.1
+		 * @private
+		 * @param {String} html
+		 */
+		unprotectSource: function( html ) {
+			return unprotectSource( html, this.editor );
 		}
 	};
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1928,13 +1928,8 @@
 			}
 			this._.initialSetData = false;
 
-			// Unescape protected content to prevent double escaping and corruption of content.
-			// This can be done by transforming the content to data format and then back to input HTML (#4060).
-			data = this.editor.dataProcessor.toDataFormat( data, {
-				context: this.getName(),
-				filter: this.filter,
-				enterMode: this.enterMode
-			} );
+			// Unescape protected content to prevent double escaping and corruption of content (#4060, #4509).
+			data = this.editor.dataProcessor.unprotectSource( data );
 			data = this.editor.dataProcessor.toHtml( data, {
 				context: this.getName(),
 				filter: this.filter,

--- a/tests/plugins/widget/dnd.js
+++ b/tests/plugins/widget/dnd.js
@@ -814,9 +814,9 @@
 				}
 			}, function( bot ) {
 				var editor = bot.editor,
-					initialHtml = '<div id="w1" data-widget="testnestedwidget">' +
+					initialHtml = '<div data-widget="testnestedwidget" id="w1">' +
 						'<div class="content">' +
-							'<div id="w2" data-widget="testnestedwidget">' +
+							'<div data-widget="testnestedwidget" id="w2">' +
 								'<div class="content">' +
 									'<p>x</p>' +
 								'</div>' +
@@ -866,7 +866,7 @@
 					dragend( editor, evt.data, parentWidget );
 
 					wait( function() {
-						assert.areSame( initialHtml, editor.getData(), 'Data should not be altered' );
+						bender.assert.isInnerHtmlMatching( initialHtml, editor.getData(), null, 'Data should not be altered' );
 						assert.areSame( 0, widgetWasDestroyed, 'Original widget should not be destroyed' );
 						assert.areSame( 0, dropNotCancelled, 'Drop event should be cancelled' );
 					}, 10 );

--- a/tests/plugins/widget/manual/parentdnd.html
+++ b/tests/plugins/widget/manual/parentdnd.html
@@ -1,0 +1,81 @@
+<head>
+	<link rel="stylesheet" href="/apps/ckeditor/contents.css">
+</head>
+<h2>Classic editor</h2>
+<div id="editor1">
+	<p>Hello, world!</p>
+
+	<div class="testwidget">
+		<div class="col1">
+			<p>x</p>
+		</div>
+
+		<div class="col2">
+			<div class="testwidget">
+				<div class="col1">
+					<p>x</p>
+				</div>
+
+				<div class="col2">
+					<p>[drop here]</p>
+				</div>
+			</div>
+			<p>x</p>
+		</div>
+	</div>
+</div>
+
+<h2>Inline editor</h2>
+<div id="editor2" contenteditable="true">
+	<p>Hello, world!</p>
+
+	<div class="testwidget">
+		<div class="col1">
+			<p>x</p>
+		</div>
+
+		<div class="col2">
+			<div class="testwidget">
+				<div class="col1">
+					<p>x</p>
+				</div>
+
+				<div class="col2">
+					<p>x</p>
+				</div>
+			</div>
+			<p>x</p>
+		</div>
+	</div>
+</div>
+<script>
+	CKEDITOR.addCss( '.testwidget {	border: 1px dashed #AAAAFF;	} .col1, .col2 { border: 1px dashed #AA9090; margin: 5px; }' );
+	CKEDITOR.plugins.add( 'doublecolumn', {
+		requires: 'widget',
+		button: 'doublecolumn',
+		init: function( editor ) {
+			editor.widgets.add( 'doublecolumn', {
+				button: 'doublecolumn',
+				template: '<div class="testwidget"><div class="col1"></div><div class="col2"></div></div>',
+				editables: {
+					col1: { selector: '.col1' },
+					col2: { selector: '.col2' }
+				},
+				upcast: function( element ) {
+					return element.hasClass( 'testwidget' );
+				}
+			} );
+		}
+	} );
+
+	CKEDITOR.replace( 'editor1', {
+		height: 400,
+		extraPlugins: 'doublecolumn',
+		allowedContent: true
+	} );
+
+	CKEDITOR.inline( 'editor2', {
+		extraPlugins: 'doublecolumn,sourcedialog',
+		allowedContent: true
+	} );
+</script>

--- a/tests/plugins/widget/manual/parentdnd.html
+++ b/tests/plugins/widget/manual/parentdnd.html
@@ -41,7 +41,7 @@
 				</div>
 
 				<div class="col2">
-					<p>x</p>
+					<p>[drop here]</p>
 				</div>
 			</div>
 			<p>x</p>

--- a/tests/plugins/widget/manual/parentdnd.md
+++ b/tests/plugins/widget/manual/parentdnd.md
@@ -1,4 +1,4 @@
-@bender-tags: widget, bug, 4509, 4.16.1
+@bender-tags: 4.16.1, bug, 4509, widget
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, undo, indent, justify, clipboard, floatingspace, basicstyles, codesnippet, link, elementspath, blockquote, format, htmlwriter, list, maximize, image
 
@@ -11,6 +11,7 @@
 	## Unexpected result
 
 	Widget drag handler is inserted into the inner widget.
+
 2. Switch to source mode.
 
 	## Expected result
@@ -20,4 +21,5 @@
 	## Unexpected result
 
 	There is an `img` element in the source.
+
 3. Repeat the procedure for every editor.

--- a/tests/plugins/widget/manual/parentdnd.md
+++ b/tests/plugins/widget/manual/parentdnd.md
@@ -1,6 +1,6 @@
 @bender-tags: widget, bug, 4509, 4.16.1
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, undo, indent, justify, clipboard, floatingspace, basicstyles, codesnippet, link, elementspath, blockquote, format, htmlwriter, list, maximize
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, undo, indent, justify, clipboard, floatingspace, basicstyles, codesnippet, link, elementspath, blockquote, format, htmlwriter, list, maximize, image
 
 1. Try to drag and drop the most outer widget into `[drop here]` area.
 

--- a/tests/plugins/widget/manual/parentdnd.md
+++ b/tests/plugins/widget/manual/parentdnd.md
@@ -1,0 +1,23 @@
+@bender-tags: widget, bug, 4509, 4.16.1
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, table, undo, indent, justify, clipboard, floatingspace, basicstyles, codesnippet, link, elementspath, blockquote, format, htmlwriter, list, maximize
+
+1. Try to drag and drop the most outer widget into `[drop here]` area.
+
+	## Expected result
+
+	Nothing happens.
+
+	## Unexpected result
+
+	Widget drag handler is inserted into the inner widget.
+2. Switch to source mode.
+
+	## Expected result
+
+	There is no `img` element in the source.
+
+	## Unexpected result
+
+	There is an `img` element in the source.
+3. Repeat the procedure for every editor.

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1742,11 +1742,11 @@
 								'<img class="cke_reset cke_widget_drag_handler" data-cke-widget-drag-handler="1" src="img" width="15" title="title" height="15" role="presentation">' +
 							'</span>' +
 						'</div>',
-						expectedHtml = '<div id="w2" data-widget="testdatafilter"><div class="foo"><p>Foo</p></div></div>';
+						expectedHtml = '<div data-widget="testdatafilter" id="w2"><div class="foo"><p>Foo</p></div></div>';
 
 					nestedEditable.setData( widgetHtml );
 
-					assert.areSame( expectedHtml, nestedEditable.getData(), 'Widget UI elements are filtered out' );
+					bender.assert.isInnerHtmlMatching( expectedHtml, nestedEditable.getData(), null, 'Widget UI elements are filtered out' );
 				} );
 			} );
 		}

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1735,14 +1735,14 @@
 							'cke_widget_testdatafilter" data-cke-display-name="div" data-cke-widget-id="1" role="region" aria-label="Widget div">' +
 							'<div id="w2" data-widget="testdatafilter" data-cke-widget-keep-attr="1" class="cke_widget_element" data-cke-widget-data="%7B%22classes%22%3Anull%7D">' +
 								'<div class="foo cke_widget_editable" contenteditable="true" data-cke-widget-editable="foo" data-cke-enter-mode="1">' +
-									'<p><br></p>' +
+									'<p>Foo</p>' +
 								'</div>' +
 							'</div>' +
 							'<span class="cke_reset cke_widget_drag_handler_container" style="background:rgba(220,220,220,0.5);background-image:url(img);display:none;">' +
 								'<img class="cke_reset cke_widget_drag_handler" data-cke-widget-drag-handler="1" src="img" width="15" title="title" height="15" role="presentation">' +
 							'</span>' +
 						'</div>',
-						expectedHtml = '<div id="w2" data-widget="testdatafilter"><div class="foo"><p> </p></div></div>';
+						expectedHtml = '<div id="w2" data-widget="testdatafilter"><div class="foo"><p>Foo</p></div></div>';
 
 					nestedEditable.setData( widgetHtml );
 

--- a/tests/plugins/widget/nestededitables.js
+++ b/tests/plugins/widget/nestededitables.js
@@ -1709,6 +1709,46 @@
 				assert.isTrue( protectedRegex.test( editableContent ), 'Source is protected' );
 				assert.areSame( html, editor.getData(), 'Data is correctly unescaped' );
 			} );
+		},
+
+		// (#4509)
+		'test filtering out widget UI elements': function() {
+			bender.editorBot.create( {
+				name: 'testdatafilter',
+				creator: 'replace',
+				config: {
+					allowedContent: true
+				}
+			}, function( bot ) {
+				var editor = bot.editor;
+
+				editor.widgets.add( 'testdatafilter', {
+					editables: {
+						foo: '.foo'
+					}
+				} );
+
+				bot.setData( '<div id="w1" data-widget="testdatafilter"><div class="foo"></div></div>', function() {
+					var widget1 = getWidgetById( editor, 'w1' ),
+						nestedEditable = widget1.editables.foo,
+						widgetHtml = '<div tabindex="-1" contenteditable="false" data-cke-widget-wrapper="1" data-cke-filter="off" class="cke_widget_wrapper cke_widget_block' +
+							'cke_widget_testdatafilter" data-cke-display-name="div" data-cke-widget-id="1" role="region" aria-label="Widget div">' +
+							'<div id="w2" data-widget="testdatafilter" data-cke-widget-keep-attr="1" class="cke_widget_element" data-cke-widget-data="%7B%22classes%22%3Anull%7D">' +
+								'<div class="foo cke_widget_editable" contenteditable="true" data-cke-widget-editable="foo" data-cke-enter-mode="1">' +
+									'<p><br></p>' +
+								'</div>' +
+							'</div>' +
+							'<span class="cke_reset cke_widget_drag_handler_container" style="background:rgba(220,220,220,0.5);background-image:url(img);display:none;">' +
+								'<img class="cke_reset cke_widget_drag_handler" data-cke-widget-drag-handler="1" src="img" width="15" title="title" height="15" role="presentation">' +
+							'</span>' +
+						'</div>',
+						expectedHtml = '<div id="w2" data-widget="testdatafilter"><div class="foo"><p> </p></div></div>';
+
+					nestedEditable.setData( widgetHtml );
+
+					assert.areSame( expectedHtml, nestedEditable.getData(), 'Widget UI elements are filtered out' );
+				} );
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4509](https://github.com/ckeditor/ckeditor4/issues/4509): Fixed: incorrect handling of drag & drop inside widgets and nested editables.
```

## What changes did you make?

I've fixed two separate issues:

* parent widget could be dropped into the child one – I've fixed it by adding a check inside `drop` listener if the dropped widget doesn't contain the target one;
* incorrect data processing in nested editables – see https://github.com/ckeditor/ckeditor4/issues/4509#issuecomment-819419828 for more details; I went with the 2. solution and exposed two private methods on `CKEDITOR.htmlDataProcessor.prototype`.

## Which issues does your PR resolve?

Closes #4509.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
