### PR TITLE
Get rid of native splitText() in Webkit based browsers [WIP]

### DIFF
--- a/core/dom/text.js
+++ b/core/dom/text.js
@@ -123,7 +123,10 @@ CKEDITOR.tools.extend( CKEDITOR.dom.text.prototype, {
 
 			retval = new CKEDITOR.dom.text( textEnd, doc );
 			this.$.deleteData( offset, this.$.data.length );
-			retval.insertAfter( this );
+
+			// How the new text nde based on split should be inserted?
+			// this.$.parentNode.appendChild( retval.$ ); Solves the initial issue but many tests fails.
+			// retval.insertAfter( this ); Tests are green but still results in the same issue as calling splitText().
 		} else {
 			retval = new CKEDITOR.dom.text( this.$.splitText( offset ), doc );
 		}

--- a/core/dom/text.js
+++ b/core/dom/text.js
@@ -119,14 +119,17 @@ CKEDITOR.tools.extend( CKEDITOR.dom.text.prototype, {
 			// Replace native split text with text removal + new text node insertion.
 			// This fixes an issue introduced in native Text.splitText() method in Chrome version 90 (#4628).
 			// See also https://bugs.chromium.org/p/chromium/issues/detail?id=1201161.
-			var textEnd = this.$.data.substring( offset );
+			var textStart = this.$.data.substring( 0, offset ),
+				textEnd = this.$.data.substring( offset ),
+				textStartNode = new CKEDITOR.dom.text( textStart, doc ),
+				textEndNode = new CKEDITOR.dom.text( textEnd, doc );
 
-			retval = new CKEDITOR.dom.text( textEnd, doc );
-			this.$.deleteData( offset, this.$.data.length );
+			retval = textEndNode;
 
-			// How the new text nde based on split should be inserted?
-			// this.$.parentNode.appendChild( retval.$ ); Solves the initial issue but many tests fails.
-			// retval.insertAfter( this ); Tests are green but still results in the same issue as calling splitText().
+			textStartNode.insertBefore( this );
+			textEndNode.insertBefore( this );
+			this.remove();
+			this.$ = textStartNode.$;
 		} else {
 			retval = new CKEDITOR.dom.text( this.$.splitText( offset ), doc );
 		}

--- a/core/dom/text.js
+++ b/core/dom/text.js
@@ -111,10 +111,22 @@ CKEDITOR.tools.extend( CKEDITOR.dom.text.prototype, {
 		// Saved the children count and text length beforehand.
 		var parent = this.$.parentNode,
 			count = parent.childNodes.length,
-			length = this.getLength();
+			length = this.getLength(),
+			doc = this.getDocument(),
+			retval;
 
-		var doc = this.getDocument();
-		var retval = new CKEDITOR.dom.text( this.$.splitText( offset ), doc );
+		if ( CKEDITOR.env.webkit ) {
+			// Replace native split text with text removal + new text node insertion.
+			// This fixes an issue introduced in native Text.splitText() method in Chrome version 90 (#4628).
+			// See also https://bugs.chromium.org/p/chromium/issues/detail?id=1201161.
+			var textEnd = this.$.data.substring( offset );
+
+			retval = new CKEDITOR.dom.text( textEnd, doc );
+			this.$.deleteData( offset, this.$.data.length );
+			retval.insertAfter( this );
+		} else {
+			retval = new CKEDITOR.dom.text( this.$.splitText( offset ), doc );
+		}
 
 		if ( parent.childNodes.length == count ) {
 			// If the offset is after the last char, IE creates the text node


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<ISSUE_NUMBER>](https://github.com/ckeditor/ckeditor4/issues/<ISSUE_NUMBER>): Describe the purpose of the pull request in a few simple sentences.
```

## What changes did you make?

@Comandeer have already checked different approaches for working around broken native `splitText()` method. But I thought if it doesn't work maybe we could get rid of it by replacing it with combination of operations which gives the same results.

Stil it looks like there is similar issue even when not using `splitText()` directly.

## Which issues does your PR resolve?

None. Targets #4628.
