### PR TITLE
Enhance accessibility of autocomplete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ CKEditor 4 Changelog
 ## CKEditor 4.16.1
 
 Fixed Issues:
-
+* [#4617](https://github.com/ckeditor/ckeditor4/issues/4617): Fixed: [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) is not accessible in inline editors.
 * [#4493](https://github.com/ckeditor/ckeditor4/issues/4493): Fixed: [Rich Combo](https://ckeditor.com/cke4/addon/richcombo) label does not reflects the current value of the combobox.
 * [#1572](https://github.com/ckeditor/ckeditor4/issues/1572): Fixed: Paragraph before or after a [widget](https://ckeditor.com/cke4/addon/widget) can not be removed. Thanks to [bunglegrind](https://github.com/bunglegrind)!
 * [#4301](https://github.com/ckeditor/ckeditor4/issues/4301): Fixed: Pasted content is overwritten when pasted in initially empty editor with [`div` enter mode](https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html).

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -347,6 +347,10 @@
 				isActive = this.model.isActive;
 
 			editable.setAttribute( 'aria-expanded', isActive ? 'true' : 'false' );
+
+			if ( !isActive ) {
+				editable.setAttribute( 'aria-activedescendant', '' );
+			}
 		},
 
 		/**
@@ -558,8 +562,13 @@
 		 * @private
 		 */
 		onSelectedItemId: function( evt ) {
-			this.model.setItem( evt.data );
-			this.view.selectItem( evt.data );
+			var itemId = evt.data,
+				selectedItem = this.view.getItemById( itemId );
+
+			this.model.setItem( itemId );
+			this.view.selectItem( itemId );
+
+			this.editor.editable().setAttribute( 'aria-activedescendant', selectedItem.getAttribute( 'id' ) );
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -296,6 +296,7 @@
 			// Register keybindings if editor is already initialized.
 			if ( editable ) {
 				this.registerPanelNavigation();
+				this.addAriaAttributes();
 			}
 
 			// Note: CKEditor's event system has a limitation that one function
@@ -303,6 +304,7 @@
 			// (#4107)
 			editor.on( 'contentDom', function() {
 				this.registerPanelNavigation();
+				this.addAriaAttributes();
 			}, this );
 		},
 
@@ -315,6 +317,16 @@
 			this._listeners.push( editable.attachListener( editable, 'keydown', function( evt ) {
 				this.onKeyDown( evt );
 			}, this, null, 5 ) );
+		},
+
+		addAriaAttributes: function() {
+			var editable = this.editor.editable(),
+				autocompleteId = this.view.element.getAttribute( 'id' );
+
+			editable.setAttribute( 'aria-controls', autocompleteId );
+			editable.setAttribute( 'aria-activedescendant', '' );
+			editable.setAttribute( 'aria-autocomplete', 'list' );
+			editable.setAttribute( 'aria-expanded', 'false' );
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -812,6 +812,8 @@
 			el.addClass( 'cke_autocomplete_panel' );
 			// Below float panels and context menu, but above maximized editor (-5).
 			el.setStyle( 'z-index', this.editor.config.baseFloatZIndex - 3 );
+			// Add also appropriate role (#4617).
+			el.setAttribute( 'role', 'listbox' );
 
 			return el;
 		},
@@ -827,7 +829,9 @@
 				itemElement = CKEDITOR.dom.element.createFromHtml( this.itemTemplate.output( encodedItem ), this.document ),
 				id = CKEDITOR.tools.getNextId();
 
+			// Add attributes needed for a11y support (#4617).
 			itemElement.setAttribute( 'id', id );
+			itemElement.setAttribute( 'role', 'option' );
 
 			return itemElement;
 		},

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -726,8 +726,11 @@
 		 * @returns {CKEDITOR.dom.element}
 		 */
 		createElement: function() {
-			var el = new CKEDITOR.dom.element( 'ul', this.document );
+			var el = new CKEDITOR.dom.element( 'ul', this.document ),
+				id = CKEDITOR.tools.getNextId();
 
+			// Id is needed to correctly bind autocomplete with the editable (#4617).
+			el.setAttribute( 'id', id );
 			el.addClass( 'cke_autocomplete_panel' );
 			// Below float panels and context menu, but above maximized editor (-5).
 			el.setStyle( 'z-index', this.editor.config.baseFloatZIndex - 3 );
@@ -742,8 +745,13 @@
 		 * @returns {CKEDITOR.dom.element}
 		 */
 		createItem: function( item ) {
-			var encodedItem = encodeItem( item );
-			return CKEDITOR.dom.element.createFromHtml( this.itemTemplate.output( encodedItem ), this.document );
+			var encodedItem = encodeItem( item ),
+				itemElement = CKEDITOR.dom.element.createFromHtml( this.itemTemplate.output( encodedItem ), this.document ),
+				id = CKEDITOR.tools.getNextId();
+
+			itemElement.setAttribute( 'id', id );
+
+			return itemElement;
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -354,6 +354,21 @@
 		},
 
 		/**
+		 * @since 4.16.1
+		 */
+		removeAriaAttributes: function() {
+			var editable = this.editor.editable();
+
+			editable.removeAttributes( [
+				'aria-controls',
+				'aria-expanded',
+				'aria-activedescendant'
+			] );
+
+			editable.setAttribute( 'aria-autocomplete', 'none' );
+		},
+
+		/**
 		 * Closes the view and sets its {@link CKEDITOR.plugins.autocomplete.model#isActive state} to inactive.
 		 */
 		close: function() {
@@ -407,6 +422,7 @@
 			this._listeners = [];
 
 			this.view.element && this.view.element.remove();
+			this.removeAriaAttributes();
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -346,6 +346,10 @@
 			var editable = this.editor.editable(),
 				isActive = this.model.isActive;
 
+			if ( !editable.isInline() ) {
+				return;
+			}
+
 			editable.setAttribute( 'aria-expanded', isActive ? 'true' : 'false' );
 
 			if ( !isActive ) {
@@ -356,8 +360,25 @@
 		/**
 		 * @since 4.16.1
 		 */
+		updateAriaActiveDescendantAttribute: function( id ) {
+			var editable = this.editor.editable();
+
+			if ( !editable.isInline() ) {
+				return;
+			}
+
+			editable.setAttribute( 'aria-activedescendant', id );
+		},
+
+		/**
+		 * @since 4.16.1
+		 */
 		removeAriaAttributes: function() {
 			var editable = this.editor.editable();
+
+			if ( !editable.isInline() ) {
+				return;
+			}
 
 			editable.removeAttributes( [
 				'aria-controls',
@@ -584,7 +605,7 @@
 			this.model.setItem( itemId );
 			this.view.selectItem( itemId );
 
-			this.editor.editable().setAttribute( 'aria-activedescendant', selectedItem.getAttribute( 'id' ) );
+			this.updateAriaActiveDescendantAttribute( selectedItem.getAttribute( 'id' ) );
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -278,6 +278,9 @@
 			this._listeners.push( this.view.on( 'change-selectedItemId', this.onSelectedItemId, this ) );
 			this._listeners.push( this.view.on( 'click-item', this.onItemClick, this ) );
 
+			// (#4617)
+			this._listeners.push( this.model.on( 'change-isActive', this.updateAriaAttributes, this ) );
+
 			// Update view position on viewport change.
 			// Note: CKEditor's event system has a limitation that one function
 			// cannot be used as listener for the same event more than once. Hence, wrapper functions.
@@ -319,6 +322,9 @@
 			}, this, null, 5 ) );
 		},
 
+		/**
+		 * @since 4.16.1
+		 */
 		addAriaAttributes: function() {
 			var editable = this.editor.editable(),
 				autocompleteId = this.view.element.getAttribute( 'id' );
@@ -331,6 +337,16 @@
 			editable.setAttribute( 'aria-activedescendant', '' );
 			editable.setAttribute( 'aria-autocomplete', 'list' );
 			editable.setAttribute( 'aria-expanded', 'false' );
+		},
+
+		/**
+		 * @since 4.16.1
+		 */
+		updateAriaAttributes: function() {
+			var editable = this.editor.editable(),
+				isActive = this.model.isActive;
+
+			editable.setAttribute( 'aria-expanded', isActive ? 'true' : 'false' );
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -279,7 +279,7 @@
 			this._listeners.push( this.view.on( 'click-item', this.onItemClick, this ) );
 
 			// (#4617)
-			this._listeners.push( this.model.on( 'change-isActive', this.updateAriaAttributes, this ) );
+			this._listeners.push( this.model.on( 'change-isActive', this.updateAriaAttributesOnEditable, this ) );
 
 			// Update view position on viewport change.
 			// Note: CKEditor's event system has a limitation that one function
@@ -299,7 +299,7 @@
 			// Register keybindings if editor is already initialized.
 			if ( editable ) {
 				this.registerPanelNavigation();
-				this.addAriaAttributes();
+				this.addAriaAttributesToEditable();
 			}
 
 			// Note: CKEditor's event system has a limitation that one function
@@ -307,7 +307,7 @@
 			// (#4107)
 			editor.on( 'contentDom', function() {
 				this.registerPanelNavigation();
-				this.addAriaAttributes();
+				this.addAriaAttributesToEditable();
 			}, this );
 		},
 
@@ -325,7 +325,7 @@
 		/**
 		 * @since 4.16.1
 		 */
-		addAriaAttributes: function() {
+		addAriaAttributesToEditable: function() {
 			var editable = this.editor.editable(),
 				autocompleteId = this.view.element.getAttribute( 'id' );
 
@@ -342,7 +342,7 @@
 		/**
 		 * @since 4.16.1
 		 */
-		updateAriaAttributes: function() {
+		updateAriaAttributesOnEditable: function() {
 			var editable = this.editor.editable(),
 				isActive = this.model.isActive;
 
@@ -360,7 +360,7 @@
 		/**
 		 * @since 4.16.1
 		 */
-		updateAriaActiveDescendantAttribute: function( id ) {
+		updateAriaActiveDescendantAttributeOnEditable: function( id ) {
 			var editable = this.editor.editable();
 
 			if ( !editable.isInline() ) {
@@ -373,7 +373,7 @@
 		/**
 		 * @since 4.16.1
 		 */
-		removeAriaAttributes: function() {
+		removeAriaAttributesFromEditable: function() {
 			var editable = this.editor.editable();
 
 			if ( !editable || !editable.isInline() ) {
@@ -443,7 +443,7 @@
 			this._listeners = [];
 
 			this.view.element && this.view.element.remove();
-			this.removeAriaAttributes();
+			this.removeAriaAttributesFromEditable();
 		},
 
 		/**
@@ -605,7 +605,7 @@
 			this.model.setItem( itemId );
 			this.view.selectItem( itemId );
 
-			this.updateAriaActiveDescendantAttribute( selectedItem.getAttribute( 'id' ) );
+			this.updateAriaActiveDescendantAttributeOnEditable( selectedItem.getAttribute( 'id' ) );
 		},
 
 		/**

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -376,7 +376,7 @@
 		removeAriaAttributes: function() {
 			var editable = this.editor.editable();
 
-			if ( !editable.isInline() ) {
+			if ( !editable || !editable.isInline() ) {
 				return;
 			}
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -296,7 +296,8 @@
 				e.data.preventDefault();
 			}, null, null, 9999 ) );
 
-			// Register keybindings if editor is already initialized.
+			// Register keybindings and add ARIA attributes to the editable right away
+			// if editor is already initialized.
 			if ( editable ) {
 				this.registerPanelNavigation();
 				this.addAriaAttributesToEditable();

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -343,9 +343,9 @@
 		/**
 		 * @since 4.16.1
 		 */
-		updateAriaAttributesOnEditable: function() {
+		updateAriaAttributesOnEditable: function( evt ) {
 			var editable = this.editor.editable(),
-				isActive = this.model.isActive;
+				isActive = evt.data;
 
 			if ( !editable.isInline() ) {
 				return;

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -323,6 +323,10 @@
 			var editable = this.editor.editable(),
 				autocompleteId = this.view.element.getAttribute( 'id' );
 
+			if ( !editable.isInline() ) {
+				return;
+			}
+
 			editable.setAttribute( 'aria-controls', autocompleteId );
 			editable.setAttribute( 'aria-activedescendant', '' );
 			editable.setAttribute( 'aria-autocomplete', 'list' );

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -18,6 +18,10 @@
 		autoComplete;
 
 	bender.test( {
+		setUp: function() {
+			bender.tools.ignoreUnsupportedEnvironment( 'autocomplete' );
+		},
+
 		tearDown: function() {
 			autoComplete && autoComplete.destroy();
 		},

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -6,17 +6,18 @@
 
 	bender.editor = {};
 
-	var configDefinition = {
-		textTestCallback: textTestCallback,
-		dataCallback: dataCallback
-	};
+	var autoCompleteConfig = {
+			textTestCallback: textTestCallback,
+			dataCallback: dataCallback
+		},
+		ESC = 27;
 
 	bender.test( {
 		// (#4617)
 		'test autocomplete adds correct ARIA attributes to the editor\'s editable (divarea)': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 				viewElement = autoComplete.view.element,
 				viewElementId = viewElement.getAttribute( 'id' );
 
@@ -38,7 +39,7 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				assert.isFalse( editable.hasAttribute( 'aria-controls' ), 'The [aria-controls] attribute is present' );
 				assert.isFalse( editable.hasAttribute( 'aria-autocomplete' ), 'The [aria-autocomplete] attribute is present' );
@@ -48,6 +49,30 @@
 				autoComplete.destroy();
 			} );
 		},
+
+		// (#4617)
+		'test opening and closing autocomplete changes the value of [aria-expanded] attribute': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ),
+				'Wrong initial value for [aria-expanded] attribute' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			assert.areSame( 'true', editable.getAttribute( 'aria-expanded' ),
+				'Wrong value for [aria-expanded] attribute after opening autocomplete' );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ESC } ) );
+
+			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ),
+				'Wrong value for [aria-expanded] attribute after closing autocomplete' );
+
+			autoComplete.destroy();
+		}
 	} );
 
 	function textTestCallback( selectionRange ) {
@@ -57,5 +82,4 @@
 	function dataCallback( matchInfo, callback ) {
 		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
 	}
-
 } )();

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -66,24 +66,57 @@
 		'test opening and closing autocomplete changes the value of [aria-expanded] attribute': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+				attributeName = 'aria-expanded';
 
 			this.editorBot.setHtmlWithSelection( '' );
 
-			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ),
+			assert.areSame( 'false', editable.getAttribute( attributeName ),
 				'Wrong initial value for [aria-expanded] attribute' );
 
 			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			assert.areSame( 'true', editable.getAttribute( 'aria-expanded' ),
+			assert.areSame( 'true', editable.getAttribute( attributeName ),
 				'Wrong value for [aria-expanded] attribute after opening autocomplete' );
 
 			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ESC } ) );
 
-			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ),
+			assert.areSame( 'false', editable.getAttribute( attributeName ),
 				'Wrong value for [aria-expanded] attribute after closing autocomplete' );
 
 			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test opening and closing autocomplete does not add or change the value of [aria-expanded] attribute for iframe-based editor': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea-toggling-aria-expanded',
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+					attributeName = 'aria-expanded';
+
+				bot.setHtmlWithSelection( '' );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ESC } ) );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				autoComplete.destroy();
+			} );
 		},
 
 		// (#4617)
@@ -117,6 +150,38 @@
 		},
 
 		// (#4617)
+		'test opening and closing autocomplete does not add or change the value of [aria-activedescendant] attribute for iframe-based editor': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea-toggling-' + ARIA_ACTIVEDESCENDANT,
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+					attributeName = ARIA_ACTIVEDESCENDANT;
+
+				bot.setHtmlWithSelection( '' );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ESC } ) );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				autoComplete.destroy();
+			} );
+		},
+
+		// (#4617)
 		'test pressing Arrow Up key triggers [aria-activedescendant] attribute update to the selected item': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
@@ -140,6 +205,34 @@
 				'Wrong value for [' + attributeName + '] attribute after opening autocomplete' );
 
 			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test pressing Arrow Up key does not add or change the value of [aria-activedescendant] attribute in the iframe-based editor': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea-arrow-up-' + ARIA_ACTIVEDESCENDANT,
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+					attributeName = ARIA_ACTIVEDESCENDANT;
+
+				bot.setHtmlWithSelection( '' );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+				editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ARROW_UP } ) );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				autoComplete.destroy();
+			} );
 		},
 
 		// (#4617)
@@ -169,6 +262,34 @@
 		},
 
 		// (#4617)
+		'test pressing Arrow Down key does not add or change the value of [aria-activedescendant] attribute in the iframe-based editor': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea-arrow-down-' + ARIA_ACTIVEDESCENDANT,
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+					attributeName = ARIA_ACTIVEDESCENDANT;
+
+				bot.setHtmlWithSelection( '' );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+				editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ARROW_DOWN } ) );
+
+				assert.isFalse( editable.hasAttribute( attributeName ),
+					'The [' + attributeName + '] attribute is present' );
+
+				autoComplete.destroy();
+			} );
+		},
+
+		// (#4617)
 		'test mouseover triggers [aria-activedescendant] attribute update to the selected item': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
@@ -192,6 +313,34 @@
 		},
 
 		// (#4617)
+		'test mouseover does not add or update the value of [aria-activedescendant] attribute in the iframe-based editor': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea-mouseover',
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+					target;
+
+				bot.setHtmlWithSelection( '' );
+
+				editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+				target = autoComplete.view.element.getLast();
+
+				autoComplete.view.element.fire( 'mouseover', new CKEDITOR.dom.event( { target: target.$ } ) );
+
+				assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
+					'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
+
+				autoComplete.destroy();
+			} );
+		},
+
+		// (#4617)
 		'test destroying autocomplete removes unnecessary ARIA attributes': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
@@ -205,6 +354,29 @@
 			assert.isFalse( editable.hasAttribute( 'aria-controls' ), 'The [aria-controls] attribute is present' );
 			assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
 				'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
+		},
+
+		// (#4617)
+		'test destroying autocomplete does not add additional [aria-autocomplete] attribute for iframe-based editor': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea-destroy',
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
+
+				autoComplete.destroy();
+
+				assert.isFalse( editable.hasAttribute( 'aria-autocomplete' ),
+					'The [aria-autocomplete] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-expanded' ), 'The [aria-expanded] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-controls' ), 'The [aria-controls] attribute is present' );
+				assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
+					'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
+			} );
 		}
 	} );
 

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -1,0 +1,40 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: autocomplete,divarea,sourcearea */
+
+( function() {
+	'use strict';
+
+	bender.editor = {};
+
+	var configDefinition = {
+		textTestCallback: textTestCallback,
+		dataCallback: dataCallback
+	};
+
+	bender.test( {
+		// (#4617)
+		'test autocomplete adds correct ARIA attributes to the editor\'s editable': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				viewElement = autoComplete.view.element,
+				viewElementId = viewElement.getAttribute( 'id' );
+
+			assert.areSame( viewElementId, editable.getAttribute( 'aria-controls' ), 'Wrong value for [aria-controls] attribute' );
+			assert.areSame( 'list', editable.getAttribute( 'aria-autocomplete' ), 'Wrong value for [aria-autocomplete] attribute' );
+			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ), 'Wrong value for [aria-expanded] attribute' );
+			assert.areSame( '', editable.getAttribute( 'aria-activedescendant' ), 'Wrong value for [aria-activedescendant] attribute' );
+
+			autoComplete.destroy();
+		}
+	} );
+
+	function textTestCallback( selectionRange ) {
+		return { text: 'text', range: selectionRange };
+	}
+
+	function dataCallback( matchInfo, callback ) {
+		return callback( [ { id: 1, name: 'item1' }, { id: 2, name: 'item2' }, { id: 3, name: 'item3' } ] );
+	}
+
+} )();

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -10,7 +10,11 @@
 			textTestCallback: textTestCallback,
 			dataCallback: dataCallback
 		},
-		ESC = 27;
+		ESC = 27,
+		ARROW_UP = 38,
+		ARROW_DOWN = 40,
+		// I always mess up this name…
+		ARIA_ACTIVEDESCENDANT = 'aria-activedescendant';
 
 	bender.test( {
 		// (#4617)
@@ -21,10 +25,14 @@
 				viewElement = autoComplete.view.element,
 				viewElementId = viewElement.getAttribute( 'id' );
 
-			assert.areSame( viewElementId, editable.getAttribute( 'aria-controls' ), 'Wrong value for [aria-controls] attribute' );
-			assert.areSame( 'list', editable.getAttribute( 'aria-autocomplete' ), 'Wrong value for [aria-autocomplete] attribute' );
-			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ), 'Wrong value for [aria-expanded] attribute' );
-			assert.areSame( '', editable.getAttribute( 'aria-activedescendant' ), 'Wrong value for [aria-activedescendant] attribute' );
+			assert.areSame( viewElementId, editable.getAttribute( 'aria-controls' ),
+				'Wrong value for [aria-controls] attribute' );
+			assert.areSame( 'list', editable.getAttribute( 'aria-autocomplete' ),
+				'Wrong value for [aria-autocomplete] attribute' );
+			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ),
+				'Wrong value for [aria-expanded] attribute' );
+			assert.areSame( '', editable.getAttribute( ARIA_ACTIVEDESCENDANT ),
+				'Wrong value for [' + ARIA_ACTIVEDESCENDANT + '] attribute' );
 
 			autoComplete.destroy();
 		},
@@ -41,10 +49,14 @@
 					editable = editor.editable(),
 					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
-				assert.isFalse( editable.hasAttribute( 'aria-controls' ), 'The [aria-controls] attribute is present' );
-				assert.isFalse( editable.hasAttribute( 'aria-autocomplete' ), 'The [aria-autocomplete] attribute is present' );
-				assert.isFalse( editable.hasAttribute( 'aria-expanded' ), 'The [aria-expanded] attribute is present' );
-				assert.isFalse( editable.hasAttribute( 'aria-activedescendant' ), 'The [aria-activedescendant] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-controls' ),
+					'The [aria-controls] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-autocomplete' ),
+					'The [aria-autocomplete] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-expanded' ),
+					'The [aria-expanded] attribute is present' );
+				assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
+					'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
 
 				autoComplete.destroy();
 			} );
@@ -79,7 +91,7 @@
 			var editor = this.editor,
 				editable = editor.editable(),
 				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
-				attributeName = 'aria-activedescendant',
+				attributeName = ARIA_ACTIVEDESCENDANT,
 				selectedItem,
 				selectedItemId;
 
@@ -100,6 +112,81 @@
 
 			assert.areSame( '', editable.getAttribute( attributeName ),
 				'Wrong value for [' + attributeName + '] attribute after closing autocomplete' );
+
+			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test pressing Arrow Up key triggers [aria-activedescendant] attribute update to the selected item': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+				attributeName = ARIA_ACTIVEDESCENDANT,
+				selectedItem,
+				selectedItemId;
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			assert.areSame( '', editable.getAttribute( attributeName ),
+				'Wrong initial value for [' + attributeName + '] attribute' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ARROW_UP } ) );
+
+			selectedItem = autoComplete.view.getItemById( autoComplete.view.selectedItemId );
+			selectedItemId = selectedItem.getAttribute( 'id' );
+
+			assert.areSame( selectedItemId, editable.getAttribute( attributeName ),
+				'Wrong value for [' + attributeName + '] attribute after opening autocomplete' );
+
+			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test pressing Arrow Down key triggers [aria-activedescendant] attribute update to the selected item': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+				attributeName = ARIA_ACTIVEDESCENDANT,
+				selectedItem,
+				selectedItemId;
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			assert.areSame( '', editable.getAttribute( attributeName ),
+				'Wrong initial value for [' + attributeName + '] attribute' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ARROW_DOWN } ) );
+
+			selectedItem = autoComplete.view.getItemById( autoComplete.view.selectedItemId );
+			selectedItemId = selectedItem.getAttribute( 'id' );
+
+			assert.areSame( selectedItemId, editable.getAttribute( attributeName ),
+				'Wrong value for [' + attributeName + '] attribute after opening autocomplete' );
+
+			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test mouseover triggers [aria-activedescendant] attribute update to the selected item': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+				target,
+				targetId;
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			target = autoComplete.view.element.getLast();
+			targetId = target.getAttribute( 'id' );
+
+			autoComplete.view.element.fire( 'mouseover', new CKEDITOR.dom.event( { target: target.$ } ) );
+
+			assert.areSame( targetId, editable.getAttribute( ARIA_ACTIVEDESCENDANT ),
+				'Wrong value for [' + ARIA_ACTIVEDESCENDANT + '] attribute' );
 
 			autoComplete.destroy();
 		}

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -189,6 +189,22 @@
 				'Wrong value for [' + ARIA_ACTIVEDESCENDANT + '] attribute' );
 
 			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test destroying autocomplete removes unnecessary ARIA attributes': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
+
+			autoComplete.destroy();
+
+			assert.areSame( 'none', editable.getAttribute( 'aria-autocomplete' ),
+				'The [aria-autocomplete] attribute is not set to none' );
+			assert.isFalse( editable.hasAttribute( 'aria-expanded' ), 'The [aria-expanded] attribute is present' );
+			assert.isFalse( editable.hasAttribute( 'aria-controls' ), 'The [aria-controls] attribute is present' );
+			assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
+				'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
 		}
 	} );
 

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -72,6 +72,36 @@
 				'Wrong value for [aria-expanded] attribute after closing autocomplete' );
 
 			autoComplete.destroy();
+		},
+
+		// (#4617)
+		'test opening and closing autocomplete changes the value of [aria-activedescendant] attribute': function() {
+			var editor = this.editor,
+				editable = editor.editable(),
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+				attributeName = 'aria-activedescendant',
+				selectedItem,
+				selectedItemId;
+
+			this.editorBot.setHtmlWithSelection( '' );
+
+			assert.areSame( '', editable.getAttribute( attributeName ),
+				'Wrong initial value for [' + attributeName + '] attribute' );
+
+			editable.fire( 'keyup', new CKEDITOR.dom.event( {} ) );
+
+			selectedItem = autoComplete.view.getItemById( autoComplete.view.selectedItemId );
+			selectedItemId = selectedItem.getAttribute( 'id' );
+
+			assert.areSame( selectedItemId, editable.getAttribute( attributeName ),
+				'Wrong value for [' + attributeName + '] attribute after opening autocomplete' );
+
+			editable.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ESC } ) );
+
+			assert.areSame( '', editable.getAttribute( attributeName ),
+				'Wrong value for [' + attributeName + '] attribute after closing autocomplete' );
+
+			autoComplete.destroy();
 		}
 	} );
 

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -14,16 +14,24 @@
 		ARROW_UP = 38,
 		ARROW_DOWN = 40,
 		// I always mess up this name…
-		ARIA_ACTIVEDESCENDANT = 'aria-activedescendant';
+		ARIA_ACTIVEDESCENDANT = 'aria-activedescendant',
+		autoComplete;
 
 	bender.test( {
+		teardown: function() {
+			autoComplete && autoComplete.destroy();
+		},
+
 		// (#4617)
 		'test autocomplete adds correct ARIA attributes to the editor\'s editable (divarea)': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
-				viewElement = autoComplete.view.element,
-				viewElementId = viewElement.getAttribute( 'id' );
+				viewElement,
+				viewElementId;
+
+			autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
+			viewElement = autoComplete.view.element,
+			viewElementId = viewElement.getAttribute( 'id' );
 
 			assert.areSame( viewElementId, editable.getAttribute( 'aria-controls' ),
 				'Wrong value for [aria-controls] attribute' );
@@ -33,8 +41,6 @@
 				'Wrong value for [aria-expanded] attribute' );
 			assert.areSame( '', editable.getAttribute( ARIA_ACTIVEDESCENDANT ),
 				'Wrong value for [' + ARIA_ACTIVEDESCENDANT + '] attribute' );
-
-			autoComplete.destroy();
 		},
 
 		// (#4617)
@@ -46,8 +52,9 @@
 				}
 			}, function( bot ) {
 				var editor = bot.editor,
-					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
+					editable = editor.editable();
+
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				assert.isFalse( editable.hasAttribute( 'aria-controls' ),
 					'The [aria-controls] attribute is present' );
@@ -57,8 +64,6 @@
 					'The [aria-expanded] attribute is present' );
 				assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
 					'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
-
-				autoComplete.destroy();
 			} );
 		},
 
@@ -66,8 +71,9 @@
 		'test opening and closing autocomplete changes the value of [aria-expanded] attribute': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 				attributeName = 'aria-expanded';
+
+			autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 			this.editorBot.setHtmlWithSelection( '' );
 
@@ -83,8 +89,6 @@
 
 			assert.areSame( 'false', editable.getAttribute( attributeName ),
 				'Wrong value for [aria-expanded] attribute after closing autocomplete' );
-
-			autoComplete.destroy();
 		},
 
 		// (#4617)
@@ -97,8 +101,9 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 					attributeName = 'aria-expanded';
+
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				bot.setHtmlWithSelection( '' );
 
@@ -114,8 +119,6 @@
 
 				assert.isFalse( editable.hasAttribute( attributeName ),
 					'The [' + attributeName + '] attribute is present' );
-
-				autoComplete.destroy();
 			} );
 		},
 
@@ -123,10 +126,11 @@
 		'test opening and closing autocomplete changes the value of [aria-activedescendant] attribute': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 				attributeName = ARIA_ACTIVEDESCENDANT,
 				selectedItem,
 				selectedItemId;
+
+			autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 			this.editorBot.setHtmlWithSelection( '' );
 
@@ -145,8 +149,6 @@
 
 			assert.areSame( '', editable.getAttribute( attributeName ),
 				'Wrong value for [' + attributeName + '] attribute after closing autocomplete' );
-
-			autoComplete.destroy();
 		},
 
 		// (#4617)
@@ -159,8 +161,9 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 					attributeName = ARIA_ACTIVEDESCENDANT;
+
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				bot.setHtmlWithSelection( '' );
 
@@ -176,8 +179,6 @@
 
 				assert.isFalse( editable.hasAttribute( attributeName ),
 					'The [' + attributeName + '] attribute is present' );
-
-				autoComplete.destroy();
 			} );
 		},
 
@@ -185,10 +186,11 @@
 		'test pressing Arrow Up key triggers [aria-activedescendant] attribute update to the selected item': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 				attributeName = ARIA_ACTIVEDESCENDANT,
 				selectedItem,
 				selectedItemId;
+
+			autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 			this.editorBot.setHtmlWithSelection( '' );
 
@@ -203,8 +205,6 @@
 
 			assert.areSame( selectedItemId, editable.getAttribute( attributeName ),
 				'Wrong value for [' + attributeName + '] attribute after opening autocomplete' );
-
-			autoComplete.destroy();
 		},
 
 		// (#4617)
@@ -217,8 +217,9 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 					attributeName = ARIA_ACTIVEDESCENDANT;
+
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				bot.setHtmlWithSelection( '' );
 
@@ -230,8 +231,6 @@
 
 				assert.isFalse( editable.hasAttribute( attributeName ),
 					'The [' + attributeName + '] attribute is present' );
-
-				autoComplete.destroy();
 			} );
 		},
 
@@ -239,10 +238,11 @@
 		'test pressing Arrow Down key triggers [aria-activedescendant] attribute update to the selected item': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 				attributeName = ARIA_ACTIVEDESCENDANT,
 				selectedItem,
 				selectedItemId;
+
+			autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 			this.editorBot.setHtmlWithSelection( '' );
 
@@ -257,8 +257,6 @@
 
 			assert.areSame( selectedItemId, editable.getAttribute( attributeName ),
 				'Wrong value for [' + attributeName + '] attribute after opening autocomplete' );
-
-			autoComplete.destroy();
 		},
 
 		// (#4617)
@@ -271,8 +269,9 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 					attributeName = ARIA_ACTIVEDESCENDANT;
+
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				bot.setHtmlWithSelection( '' );
 
@@ -284,8 +283,6 @@
 
 				assert.isFalse( editable.hasAttribute( attributeName ),
 					'The [' + attributeName + '] attribute is present' );
-
-				autoComplete.destroy();
 			} );
 		},
 
@@ -293,9 +290,10 @@
 		'test mouseover triggers [aria-activedescendant] attribute update to the selected item': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
-				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 				target,
 				targetId;
+
+			autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 			this.editorBot.setHtmlWithSelection( '' );
 
@@ -308,8 +306,6 @@
 
 			assert.areSame( targetId, editable.getAttribute( ARIA_ACTIVEDESCENDANT ),
 				'Wrong value for [' + ARIA_ACTIVEDESCENDANT + '] attribute' );
-
-			autoComplete.destroy();
 		},
 
 		// (#4617)
@@ -322,8 +318,9 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					editable = editor.editable(),
-					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig ),
 					target;
+
+				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				bot.setHtmlWithSelection( '' );
 
@@ -335,8 +332,6 @@
 
 				assert.isFalse( editable.hasAttribute( ARIA_ACTIVEDESCENDANT ),
 					'The [' + ARIA_ACTIVEDESCENDANT + '] attribute is present' );
-
-				autoComplete.destroy();
 			} );
 		},
 
@@ -347,6 +342,7 @@
 				autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 			autoComplete.destroy();
+			autoComplete = null;
 
 			assert.areSame( 'none', editable.getAttribute( 'aria-autocomplete' ),
 				'The [aria-autocomplete] attribute is not set to none' );
@@ -369,6 +365,7 @@
 					autoComplete = new CKEDITOR.plugins.autocomplete( editor, autoCompleteConfig );
 
 				autoComplete.destroy();
+				autoComplete = null;
 
 				assert.isFalse( editable.hasAttribute( 'aria-autocomplete' ),
 					'The [aria-autocomplete] attribute is present' );

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -13,7 +13,7 @@
 		ESC = 27,
 		ARROW_UP = 38,
 		ARROW_DOWN = 40,
-		// I always mess up this name…
+		// Avoid attribute misspell in many places. Support IDE auto-complete.
 		ARIA_ACTIVEDESCENDANT = 'aria-activedescendant',
 		autoComplete;
 

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: autocomplete,divarea,sourcearea */
+/* bender-ckeditor-plugins: autocomplete,divarea */
 
 ( function() {
 	'use strict';
@@ -13,7 +13,7 @@
 
 	bender.test( {
 		// (#4617)
-		'test autocomplete adds correct ARIA attributes to the editor\'s editable': function() {
+		'test autocomplete adds correct ARIA attributes to the editor\'s editable (divarea)': function() {
 			var editor = this.editor,
 				editable = editor.editable(),
 				autoComplete = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
@@ -26,7 +26,28 @@
 			assert.areSame( '', editable.getAttribute( 'aria-activedescendant' ), 'Wrong value for [aria-activedescendant] attribute' );
 
 			autoComplete.destroy();
-		}
+		},
+
+		// (#4617)
+		'test autocomplete does not add correct ARIA attributes to the editor\'s editable (wysiwygarea)': function() {
+			bender.editorBot.create( {
+				name: 'wysiwygarea',
+				config: {
+					plugins: 'autocomplete,wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					autoComplete = new CKEDITOR.plugins.autocomplete( editor, configDefinition );
+
+				assert.isFalse( editable.hasAttribute( 'aria-controls' ), 'The [aria-controls] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-autocomplete' ), 'The [aria-autocomplete] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-expanded' ), 'The [aria-expanded] attribute is present' );
+				assert.isFalse( editable.hasAttribute( 'aria-activedescendant' ), 'The [aria-activedescendant] attribute is present' );
+
+				autoComplete.destroy();
+			} );
+		},
 	} );
 
 	function textTestCallback( selectionRange ) {

--- a/tests/plugins/autocomplete/a11y.js
+++ b/tests/plugins/autocomplete/a11y.js
@@ -18,7 +18,7 @@
 		autoComplete;
 
 	bender.test( {
-		teardown: function() {
+		tearDown: function() {
 			autoComplete && autoComplete.destroy();
 		},
 

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -64,6 +64,22 @@
 			ac.destroy();
 		},
 
+		// (#4617)
+		'test autocomplete adds correct ARIA attributes to the editor\'s editable': function() {
+			var editor = this.editors.standard,
+				editable = editor.editable(),
+				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
+				viewElement = ac.view.element,
+				viewElementId = viewElement.getAttribute( 'id' );
+
+			assert.areSame( viewElementId, editable.getAttribute( 'aria-controls' ), 'Wrong value for [aria-controls] attribute' );
+			assert.areSame( 'list', editable.getAttribute( 'aria-autocomplete' ), 'Wrong value for [aria-autocomplete] attribute' );
+			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ), 'Wrong value for [aria-expanded] attribute' );
+			assert.areSame( '', editable.getAttribute( 'aria-activedescendant' ), 'Wrong value for [aria-activedescendant] attribute' );
+
+			ac.destroy();
+		},
+
 		'test autocomplete starts with the first item selected': function() {
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -468,14 +468,17 @@
 						callback( [ { id: 1, name: 'anna' } ] );
 					},
 					itemTemplate: '<li data-id="{id}"><strong>{name}</strong></li>'
-				} );
+				} ),
+				expectedHtmlRegex = /<ul><li class="cke_autocomplete_selected" data-id="1" id="cke_[\d]+"><strong>anna<\/strong><\/li><\/ul>/,
+				actualHtml;
 
 			this.editorBots.standard.setHtmlWithSelection( '' );
 
 			editor.editable().fire( 'keyup', new CKEDITOR.dom.event( {} ) );
 
-			assert.beautified.html( '<ul><li class="cke_autocomplete_selected" data-id="1"><strong>anna</strong></li></ul>',
-				ac.view.element.getHtml() );
+			actualHtml = bender.tools.compatHtml( ac.view.element.getHtml(), false, true );
+
+			assert.isTrue( expectedHtmlRegex.test( actualHtml ), 'Incorrect autocomplete item HTML' );
 
 			ac.destroy();
 		},

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -453,7 +453,7 @@
 					},
 					itemTemplate: '<li data-id="{id}"><strong>{name}</strong></li>'
 				} ),
-				expectedHtmlRegex = /<ul><li class="cke_autocomplete_selected" data-id="1" id="cke_[\d]+"><strong>anna<\/strong><\/li><\/ul>/,
+				expectedHtmlRegex = /<ul><li class="cke_autocomplete_selected" data-id="1" id="cke_[\d]+" role="option"><strong>anna<\/strong><\/li><\/ul>/,
 				actualHtml;
 
 			this.editorBots.standard.setHtmlWithSelection( '' );

--- a/tests/plugins/autocomplete/autocomplete.js
+++ b/tests/plugins/autocomplete/autocomplete.js
@@ -64,22 +64,6 @@
 			ac.destroy();
 		},
 
-		// (#4617)
-		'test autocomplete adds correct ARIA attributes to the editor\'s editable': function() {
-			var editor = this.editors.standard,
-				editable = editor.editable(),
-				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition ),
-				viewElement = ac.view.element,
-				viewElementId = viewElement.getAttribute( 'id' );
-
-			assert.areSame( viewElementId, editable.getAttribute( 'aria-controls' ), 'Wrong value for [aria-controls] attribute' );
-			assert.areSame( 'list', editable.getAttribute( 'aria-autocomplete' ), 'Wrong value for [aria-autocomplete] attribute' );
-			assert.areSame( 'false', editable.getAttribute( 'aria-expanded' ), 'Wrong value for [aria-expanded] attribute' );
-			assert.areSame( '', editable.getAttribute( 'aria-activedescendant' ), 'Wrong value for [aria-activedescendant] attribute' );
-
-			ac.destroy();
-		},
-
 		'test autocomplete starts with the first item selected': function() {
 			var editor = this.editors.standard,
 				ac = new CKEDITOR.plugins.autocomplete( editor, configDefinition );

--- a/tests/plugins/autocomplete/manual/a11ydivarea.html
+++ b/tests/plugins/autocomplete/manual/a11ydivarea.html
@@ -1,0 +1,22 @@
+<div id="editor1" >
+	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+	<p>Vitae perferendis architecto sapiente veniam eius eos enim mollitia</p>
+	<p>Sint accusamus sed voluptatum, consectetur illum nam, ab quod id amet.</p>
+</div>
+
+<script>
+	bender.tools.ignoreUnsupportedEnvironment( 'autocomplete' );
+
+	CKEDITOR.replace( 'editor1', {
+		width: 600,
+		extraPlugins: 'textmatch',
+		on: {
+			instanceReady: function( evt ) {
+				new CKEDITOR.plugins.autocomplete( evt.editor, {
+					textTestCallback: autocompleteUtils.getTextTestCallback(),
+					dataCallback: autocompleteUtils.getDataCallback()
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/autocomplete/manual/a11ydivarea.md
+++ b/tests/plugins/autocomplete/manual/a11ydivarea.md
@@ -3,48 +3,29 @@
 @bender-ckeditor-plugins: divarea, toolbar, basicstyles, autocomplete
 @bender-include: _helpers/utils.js
 
-## Procedure
-
-**Note**: it's a longish one, requires the constant editor focus, so better read it whole before doing anything!
+**Note**: It's a longish one, requires the constant editor focus, so better read it whole before doing anything!
 
 1. Open screen reader.
 2. Focus the editor.
 
-	### Expected result
+	**Expected:** Screen reader announces the editor and its autocomplete (e.g. "has popup" or "has autocomplete). Note: JAWS can announce the autocomplete only if the editor is empty.
 
-	* Screen reader announces the editor and its autocomplete (e.g. "has popup" or "has autocomplete). Note: JAWS can announce the autocomplete only if the editor is empty.
-
-	## Unexpected
-
-	* Screen reader does not announce the editor or its autocomplete.
+	**Unexpected:** Screen reader does not announce the editor or its autocomplete.
 
 3. Press `@` and wait until autocomplete opens.
 
-	### Expected result
+	**Expected:** Screen reader announces the autocomplete ("expanded" with optional "listbox"/"list") and reads the selected item.
 
-	* Screen reader announces the autocomplete ("expanded" with optional "listbox"/"list") and reads the selected item.
-
-	### Unexpected result
-
-	* Screen reader does not announce the autocomplete or doesn't read the selected item.
+	**Unexpected:** Screen reader does not announce the autocomplete or doesn't read the selected item.
 
 4. Press arrow up/arrow down.
 
-	### Expected result
+	**Expected:** Screen reader announces the newly selected item (e.g. "at thomas, 2 of 5").
 
-	* Screen reader announces the newly selected item (e.g. "at thomas, 2 of 5").
+	**Unexpected:** Screen reader does not announce the newly selected item.
 
-	### Unexpected result
+5. Press Esc (you probably will need to press it twice) to close the autocomplete.
 
-	* Screen reader does not announce the newly selected item.
+	**Expected:** Screen reader optionally inform about collapsed autocomplete. Screen reader reannounces the editor.
 
-5. Press Esc (you probably will need to press it twice) to close the autocomplete
-
-	### Expected result
-
-	* Screen reader optionally inform about collapsed autocomplete.
-	* Screen reader reannounces the editor.
-
-	### Unexpected result
-
-	* Screen reader does not say anything.
+	**Unexpected:** Screen reader does not say anything.

--- a/tests/plugins/autocomplete/manual/a11ydivarea.md
+++ b/tests/plugins/autocomplete/manual/a11ydivarea.md
@@ -1,0 +1,50 @@
+@bender-tags: 4.16.1, bug, 4617
+@bender-ui: collapsed
+@bender-ckeditor-plugins: divarea, toolbar, basicstyles, autocomplete
+@bender-include: _helpers/utils.js
+
+## Procedure
+
+**Note**: it's a longish one, requires the constant editor focus, so better read it whole before doing anything!
+
+1. Open screen reader.
+2. Focus the editor.
+
+	### Expected result
+
+	* Screen reader announces the editor and its autocomplete (e.g. "has popup" or "has autocomplete). Note: JAWS can announce the autocomplete only if the editor is empty.
+
+	## Unexpected
+
+	* Screen reader does not announce the editor or its autocomplete.
+
+3. Press `@` and wait until autocomplete opens.
+
+	### Expected result
+
+	* Screen reader announces the autocomplete ("expanded" with optional "listbox"/"list") and reads the selected item.
+
+	### Unexpected result
+
+	* Screen reader does not announce the autocomplete or doesn't read the selected item.
+
+4. Press arrow up/arrow down.
+
+	### Expected result
+
+	* Screen reader announces the newly selected item (e.g. "at thomas, 2 of 5").
+
+	### Unexpected result
+
+	* Screen reader does not announce the newly selected item.
+
+5. Press Esc (you probably will need to press it twice) to close the autocomplete
+
+	### Expected result
+
+	* Screen reader optionally inform about collapsed autocomplete.
+	* Screen reader reannounces the editor.
+
+	### Unexpected result
+
+	* Screen reader does not say anything.

--- a/tests/plugins/autocomplete/model.js
+++ b/tests/plugins/autocomplete/model.js
@@ -137,6 +137,22 @@
 			assert.isTrue( spy.calledWith( 'change-isActive', true ) );
 		},
 
+		// (#4653)
+		'test change-isActive event is propagated correctly for setting autocomplete to inactive state': function() {
+			var model = new CKEDITOR.plugins.autocomplete.model( dataCallback ),
+				spy = sinon.spy();
+
+			model.on( 'change-isActive', spy );
+			// CKEditor 4 does not allow to bind the same listener more than once.
+			model.on( 'change-isActive', function() {
+				spy();
+			} );
+
+			model.setActive( false );
+
+			assert.areSame( 2, spy.callCount );
+		},
+
 		'test set query sync': function() {
 			var expectedQuery = 'query',
 					expectedRange = 'range',

--- a/tests/plugins/autocomplete/model.js
+++ b/tests/plugins/autocomplete/model.js
@@ -138,7 +138,7 @@
 		},
 
 		// (#4653)
-		'test change-isActive event is propagated correctly for setting autocomplete to inactive state': function() {
+		'test change-isActive event is propagated when model is deactivated with event.data set as false': function() {
 			var model = new CKEDITOR.plugins.autocomplete.model( dataCallback ),
 				spy = sinon.spy();
 
@@ -150,7 +150,7 @@
 
 			model.setActive( false );
 
-			assert.areSame( 2, spy.callCount );
+			assert.areSame( 2, spy.callCount, 'Event change-isActive wasn't propagated with two callbacks.' );
 		},
 
 		'test set query sync': function() {

--- a/tests/plugins/autocomplete/model.js
+++ b/tests/plugins/autocomplete/model.js
@@ -150,7 +150,7 @@
 
 			model.setActive( false );
 
-			assert.areSame( 2, spy.callCount, 'Event change-isActive wasn't propagated with two callbacks.' );
+			assert.areSame( 2, spy.callCount, 'Event change-isActive was not propagated with two callbacks.' );
 		},
 
 		'test set query sync': function() {

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -195,13 +195,17 @@
 
 	function assertViewElement( editor, element ) {
 		var zIndex = editor.config.baseFloatZIndex - 3,
-			expectedHtml = '<ul class="cke_autocomplete_panel" style="z-index: ' + zIndex + ';"></ul>';
+			expectedHtmlRegex = new RegExp( '<ul class="cke_autocomplete_panel" id="cke_[\\d]+" style="z-index: ' + zIndex + ';"></ul>' ),
+			actualHtml = bender.tools.compatHtml( element.$.outerHTML, false, true );
 
-		assert.areEqual( expectedHtml, bender.tools.compatHtml( element.$.outerHTML, false, true ) );
+		assert.isTrue( expectedHtmlRegex.test( actualHtml ), 'The generated autocomplete HTML is incorrect' );
 	}
 
 	function assertItemElement( item, itemElement ) {
-		assert.areEqual( '<li data-id="' + item.id + '">' + item.name + '</li>', itemElement.$.outerHTML );
+		var expectedHtmlRegex = new RegExp( '<li data-id="' + item.id + '" id="cke_[\\d]+">' + item.name + '</li>' ),
+			actualHtml = bender.tools.compatHtml( itemElement.$.outerHTML, false, true );
+
+		assert.isTrue( expectedHtmlRegex.test( actualHtml ), 'The generated autocomplete item HTML is incorrect'  );
 	}
 
 	function getCaretRect( editor, caretPosition, offset ) {

--- a/tests/plugins/autocomplete/view.js
+++ b/tests/plugins/autocomplete/view.js
@@ -195,14 +195,14 @@
 
 	function assertViewElement( editor, element ) {
 		var zIndex = editor.config.baseFloatZIndex - 3,
-			expectedHtmlRegex = new RegExp( '<ul class="cke_autocomplete_panel" id="cke_[\\d]+" style="z-index: ' + zIndex + ';"></ul>' ),
+			expectedHtmlRegex = new RegExp( '<ul class="cke_autocomplete_panel" id="cke_[\\d]+" role="listbox" style="z-index: ' + zIndex + ';"></ul>' ),
 			actualHtml = bender.tools.compatHtml( element.$.outerHTML, false, true );
 
 		assert.isTrue( expectedHtmlRegex.test( actualHtml ), 'The generated autocomplete HTML is incorrect' );
 	}
 
 	function assertItemElement( item, itemElement ) {
-		var expectedHtmlRegex = new RegExp( '<li data-id="' + item.id + '" id="cke_[\\d]+">' + item.name + '</li>' ),
+		var expectedHtmlRegex = new RegExp( '<li data-id="' + item.id + '" id="cke_[\\d]+" role="option">' + item.name + '</li>' ),
 			actualHtml = bender.tools.compatHtml( itemElement.$.outerHTML, false, true );
 
 		assert.isTrue( expectedHtmlRegex.test( actualHtml ), 'The generated autocomplete item HTML is incorrect'  );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4617](https://github.com/ckeditor/ckeditor4/issues/4617): Fixed: [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) is not accessible in inline editors.
```

## What changes did you make?

I've added appropriate attributes to the editor's editable (`[aria-autocomplete="list"]`, `[aria-controls]`, `[aria-activedescendant]`, `[aria-expanded]`) and to the autocomplete and its items (mainly roles – `listbox` for the autocomplete itself and `option` for its items). Thanks to that screen readers far better support the autocomplete:

* NVDA announces the presence of the autocomplete on editor focus and reads options from the listbox,
* JAWS announces the presence of the autocomplete on editor focus if the editor is empty (it's probably connected with the default verbosity settings) and reads options from the listbox,
* VoiceOver does _not_ announce the presence of the autocomplete, however it reads options from the listbox.

I've also ensured that these changes aren't applied to iframe-based editors.

## Which issues does your PR resolve?

Closes #4617.
Closes #4653.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
