### PR TITLE
Fix incorrect HSL/HSLA conversion

### DIFF
--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -112,12 +112,20 @@
 			 *
 			 */
 			getHsl: function() {
+				var isIntegerAlpha = this._.alpha === 0 || this._.alpha === 1,
+					hsl,
+					color;
+
 				if ( !this._.isValidColor ) {
 					return this._.defaultValue;
 				}
 
-				var color = this._.blendAlphaColor( this._.red, this._.green, this._.blue, this._.alpha ),
+				if ( this._.type === CKEDITOR.tools.color.TYPE_HSL && isIntegerAlpha ) {
+					hsl = [ this._.hue, this._.saturation, this._.lightness ];
+				} else {
+					color = this._.blendAlphaColor( this._.red, this._.green, this._.blue, this._.alpha );
 					hsl = this._.rgbToHsl( color[ 0 ], color[ 1 ], color[ 2 ] );
+				}
 
 				return this._.formatHslString( 'hsl', hsl[ 0 ], hsl[ 1 ], hsl[ 2 ] );
 			},
@@ -128,11 +136,17 @@
 			 * @returns {String/*} HSLA color representation (e.g. `hsla(360,100%,50%,0)`) or default value.
 			 */
 			getHsla: function() {
+				var hsl;
+
 				if ( !this._.isValidColor ) {
 					return this._.defaultValue;
 				}
 
-				var hsl = this._.rgbToHsl( this._.red, this._.green, this._.blue );
+				if ( this._.type === CKEDITOR.tools.color.TYPE_HSL ) {
+					hsl = [ this._.hue, this._.saturation, this._.lightness ];
+				} else {
+					hsl = this._.rgbToHsl( this._.red, this._.green, this._.blue );
+				}
 
 				return this._.formatHslString( 'hsla', hsl[ 0 ], hsl[ 1 ], hsl[ 2 ], this._.alpha );
 			},

--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -179,12 +179,12 @@
 			isValidColor: true,
 
 			/**
-			 * Original color type..
+			 * Original color type.
 			 *
 			 * @private
 			 * @property {Number}
 			 */
-			originalType: 0,
+			type: 0,
 
 			/**
 			 * Hue value.

--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -576,7 +576,7 @@
 
 				hue = Math.round( hue );
 				saturation = Math.round( saturation * 100 );
-				lightness = lightness * 100;
+				lightness = Math.round( lightness * 100 );
 
 				return [ hue, saturation, lightness ];
 			}

--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -575,7 +575,7 @@
 				}
 
 				hue = Math.round( hue );
-				saturation = Math.round( saturation ) * 100;
+				saturation = Math.round( saturation * 100 );
 				lightness = lightness * 100;
 
 				return [ hue, saturation, lightness ];

--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -175,7 +175,7 @@
 			/**
 			 * Hue value.
 			 *
-			 * Used in HSL colors.
+			 * Used in HSL colors. Ranges between 0-360 (inclusive).
 			 *
 			 * @private
 			 * @property {Number}
@@ -183,7 +183,7 @@
 			hue: 0,
 
 			/**
-			 * Saturation value. Ranges between 0-1 (inclusive).
+			 * Saturation value. Ranges between 0-100 (inclusive).
 			 *
 			 * Used in HSL colors.
 			 *
@@ -193,7 +193,7 @@
 			saturation: 0,
 
 			/**
-			 * Ligthness value. Ranges between 0-1 (inclusive).
+			 * Ligthness value. Ranges between 0-100 (inclusive).
 			 *
 			 * Used in HSL colors.
 			 *
@@ -484,8 +484,8 @@
 					blue: rgba[ 2 ],
 					alpha: rgba[ 3 ],
 					hue: hue,
-					saturation: saturation,
-					lightness: lightness
+					saturation: Math.round( saturation * 100 ),
+					lightness: Math.round( lightness * 100 )
 				};
 
 				return this._.areColorChannelsValid( rgba[ 0 ], rgba[ 1 ], rgba[ 2 ], rgba[ 3 ] ) ? result : null;

--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -165,6 +165,44 @@
 			isValidColor: true,
 
 			/**
+			 * Original color type..
+			 *
+			 * @private
+			 * @property {Number}
+			 */
+			originalType: 0,
+
+			/**
+			 * Hue value.
+			 *
+			 * Used in HSL colors.
+			 *
+			 * @private
+			 * @property {Number}
+			 */
+			hue: 0,
+
+			/**
+			 * Saturation value. Ranges between 0-1 (inclusive).
+			 *
+			 * Used in HSL colors.
+			 *
+			 * @private
+			 * @property {Number}
+			 */
+			saturation: 0,
+
+			/**
+			 * Ligthness value. Ranges between 0-1 (inclusive).
+			 *
+			 * Used in HSL colors.
+			 *
+			 * @private
+			 * @property {Number}
+			 */
+			lightness: 0,
+
+			/**
 			 * Red channel value. Ranges between 0-255 (inclusive).
 			 *
 			 * @private
@@ -307,10 +345,17 @@
 					return;
 				}
 
-				this._.red = colorChannels[ 0 ];
-				this._.green = colorChannels[ 1 ];
-				this._.blue = colorChannels[ 2 ];
-				this._.alpha = colorChannels[ 3 ];
+				this._.type = colorChannels.type;
+				this._.red = colorChannels.red;
+				this._.green = colorChannels.green;
+				this._.blue = colorChannels.blue;
+				this._.alpha = colorChannels.alpha;
+
+				if ( colorChannels.type === CKEDITOR.tools.color.TYPE_HSL ) {
+					this._.hue = colorChannels.hue;
+					this._.saturation = colorChannels.saturation;
+					this._.lightness = colorChannels.lightness;
+				}
 			},
 
 			/**
@@ -329,7 +374,7 @@
 			 *
 			 * @private
 			 * @param {String} colorCode HEX color representation.
-			 * @returns {Array/null}
+			 * @returns {Object/null}
 			 */
 			extractColorChannelsFromHex: function( colorCode ) {
 				// We also like to support hex-like values (so hexes without hash at the beginning).
@@ -358,12 +403,13 @@
 					alpha = Number( alpha.toFixed( 1 ) );
 				}
 
-				return [
-					hexToNumber( parts[ 1 ] + parts[ 2 ] ),
-					hexToNumber( parts[ 3 ] + parts[ 4 ] ),
-					hexToNumber( parts[ 5 ] + parts [ 6 ] ),
-					alpha
-				];
+				return {
+					type: CKEDITOR.tools.color.TYPE_RGB,
+					red: hexToNumber( parts[ 1 ] + parts[ 2 ] ),
+					green: hexToNumber( parts[ 3 ] + parts[ 4 ] ),
+					blue: hexToNumber( parts[ 5 ] + parts [ 6 ] ),
+					alpha: alpha
+				};
 			},
 
 			/**
@@ -371,7 +417,7 @@
 			 *
 			 * @private
 			 * @param {String} colorCode RGB or RGBA color representation.
-			 * @returns {Array/null}
+			 * @returns {Object/null}
 			 */
 			extractColorChannelsFromRgba: function( colorCode ) {
 				var channels =  this._.extractColorChannelsByPattern( colorCode, CKEDITOR.tools.color.rgbRegExp );
@@ -391,7 +437,15 @@
 					alpha = tryToConvertToValidFloatValue( channels[ 3 ], CKEDITOR.tools.color.MAX_ALPHA_CHANNEL_VALUE );
 				}
 
-				return this._.areColorChannelsValid( red, green, blue, alpha ) ? [ red, green, blue, alpha ] : null;
+				var result = {
+					type: CKEDITOR.tools.color.TYPE_RGB,
+					red: red,
+					green: green,
+					blue: blue,
+					alpha: alpha
+				};
+
+				return this._.areColorChannelsValid( red, green, blue, alpha ) ? result : null;
 			},
 
 			/**
@@ -399,7 +453,7 @@
 			 *
 			 * @private
 			 * @param {String} colorCode HSL or HSLA color representation.
-			 * @returns {Array/null}
+			 * @returns {Object/null}
 			 */
 			extractColorChannelsFromHsla: function( colorCode ) {
 				var channels =  this._.extractColorChannelsByPattern( colorCode, CKEDITOR.tools.color.hslRegExp );
@@ -423,7 +477,18 @@
 
 				rgba.push( alpha );
 
-				return this._.areColorChannelsValid( rgba[ 0 ], rgba[ 1 ], rgba[ 2 ], rgba[ 3 ] ) ? rgba : null;
+				var result = {
+					type: CKEDITOR.tools.color.TYPE_HSL,
+					red: rgba[ 0 ],
+					green: rgba[ 1 ],
+					blue: rgba[ 2 ],
+					alpha: rgba[ 3 ],
+					hue: hue,
+					saturation: saturation,
+					lightness: lightness
+				};
+
+				return this._.areColorChannelsValid( rgba[ 0 ], rgba[ 1 ], rgba[ 2 ], rgba[ 3 ] ) ? result : null;
 			},
 
 			/**
@@ -583,6 +648,26 @@
 		},
 
 		statics: {
+			/**
+			 * Indicates that the color is in RGB format.
+			 *
+			 * @private
+			 * @static
+			 * @readonly
+			 * @property {Number}
+			 */
+			TYPE_RGB: 1,
+
+			/**
+			 * Indicates that the color is in HSL format.
+			 *
+			 * @private
+			 * @static
+			 * @readonly
+			 * @property {Number}
+			 */
+			TYPE_HSL: 2,
+
 			/**
 			 * The maximum value of RGB channel.
 			 *

--- a/tests/core/tools/color.js
+++ b/tests/core/tools/color.js
@@ -189,7 +189,7 @@
 		'test converting HSLA (123, 50%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 50%, 50%, .5 )', 'hsla(123,50%,50%,0.5)', 'getHsla' ),
 
 		// (#4596)
-		'test converting HSL (123, 0%, 50%) to HSL value returns the original value': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsla(123,0%,50%)', 'getHsl' ),
+		'test converting HSL (123, 0%, 50%) to HSL value returns the original value': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsl(123,0%,50%)', 'getHsl' ),
 
 		// (#4596)
 		'test converting HSL (123, 0%, 50%) to HSLA value returns the original value with 1 opacity': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsla(123,0%,50%,1)', 'getHsla' ),

--- a/tests/core/tools/color.js
+++ b/tests/core/tools/color.js
@@ -140,28 +140,22 @@
 		'test RGBA value with alpha (percentage) and no-comma syntax': colorTools.testColorConversion( 'rgba( 255 0 255 / 10% )', 'rgba(255,0,255,0.1)', 'getRgba' ),
 
 		// (#4583)
-		// The expected value is incorrect due to #4597.
-		'test HSL value with no-comma syntax': colorTools.testColorConversion( 'hsl( 200 50% 10% )', 'hsl(199,0%,10%)', 'getHsl' ),
+		'test HSL value with no-comma syntax': colorTools.testColorConversion( 'hsl( 200 50% 10% )', 'hsl(200,50%,10%)', 'getHsl' ),
 
 		// (#4583)
-		// The expected value is incorrect due to #4597.
-		'test HSL value with alpha (number) and no-comma syntax': colorTools.testColorConversion( 'hsl( 200 50% 10% / 0.1 )', 'hsla(199,0%,10%,0.1)', 'getHsla' ),
+		'test HSL value with alpha (number) and no-comma syntax': colorTools.testColorConversion( 'hsl( 200 50% 10% / 0.1 )', 'hsla(200,50%,10%,0.1)', 'getHsla' ),
 
 		// (#4583)
-		// The expected value is incorrect due to #4597.
-		'test HSL value with alpha (percentage) and no-comma syntax': colorTools.testColorConversion( 'hsl( 200 50% 10% / 10% )', 'hsla(199,0%,10%,0.1)', 'getHsla' ),
+		'test HSL value with alpha (percentage) and no-comma syntax': colorTools.testColorConversion( 'hsl( 200 50% 10% / 10% )', 'hsla(200,50%,10%,0.1)', 'getHsla' ),
 
 		// (#4583)
-		// The expected value is incorrect due to #4597.
-		'test HSLA value with no-comma syntax': colorTools.testColorConversion( 'hsla( 200 50% 10% )', 'hsl(199,0%,10%)', 'getHsl' ),
+		'test HSLA value with no-comma syntax': colorTools.testColorConversion( 'hsla( 200 50% 10% )', 'hsl(200,50%,10%)', 'getHsl' ),
 
 		// (#4583)
-		// The expected value is incorrect due to #4597.
-		'test HSLA value with alpha (number) and no-comma syntax': colorTools.testColorConversion( 'hsla( 200 50% 10% / 0.1 )', 'hsla(199,0%,10%,0.1)', 'getHsla' ),
+		'test HSLA value with alpha (number) and no-comma syntax': colorTools.testColorConversion( 'hsla( 200 50% 10% / 0.1 )', 'hsla(200,50%,10%,0.1)', 'getHsla' ),
 
 		// (#4583)
-		// The expected value is incorrect due to #4597.
-		'test HSLA value with alpha (percentage) and no-comma syntax': colorTools.testColorConversion( 'hsla( 200 50% 10% / 10% )', 'hsla(199,0%,10%,0.1)', 'getHsla' ),
+		'test HSLA value with alpha (percentage) and no-comma syntax': colorTools.testColorConversion( 'hsla( 200 50% 10% / 10% )', 'hsla(200,50%,10%,0.1)', 'getHsla' ),
 
 		// (#4583)
 		'test 6-HEX-like value is treated as 6-HEX value': colorTools.testColorConversion( 'FF0000', '#FF0000', 'getHex' ),

--- a/tests/core/tools/color.js
+++ b/tests/core/tools/color.js
@@ -204,8 +204,8 @@
 
 			assert.areSame( CKEDITOR.tools.color.TYPE_HSL, color._.type, 'Color type is correctly set to HSL' );
 			assert.areSame( 100, color._.hue, 'Hue data is saved' );
-			assert.areSame( 0.37, color._.saturation, 'Saturation data is saved' );
-			assert.areSame( 0.17, color._.lightness, 'Lightness data is saved' );
+			assert.areSame( 37, color._.saturation, 'Saturation data is saved' );
+			assert.areSame( 17, color._.lightness, 'Lightness data is saved' );
 		},
 
 		// (#4596)

--- a/tests/core/tools/color.js
+++ b/tests/core/tools/color.js
@@ -195,7 +195,34 @@
 		'test converting HSL (123, 0%, 50%) to HSLA value returns the original value with 1 opacity': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsla(123,0%,50%,1)', 'getHsla' ),
 
 		// (#4596)
-		'test converting HSLA (123, 0%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 0%, 50%, 0.5 )', 'hsla(123,0%,50%,0.5)', 'getHsla' )
+		'test converting HSLA (123, 0%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 0%, 50%, 0.5 )', 'hsla(123,0%,50%,0.5)', 'getHsla' ),
+
+		// (#4596)
+		'test saving data about color type, hue, saturation and ligthness for HSL color': function() {
+			var input = 'hsl( 100, 37%, 17% )',
+				color = new CKEDITOR.tools.color( input );
+
+			assert.areSame( CKEDITOR.tools.color.TYPE_HSL, color._.type, 'Color type is correctly set to HSL' );
+			assert.areSame( 100, color._.hue, 'Hue data is saved' );
+			assert.areSame( 0.37, color._.saturation, 'Saturation data is saved' );
+			assert.areSame( 0.17, color._.lightness, 'Lightness data is saved' );
+		},
+
+		// (#4596)
+		'test saving data about color type for RGB color': function() {
+			var input = 'rgb( 124, 54, 33 )',
+				color = new CKEDITOR.tools.color( input );
+
+			assert.areSame( CKEDITOR.tools.color.TYPE_RGB, color._.type, 'Color type is correctly set to RGB' );
+		},
+
+		// (#4596)
+		'test saving data about color type for hex color': function() {
+			var input = '#FF00FF',
+				color = new CKEDITOR.tools.color( input );
+
+			assert.areSame( CKEDITOR.tools.color.TYPE_RGB, color._.type, 'Color type is correctly set to RGB' );
+		}
 	} );
 
 } )();

--- a/tests/core/tools/color.js
+++ b/tests/core/tools/color.js
@@ -173,7 +173,20 @@
 		'test 8-HEX-like value is treated as 8-HEX value': colorTools.testColorConversion( 'FF0000FF', '#FF0000FF', 'getHexWithAlpha' ),
 
 		// (#4583)
-		'test 4-HEX-like value is treated as 8-HEX value': colorTools.testColorConversion( 'F00F', '#FF0000FF', 'getHexWithAlpha' )
+		'test 4-HEX-like value is treated as 8-HEX value': colorTools.testColorConversion( 'F00F', '#FF0000FF', 'getHexWithAlpha' ),
+
+		// (#4596)
+		'test converting RGB (64, 115, 38) produces HSL value with correct saturation value (100, 50%, 30%)': colorTools.testColorConversion( 'rgb( 64, 115, 38 )', 'hsl(100,50%,30%)', 'getHsl' ),
+
+		// (#4596)
+		'test converting RGBA (64, 115, 38, .4) produces HSLA value with correct saturation value (100, 50%, 30%, 0.4)': colorTools.testColorConversion( 'rgb( 64, 115, 38, .4 )',
+			'hsla(100,50%,30%,0.4)', 'getHsla' ),
+
+		// (#4096)
+		'test converting HSL (123, 50%, 50%) to HSL value returns the original value': colorTools.testColorConversion( 'hsl( 123, 50%, 50% )', 'hsl(123,50%,50%)', 'getHsl' ),
+
+		// (#4596)
+		'test converting HSLA (123, 50%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 50%, 50%, .5 )', 'hsla(123,50%,50%,0.5)', 'getHsla' )
 	} );
 
 } )();

--- a/tests/core/tools/color.js
+++ b/tests/core/tools/color.js
@@ -186,7 +186,16 @@
 		'test converting HSL (123, 50%, 50%) to HSL value returns the original value': colorTools.testColorConversion( 'hsl( 123, 50%, 50% )', 'hsl(123,50%,50%)', 'getHsl' ),
 
 		// (#4596)
-		'test converting HSLA (123, 50%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 50%, 50%, .5 )', 'hsla(123,50%,50%,0.5)', 'getHsla' )
+		'test converting HSLA (123, 50%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 50%, 50%, .5 )', 'hsla(123,50%,50%,0.5)', 'getHsla' ),
+
+		// (#4596)
+		'test converting HSL (123, 0%, 50%) to HSL value returns the original value': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsla(123,0%,50%)', 'getHsl' ),
+
+		// (#4596)
+		'test converting HSL (123, 0%, 50%) to HSLA value returns the original value with 1 opacity': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsla(123,0%,50%,1)', 'getHsla' ),
+
+		// (#4596)
+		'test converting HSLA (123, 0%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 0%, 50%, 0.5 )', 'hsla(123,0%,50%,0.5)', 'getHsla' )
 	} );
 
 } )();


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4597](https://github.com/ckeditor/ckeditor4/issues/4597): Fixed: incorrect color conversion for HSL/HSLA values.
```

## What changes did you make?

Due to the issue mentioned in https://github.com/ckeditor/ckeditor4/issues/4597#issuecomment-823094637 I've introduced additional data saved for HSL colors (hue, saturation and lightness) alongside the concept of color type.

Additionally I added rounding of lightness value and fixed the issue with saturation being always 0 or 1, due to incorrect rounding.

## Which issues does your PR resolve?

Closes #4597.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
