### PR TITLE
Fix formatting when selecting new empty lines

### DIFF
--- a/plugins/enterkey/plugin.js
+++ b/plugins/enterkey/plugin.js
@@ -388,8 +388,8 @@
 				// Recreate the inline elements tree, which was available
 				// before hitting enter, so the same styles will be available in
 				// the new block.
-				var elementPath = splitInfo.elementPath;
-				var bogusHolder = newBlock;
+				var elementPath = splitInfo.elementPath,
+					bogusHolder = newBlock;
 				if ( elementPath ) {
 					for ( var i = 0, len = elementPath.elements.length; i < len; i++ ) {
 						var element = elementPath.elements[ i ];
@@ -401,7 +401,7 @@
 							element = element.clone();
 							newBlock.moveChildren( element );
 							newBlock.append( element );
-							if (bogusHolder === newBlock) {
+							if ( bogusHolder === newBlock ) {
 								bogusHolder = element;
 							}
 						}

--- a/plugins/enterkey/plugin.js
+++ b/plugins/enterkey/plugin.js
@@ -389,6 +389,7 @@
 				// before hitting enter, so the same styles will be available in
 				// the new block.
 				var elementPath = splitInfo.elementPath;
+				var bogusHolder = newBlock;
 				if ( elementPath ) {
 					for ( var i = 0, len = elementPath.elements.length; i < len; i++ ) {
 						var element = elementPath.elements[ i ];
@@ -400,11 +401,14 @@
 							element = element.clone();
 							newBlock.moveChildren( element );
 							newBlock.append( element );
+							if (bogusHolder === newBlock) {
+								bogusHolder = element;
+							}
 						}
 					}
 				}
 
-				newBlock.appendBogus();
+				bogusHolder.appendBogus();
 
 				if ( !newBlock.getParent() )
 					range.insertNode( newBlock );

--- a/tests/plugins/enterkey/enterkey.js
+++ b/tests/plugins/enterkey/enterkey.js
@@ -96,6 +96,25 @@
 			assert.areSame( '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p>', bot.getData( false, true ) );
 		},
 
+		// https://github.com/ckeditor/ckeditor4/issues/4626: Selecting an empty line after pressing enter twice loses the formatting
+		'test enter key twice then select empty line': function() {
+			// The bogus should be in the right place for empty lines, otherwise the selection will be
+			// outside the formatted range.
+			var bot = this.editorBots.editor,
+				editor = bot.editor,
+				editable = editor.editable();
+
+			bot.setHtmlWithSelection( '<p><b><i>foo^</i></b></p>' );
+			bot.execCommand( 'enter' );
+			bot.execCommand( 'enter' );
+
+			var selectionAtTheEndOfEmptyLine = new CKEDITOR.dom.range( editor.document );
+			selectionAtTheEndOfEmptyLine.moveToElementEditablePosition( editable.getChild(1), true );
+			editor.getSelection().selectRanges( [ selectionAtTheEndOfEmptyLine ] );
+			editor.insertText( 'bar' );
+			assert.areSame( '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p><p>&nbsp;</p>', bot.getData( false, true ) );
+		},
+
 		// https://dev.ckeditor.com/ticket/7946 TODO: Add editor doc quirks mode tests.
 		'test enter key key scrolls document': function() {
 			// On iPads, behavior of scrollTop, scrollHeight and clientHeight is a bit unexpected.

--- a/tests/plugins/enterkey/enterkey.js
+++ b/tests/plugins/enterkey/enterkey.js
@@ -96,27 +96,6 @@
 			assert.areSame( '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p>', bot.getData( false, true ) );
 		},
 
-		// https://github.com/ckeditor/ckeditor4/issues/4626: Selecting an empty line after pressing enter twice loses the formatting
-		'test enter key twice then select empty line': function() {
-			// The bogus should be in the right place for empty lines, otherwise the selection will be
-			// outside the formatted range.
-			var bot = this.editorBots.editor,
-				editor = bot.editor,
-				editable = editor.editable();
-
-			bot.setHtmlWithSelection( '<p><b><i>foo^</i></b></p>' );
-			bot.execCommand( 'enter' );
-			bot.execCommand( 'enter' );
-
-			var selectionAtTheEndOfEmptyLine = new CKEDITOR.dom.range( editor.document );
-
-			selectionAtTheEndOfEmptyLine.moveToElementEditablePosition( editable.getChild( 1 ), true );
-			editor.getSelection().selectRanges( [ selectionAtTheEndOfEmptyLine ] );
-			editor.insertText( 'bar' );
-
-			assert.areSame( '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p><p>&nbsp;</p>', bot.getData( false, true ) );
-		},
-
 		// https://dev.ckeditor.com/ticket/7946 TODO: Add editor doc quirks mode tests.
 		'test enter key key scrolls document': function() {
 			// On iPads, behavior of scrollTop, scrollHeight and clientHeight is a bit unexpected.

--- a/tests/plugins/enterkey/enterkey.js
+++ b/tests/plugins/enterkey/enterkey.js
@@ -109,9 +109,11 @@
 			bot.execCommand( 'enter' );
 
 			var selectionAtTheEndOfEmptyLine = new CKEDITOR.dom.range( editor.document );
-			selectionAtTheEndOfEmptyLine.moveToElementEditablePosition( editable.getChild(1), true );
+
+			selectionAtTheEndOfEmptyLine.moveToElementEditablePosition( editable.getChild( 1 ), true );
 			editor.getSelection().selectRanges( [ selectionAtTheEndOfEmptyLine ] );
 			editor.insertText( 'bar' );
+
 			assert.areSame( '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p><p>&nbsp;</p>', bot.getData( false, true ) );
 		},
 

--- a/tests/plugins/enterkey/format-after-enterkey.js
+++ b/tests/plugins/enterkey/format-after-enterkey.js
@@ -1,0 +1,102 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: entities, enterkey */
+
+var INITIALCONTENT_P = '<p><b><i>foo^</i></b></p>',
+	INITIALCONTENT_DIV = '<div><b><i>foo^</i></b></div>',
+	INITIALCONTENT_BR = '<b><i>foo^</i></b>',
+	KEY_BACKSPACE = 8
+
+bender.editors = {
+	editorP: {
+		name: 'editorP',
+		config: {
+			enterMode: CKEDITOR.ENTER_P,
+			allowedContent: true,
+		},
+	},
+
+	editorDiv: {
+		name: 'editorDiv',
+		config: {
+			enterMode: CKEDITOR.ENTER_DIV,
+			allowedContent: true,
+		},
+	},
+
+	editorBr: {
+		name: 'editorBr',
+		config: {
+			enterMode: CKEDITOR.ENTER_BR,
+			allowedContent: true,
+		},
+	},
+};
+
+bender.test( {
+	_should: {
+		ignore: {
+			// Backspace is not handled by the editor itself in BR mode, so it cannot be simulated
+			'test enter key twice then select backspace with BR mode': true
+		}
+	},
+
+	// https://github.com/ckeditor/ckeditor4/issues/4626: Selecting an empty line after pressing enter twice loses the formatting
+	'test enter key twice then select empty line with P mode': doubleEnter( 'editorP', INITIALCONTENT_P, selectElement( secondLineInBlockMode ), '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p><p>&nbsp;</p>' ),
+	'test enter key twice then select empty line with DIV mode': doubleEnter( 'editorDiv', INITIALCONTENT_DIV, selectElement( secondLineInBlockMode ), '<div><b><i>foo</i></b></div><div><b><i>bar</i></b></div><div>&nbsp;</div>' ),
+	'test enter key twice then select empty line with BR mode': doubleEnter( 'editorBr', INITIALCONTENT_BR, selectElement( secondLineInBrMode ), '<b><i>foo<br />bar</i></b><br />&nbsp;' ),
+	'test enter key twice then select backspace with P mode': doubleEnter( 'editorP', INITIALCONTENT_P, pressBackspace( ), '<p><b><i>foo</i></b></p><p><b><i>bar</i></b></p>' ),
+	'test enter key twice then select backspace with DIV mode': doubleEnter( 'editorDiv', INITIALCONTENT_DIV, pressBackspace( ), '<div><b><i>foo</i></b></div><div><b><i>bar</i></b></div>' ),
+	'test enter key twice then select backspace with BR mode': doubleEnter( 'editorBr', INITIALCONTENT_BR, pressBackspace( ), '<b><i>foo<br />bar</i></b>' ),
+} );
+
+function doubleEnter( editorName, initialContent, afterDoubleEnter, expectedContent ) {
+	return function() {
+		// The bogus should be in the right place for empty lines, otherwise the selection will be
+		// outside the formatted range.
+		var bot = this.editorBots[ editorName ],
+			editor = bot.editor;
+
+		bot.setHtmlWithSelection( initialContent );
+		bot.execCommand( 'enter' );
+		bot.execCommand( 'enter' );
+
+		afterDoubleEnter( editor );
+
+		editor.insertText( 'bar' );
+
+		assert.areSame(
+			expectedContent,
+			bot.getData( false, true )
+		);
+	};
+}
+
+function secondLineInBlockMode( editable ) {
+	// Using block enter mode, second child is the second line
+	return editable.getChild( 1 );
+}
+
+function secondLineInBrMode( editable ) {
+	// Using BR enter mode, third child inside <b><i> is the second line [ #text, <br />, #text, <br /> #text ]
+	return editable.getChild( 0 ).getChild( 0 ).getChild( 2 );
+}
+
+function selectElement( elementSelector ) {
+	return function( editor ) {
+		var selectionAtTheEndOfEmptyLine = new CKEDITOR.dom.range(
+			editor.document
+		);
+
+		selectionAtTheEndOfEmptyLine.moveToElementEditablePosition(
+			elementSelector( editor.editable() ),
+			true
+		);
+		editor.getSelection().selectRanges( [ selectionAtTheEndOfEmptyLine ] );
+	};
+}
+
+function pressBackspace( ) {
+	return function( editor ) {
+		editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: KEY_BACKSPACE } ) );
+	};
+}

--- a/tests/plugins/enterkey/manual/emptylineselection.html
+++ b/tests/plugins/enterkey/manual/emptylineselection.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p><b><i>foo</i></b></p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/enterkey/manual/emptylineselection.html
+++ b/tests/plugins/enterkey/manual/emptylineselection.html
@@ -1,7 +1,21 @@
-<div id="editor">
+<pre>{ enterMode: CKEDITOR.ENTER_P }</pre>
+<div id="editorP">
 	<p><b><i>foo</i></b></p>
 </div>
 
+<pre>{ enterMode: CKEDITOR.ENTER_DIV }</pre>
+<div id="editorDiv">
+	<div><b><i>foo</i></b></div>
+</div>
+
+<pre>{ enterMode: CKEDITOR.ENTER_BR }</pre>
+<div id="editorBr">
+	<b><i>foo</i></b>
+</div>
+
+
 <script>
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editorP', { enterMode: CKEDITOR.ENTER_P } );
+	CKEDITOR.replace( 'editorDiv', { enterMode: CKEDITOR.ENTER_DIV } );
+	CKEDITOR.replace( 'editorBr', { enterMode: CKEDITOR.ENTER_BR } );
 </script>

--- a/tests/plugins/enterkey/manual/emptylineselection.md
+++ b/tests/plugins/enterkey/manual/emptylineselection.md
@@ -1,0 +1,24 @@
+@bender-tags: 4.16, bug, 4626
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, enterkey
+
+1. Place a cursor right after 'foo'
+
+```
+foo
+   ^ - put selection here
+```
+
+2. Press `Enter` twice.
+
+3. Press `Left` key to move the cursor to the empty line
+
+4. Type 'bar'
+
+## Expected
+
+The text 'bar' is bold and italic.
+
+## Unexpected
+
+The text 'bar' is unformatted.

--- a/tests/plugins/enterkey/manual/emptylineselection.md
+++ b/tests/plugins/enterkey/manual/emptylineselection.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, enterkey
 
-1. Place a cursor right after 'foo'
+1. Place a cursor right after 'foo' in either of the editors
 
 ```
 foo
@@ -11,7 +11,7 @@ foo
 
 2. Press `Enter` twice.
 
-3. Press `Left` key to move the cursor to the empty line
+3. Press `Left` key or `Up` key or `Backspace` to move the cursor to the empty line
 
 4. Type 'bar'
 

--- a/tests/plugins/enterkey/manual/emptylineselection.md
+++ b/tests/plugins/enterkey/manual/emptylineselection.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.16, bug, 4626
+@bender-tags: 4.16.1, bug, 4626
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, enterkey
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4626](https://github.com/ckeditor/ckeditor4/issues/4626): Fix formatting when selecting new empty lines.
```

## What changes did you make?

When enter is pressed, the _enterkey_ plugin clones the formatting nodes (span/b/i).
It also adds a `<br>` bogus so the line can be selected even if it's empty.

The problem was that the bogus was added after the formatting nodes, not inside them.
So instead of this:
`<p><b><br></b></p>`
it looked like this:
`<p><b></b><br></p>`

## Which issues does your PR resolve?

Closes #4626 .
