### PR TITLE
Fix API docs issues in `CKEDITOR.tools.color`

### DIFF
--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -187,9 +187,9 @@
 			 * +------+---------------+---------------------------------------+
 			 * | Type | Integer value |                Constant               |
 			 * +------+---------------+---------------------------------------+
-			 * |  RGB |       1       | {@link CKEDITOR.tools.color.TYPE_RGB} |
+			 * |  RGB |       1       |                TYPE_RGB               |
 			 * +------+---------------+---------------------------------------+
-			 * |  HSL |       2       | {@link CKEDITOR.tools.color.TYPE_HSL} |
+			 * |  HSL |       2       |                TYPE_HSL               |
 			 * +------+---------------+---------------------------------------+
 			 * ```
 			 *
@@ -797,13 +797,13 @@
 			 * @static
 			 * @property {RegExp}
 			 */
-			// Some docs for the regex:
+			hslRegExp: /hsla?\((\s*(?:[.\d]+(?:deg)?)(?:\s*,?\s*[.\d]+%){2})((?:(?:\s*\/\s*)|(?:\s*,\s*))[\d.]+%?)?\s*\)/i,
+			// Some docs for the above regex:
 			// * all values except opacity are in the first capturing group, the opacity is in the second (needed by extraction logic);
 			// therefore every subgroup is non-capturing (we need only two capturing groups at the end!)
 			// * (?:[.\d]+(?:deg)?) – gets the hue with optional deg unit
 			// * (?:\s*,?\s*[.\d]+%){2}) – gets the saturation and lightness as percents and with optional preceding comma
 			// * (?:(?:\s*\/\s*)|(?:\s*,\s*)) – gets the opacity separator (comma or slash)
-			hslRegExp: /hsla?\((\s*(?:[.\d]+(?:deg)?)(?:\s*,?\s*[.\d]+%){2})((?:(?:\s*\/\s*)|(?:\s*,\s*))[\d.]+%?)?\s*\)/i,
 
 			/**
 			 * Color list based on [W3 named colors list](https://www.w3.org/TR/css-color-4/#named-colors).


### PR DESCRIPTION
## What is the purpose of this pull request?

API docs fixes

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

nope

## What changes did you make?

1) `CKEDITOR.tools.color.TYPE_RGB` and `CKEDITOR.tools.color.TYPE_HSL` should've been link using `#` instead of `.`, which was causing the problem while building docs (references to these properties couldn't have been resolved). However mentioned references were placed inside the code block, which meant they were just removed anyway during build process, ruining the formatting. Hence I've just removed the faulty references instead of fixing them.
2) The `Unnamed property` error was caused by inline comments placed right after block comment and before the property itself. I've moved inline comments after the property to help parser here.

## Which issues does your PR resolve?

Closes #4657.
