### PR TITLE
Fix inserting `<br>` element after widget in `ENTER_BR` mode

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3465,7 +3465,10 @@
 		var elementTag = decodeEnterMode( widget.editor.config.enterMode ),
 			newElement = new CKEDITOR.dom.element( elementTag );
 
-		newElement.appendBogus();
+		// Avoid nesting <br> inside <br>.
+		if ( elementTag !== 'br' ) {
+			newElement.appendBogus();
+		}
 
 		if ( position === 'after' ) {
 			newElement.insertAfter( widget.wrapper );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

none

## What changes did you make?

With https://github.com/ckeditor/ckeditor4/pull/4539, in `ENTER_BR` mode we were inserting nested `<br>` elements after widget. It happened on all the browsers, but others than IE11 was handling it well (only displayed single line break) and after toggling source mode the code was correctly cleaned up, so the issue was not visible there (although still present). IE11 though was flattening those nested `<br>`s, producing double line break in the effect.

## Which issues does your PR resolve?

Closes #4634.
