### PR TITLE
Enhance getting types from dataTransfer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,16 @@ CKEditor 4 Changelog
 
 New Features:
 
+Fixed Issues:
+
+* [#4604](https://github.com/ckeditor/ckeditor4/issues/4604): Fixed: [`CKEDITOR.plugins.clipboard.dataTransfer#getTypes()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard_dataTransfer.html#method-getTypes) returns no types.
+
+**API Changes:**
+
+* [#4604](https://github.com/ckeditor/ckeditor4/issues/4604): Added the [`CKEDITOR.plugins.clipboard.dataTransfer#isFileTransfer()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard_dataTransfer.html#method-isFileTransfer) method.
 * [#4583](https://github.com/ckeditor/ckeditor4/issues/4583): Added support for new, comma-less color syntax to [`CKEDITOR.tools.color`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_color.html).
 * [#4467](https://github.com/ckeditor/ckeditor4/issues/4467): Inserting content next to block [widgets](https://ckeditor.com/cke4/addon/widget) using keyboard navigation is now possible. Thanks to [bunglegrind](https://github.com/bunglegrind)!
+
 ## CKEditor 4.16.1
 
 Fixed Issues:

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2685,6 +2685,18 @@
 		},
 
 		/**
+		 * Checks if the data transfer contains only files.
+		 *
+		 * @since 4.17.0
+		 * @returns {Boolean} `true` if the object contains only files.
+		 */
+		isFileTransfer: function() {
+			var types = this.getTypes();
+
+			return types.length === 1 && types[ 0 ].toLowerCase() === 'files';
+		},
+
+		/**
 		 * Checks if the data transfer contains any data.
 		 *
 		 * @returns {Boolean} `true` if the object contains no data.

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2341,6 +2341,7 @@
 			bodyRegExp: /<body(?:[\s\S]*?)>([\s\S]*)<\/body>/i,
 			fragmentRegExp: /\s*<!--StartFragment-->|<!--EndFragment-->\s*/g,
 
+			types: [],
 			data: {},
 			files: [],
 
@@ -2610,6 +2611,9 @@
 				if ( data ) {
 					that._.data[ type ] = data;
 				}
+
+				// Cache type itself (#4604).
+				that._.types.push( type );
 			}
 
 			// Copy data.
@@ -2733,6 +2737,10 @@
 		 * @returns {String[]}
 		 */
 		getTypes: function() {
+			if ( this._.types.length > 0 ) {
+				return this._.types;
+			}
+
 			if ( !this.$ || !this.$.types ) {
 				return [];
 			}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2355,6 +2355,9 @@
 					return 'Text'; // IE support only Text and URL;
 				} else if ( type == 'url' ) {
 					return 'URL'; // IE support only Text and URL;
+				} else if ( type === 'files' ) {
+					// Do not normalize Files type (#4604).
+					return 'Files';
 				} else {
 					return type;
 				}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -2691,9 +2691,13 @@
 		 * @returns {Boolean} `true` if the object contains only files.
 		 */
 		isFileTransfer: function() {
-			var types = this.getTypes();
+			var types = this.getTypes(),
+				// Firefox uses application/x-moz-file type for dropped local files.
+				filteredTypes = CKEDITOR.tools.array.filter( types, function( type ) {
+					return type !== 'application/x-moz-file';
+				} );
 
-			return types.length === 1 && types[ 0 ].toLowerCase() === 'files';
+			return filteredTypes.length === 1 && filteredTypes[ 0 ].toLowerCase() === 'files';
 		},
 
 		/**

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1336,5 +1336,22 @@ bender.test( {
 		nativeData.setData( 'text/html', '<p>Foobar</p>' );
 
 		assert.isFalse( dataTransfer.isFileTransfer() );
+	},
+
+	// (#4604)
+	'test isFileTransfer method detecting correctly file transfer with Firefox custom file type': function() {
+		if ( !CKEDITOR.env.gecko ) {
+			return assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData );
+
+		nativeData.types.push( 'application/x-moz-file' );
+		nativeData.types.push( 'Files' );
+		nativeData.files.push( 'foo' );
+		nativeData.files.push( 'bar' );
+
+		assert.isTrue( dataTransfer.isFileTransfer() );
 	}
 } );

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1255,7 +1255,7 @@ bender.test( {
 	},
 
 	// (#4604)
-	'test asynchronous getTypes': function() {
+	'test asynchronous getTypes (in browsers with custom types support)': function() {
 		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();
 		}
@@ -1274,9 +1274,28 @@ bender.test( {
 	},
 
 	// (#4604)
+	'test asynchronous getTypes (in browsers without custom types support)': function() {
+		if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			return assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData ),
+			expectedTypes = [ 'Text', 'URL' ];
+
+		nativeData.setData( 'Text', 'Test' );
+		dataTransfer.cacheData();
+
+		// When asynchronously accessing native data transfer it is unavailable. Here we simulate it by removing stored types.
+		nativeData.types = [];
+
+		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes() );
+	},
+
+	// (#4604)
 	'test isFileTransfer method detecting correctly file transfer': function() {
-		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
-			assert.ignore();
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			return assert.ignore();
 		}
 
 		var nativeData = bender.tools.mockNativeDataTransfer(),
@@ -1291,8 +1310,8 @@ bender.test( {
 
 	// (#4604)
 	'test isFileTransfer method detecting correctly non-file transfer': function() {
-		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
-			assert.ignore();
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			return assert.ignore();
 		}
 
 		var nativeData = bender.tools.mockNativeDataTransfer(),
@@ -1305,8 +1324,8 @@ bender.test( {
 
 	// (#4604)
 	'test isFileTransfer method detecting correctly file + non-file transfer': function() {
-		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
-			assert.ignore();
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			return assert.ignore();
 		}
 
 		var nativeData = bender.tools.mockNativeDataTransfer(),

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1252,5 +1252,24 @@ bender.test( {
 		var dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer();
 
 		arrayAssert.itemsAreSame( [], dataTransfer.getTypes() );
+	},
+
+	// (#4604)
+	'test asynchronous getTypes': function() {
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			return assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData ),
+			expectedTypes = [ 'hublabubla', 'cke4/custom' ];
+
+		nativeData.types = expectedTypes;
+		dataTransfer.cacheData();
+
+		// When asynchronously accessing native data transfer it is unavailable. Here we simulate it by removing stored types.
+		nativeData.types = [];
+
+		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes() );
 	}
 } );

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1274,6 +1274,25 @@ bender.test( {
 	},
 
 	// (#4604)
+	'test asynchronous getTypes in browsers with custom types support returns unnormalized Files type': function() {
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			return assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData ),
+			expectedTypes = [ 'Files' ];
+
+		nativeData.types = expectedTypes;
+		dataTransfer.cacheData();
+
+		// When asynchronously accessing native data transfer it is unavailable. Here we simulate it by removing stored types.
+		nativeData.types = [];
+
+		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes(), 'The Files type was normalized to files' );
+	},
+
+	// (#4604)
 	'test asynchronous getTypes in browsers without custom types support returns original types': function() {
 		if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1255,7 +1255,7 @@ bender.test( {
 	},
 
 	// (#4604)
-	'test asynchronous getTypes (in browsers with custom types support)': function() {
+	'test asynchronous getTypes in browsers with custom types support returns original types': function() {
 		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();
 		}
@@ -1270,11 +1270,11 @@ bender.test( {
 		// When asynchronously accessing native data transfer it is unavailable. Here we simulate it by removing stored types.
 		nativeData.types = [];
 
-		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes() );
+		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes(), 'Incorrect types returned by getTypes()' );
 	},
 
 	// (#4604)
-	'test asynchronous getTypes (in browsers without custom types support)': function() {
+	'test asynchronous getTypes in browsers without custom types support returns original types': function() {
 		if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();
 		}
@@ -1289,11 +1289,11 @@ bender.test( {
 		// When asynchronously accessing native data transfer it is unavailable. Here we simulate it by removing stored types.
 		nativeData.types = [];
 
-		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes() );
+		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes(), 'Incorrect types returned by getTypes()' );
 	},
 
 	// (#4604)
-	'test isFileTransfer method detecting correctly file transfer': function() {
+	'test isFileTransfer method detecting file transfer for DataTransfer with files only': function() {
 		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();
 		}
@@ -1305,11 +1305,11 @@ bender.test( {
 		nativeData.files.push( 'foo' );
 		nativeData.files.push( 'bar' );
 
-		assert.isTrue( dataTransfer.isFileTransfer() );
+		assert.isTrue( dataTransfer.isFileTransfer(), 'isFileTransfer() incorrect result for file transfer' );
 	},
 
 	// (#4604)
-	'test isFileTransfer method detecting correctly non-file transfer': function() {
+	'test isFileTransfer method not detecting file transfer for DataTransfer with text data': function() {
 		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();
 		}
@@ -1319,11 +1319,11 @@ bender.test( {
 
 		nativeData.setData( 'text/html', '<p>Foobar</p>' );
 
-		assert.isFalse( dataTransfer.isFileTransfer() );
+		assert.isFalse( dataTransfer.isFileTransfer(), 'isFileTransfer() incorrect result for non-file transfer' );
 	},
 
 	// (#4604)
-	'test isFileTransfer method detecting correctly file + non-file transfer': function() {
+	'test isFileTransfer method not detecting file transfer for DataTransfer with file and text data': function() {
 		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			return assert.ignore();
 		}
@@ -1335,11 +1335,11 @@ bender.test( {
 		nativeData.files.push( 'foo' );
 		nativeData.setData( 'text/html', '<p>Foobar</p>' );
 
-		assert.isFalse( dataTransfer.isFileTransfer() );
+		assert.isFalse( dataTransfer.isFileTransfer(), 'isFileTransfer() incorrect result for file + non-file transfer' );
 	},
 
 	// (#4604)
-	'test isFileTransfer method detecting correctly file transfer with Firefox custom file type': function() {
+	'test isFileTransfer method detecting file transfer for DataTransfer with files and Firefox custom file type set': function() {
 		if ( !CKEDITOR.env.gecko ) {
 			return assert.ignore();
 		}
@@ -1352,6 +1352,6 @@ bender.test( {
 		nativeData.files.push( 'foo' );
 		nativeData.files.push( 'bar' );
 
-		assert.isTrue( dataTransfer.isFileTransfer() );
+		assert.isTrue( dataTransfer.isFileTransfer(), 'isFileTransfer() incorrect result for Firefox custom file type' );
 	}
 } );

--- a/tests/plugins/clipboard/datatransfer.js
+++ b/tests/plugins/clipboard/datatransfer.js
@@ -1271,5 +1271,51 @@ bender.test( {
 		nativeData.types = [];
 
 		arrayAssert.itemsAreSame( expectedTypes, dataTransfer.getTypes() );
+	},
+
+	// (#4604)
+	'test isFileTransfer method detecting correctly file transfer': function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
+			assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData );
+
+		nativeData.types.push( 'Files' );
+		nativeData.files.push( 'foo' );
+		nativeData.files.push( 'bar' );
+
+		assert.isTrue( dataTransfer.isFileTransfer() );
+	},
+
+	// (#4604)
+	'test isFileTransfer method detecting correctly non-file transfer': function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
+			assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData );
+
+		nativeData.setData( 'text/html', '<p>Foobar</p>' );
+
+		assert.isFalse( dataTransfer.isFileTransfer() );
+	},
+
+	// (#4604)
+	'test isFileTransfer method detecting correctly file + non-file transfer': function() {
+		if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10 ) {
+			assert.ignore();
+		}
+
+		var nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData );
+
+		nativeData.types.push( 'Files' );
+		nativeData.files.push( 'foo' );
+		nativeData.setData( 'text/html', '<p>Foobar</p>' );
+
+		assert.isFalse( dataTransfer.isFileTransfer() );
 	}
 } );

--- a/tests/plugins/clipboard/manual/isfiletransfer.html
+++ b/tests/plugins/clipboard/manual/isfiletransfer.html
@@ -12,6 +12,10 @@
 </div>
 
 <script>
+	if ( CKEDITOR.env.ie && CKEDITOR.env.version < 10  ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor', {
 		on: {
 			paste: function( evt ) {

--- a/tests/plugins/clipboard/manual/isfiletransfer.html
+++ b/tests/plugins/clipboard/manual/isfiletransfer.html
@@ -20,7 +20,7 @@
 		on: {
 			paste: function( evt ) {
 				var message = CKEDITOR.document.getById( 'message' ),
-					isFileTransfer = evt.data.dataTransfer.isFileTransfer()
+					isFileTransfer = evt.data.dataTransfer.isFileTransfer();
 
 				message.removeAttribute( 'class' );
 				message.addClass( isFileTransfer ? 'ok' : 'not-ok' );

--- a/tests/plugins/clipboard/manual/isfiletransfer.html
+++ b/tests/plugins/clipboard/manual/isfiletransfer.html
@@ -1,0 +1,27 @@
+<style>
+	.ok {
+		background: green;
+	}
+	.not-ok {
+		background: red;
+	}
+</style>
+<p id="message"></p>
+<div id="editor">
+	<p>Paste from clipboard here:</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			paste: function( evt ) {
+				var message = CKEDITOR.document.getById( 'message' ),
+					isFileTransfer = evt.data.dataTransfer.isFileTransfer()
+
+				message.removeAttribute( 'class' );
+				message.addClass( isFileTransfer ? 'ok' : 'not-ok' );
+				message.setText( isFileTransfer ? 'File pasted' : 'Non-file pasted' );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/isfiletransfer.md
+++ b/tests/plugins/clipboard/manual/isfiletransfer.md
@@ -8,7 +8,7 @@ Paste image from the clipboard into the editor.
 
 **Expected**: The message above the editor says "File pasted" on the green background.
 
-Note: image will be actually inserted into the editor only in Firefox!
+Note: test does _not_ require the image to be actually inserted into the editor.
 
 ## Scenario 2:
 
@@ -22,7 +22,7 @@ Drop image or some other file into the editor.
 
 **Expected**: The message above the editor says "File pasted" on the green background.
 
-Note: image will be actually inserted into the editor only in Firefox! File won't be inserted at all.
+Note: test does _not_ require the image nor file to be actually inserted into the editor.
 
 ## Scenario 4:
 

--- a/tests/plugins/clipboard/manual/isfiletransfer.md
+++ b/tests/plugins/clipboard/manual/isfiletransfer.md
@@ -4,31 +4,39 @@
 
 ## Scenario 1:
 
-Paste image from the clipboard into the editor.
+1. Paste image from the clipboard into the editor.
 
-**Expected**: The message above the editor says "File pasted" on the green background.
+	### Expected:
+
+	* The message above the editor says "File pasted" on the green background.
 
 Notes:
-
 * Test does _not_ require the image to be actually inserted into the editor.
 * IEs could ignore pasting in such a case.
 
 ## Scenario 2:
 
-Paste non-file content (e.g. text) into the editor.
+1. Paste non-file content (e.g. text) into the editor.
 
-**Expected**: The message above the editor says "Non-file pasted" on the red background.
+	### Expected:
+
+	* The message above the editor says "Non-file pasted" on the red background.
 
 ## Scenario 3:
 
-Drop image or some other file into the editor.
+1. Drop image or some other file into the editor.
 
-**Expected**: The message above the editor says "File pasted" on the green background.
+	### Expected:
 
-Note: test does _not_ require the image nor file to be actually inserted into the editor.
+	* The message above the editor says "File pasted" on the green background.
+
+Notes:
+* Test does _not_ require the image nor file to be actually inserted into the editor.
 
 ## Scenario 4:
 
-Drop non-file content (e.g. text) into the editor.
+1. Drop non-file content (e.g. text) into the editor.
 
-**Expected**: The message above the editor says "Non-file pasted" on the red background.
+	### Expected:
+
+	* The message above the editor says "Non-file pasted" on the red background.

--- a/tests/plugins/clipboard/manual/isfiletransfer.md
+++ b/tests/plugins/clipboard/manual/isfiletransfer.md
@@ -8,7 +8,10 @@ Paste image from the clipboard into the editor.
 
 **Expected**: The message above the editor says "File pasted" on the green background.
 
-Note: test does _not_ require the image to be actually inserted into the editor.
+Notes:
+
+* Test does _not_ require the image to be actually inserted into the editor.
+* IEs could ignore pasting in such a case.
 
 ## Scenario 2:
 

--- a/tests/plugins/clipboard/manual/isfiletransfer.md
+++ b/tests/plugins/clipboard/manual/isfiletransfer.md
@@ -1,0 +1,31 @@
+@bender-ui: collapsed
+@bender-tags: 4.17.0, 4604, feature, clipboard
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image, clipboard, sourcearea
+
+## Scenario 1:
+
+Paste image from the clipboard into the editor.
+
+**Expected**: The message above the editor says "File pasted" on the green background.
+
+Note: image will be actually inserted into the editor only in Firefox!
+
+## Scenario 2:
+
+Paste non-file content (e.g. text) into the editor.
+
+**Expected**: The message above the editor says "Non-file pasted" on the red background.
+
+## Scenario 3:
+
+Drop image or some other file into the editor.
+
+**Expected**: The message above the editor says "File pasted" on the green background.
+
+Note: image will be actually inserted into the editor only in Firefox! File won't be inserted at all.
+
+## Scenario 4:
+
+Drop non-file content (e.g. text) into the editor.
+
+**Expected**: The message above the editor says "Non-file pasted" on the red background.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Fixed Issues:

*[#4604](https://github.com/ckeditor/ckeditor4/issues/4604): Fixed: [`CKEDITOR.plugins.clipboard.dataTransfer#getTypes()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard_dataTransfer.html#method-getTypes) returns no types.

API Changes:

*[#4604](https://github.com/ckeditor/ckeditor4/issues/4604): Added the [`CKEDITOR.plugins.clipboard.dataTransfer#isFileTransfer()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard_dataTransfer.html#method-isFileTransfer) method.
```

## What changes did you make?

I've added caching also the types in `CKEDITOR.plugins.clipboard.dataTransfer`. Additionally I've introduced `CKEDITOR.plugins.dataTransfer#isFileTransfer()` method that checks if the data transfer object contains only files (has only `Files` type).

## Which issues does your PR resolve?

Closes #4604.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
