### PR TITLE
Fix for regression with pasting images in Firefox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ New Features:
 
 Fixed Issues:
 
+* [#3757](https://github.com/ckeditor/ckeditor4/issues/3757): [Firefox] Fixed: images pasted from [clipboard](https://ckeditor.com/cke4/addon/clipboard) are not inserted as Base64-encoded images.
 * [#4604](https://github.com/ckeditor/ckeditor4/issues/4604): Fixed: [`CKEDITOR.plugins.clipboard.dataTransfer#getTypes()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard_dataTransfer.html#method-getTypes) returns no types.
 * [#4597](https://github.com/ckeditor/ckeditor4/issues/4597): Fixed: Incorrect color conversion for HSL/HSLA values in [`CKEDITOR.tools.color`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_color.html).
 * [#4596](https://github.com/ckeditor/ckeditor4/issues/4596): Fixed: Incorrect handling of HSL/HSLA values in [`CKEDITOR.tools.color`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_color.html).

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -197,11 +197,7 @@
 					return false;
 				}
 
-				var types = dataTransfer.getTypes(),
-					isFileOnly = types.length === 1 && types[ 0 ] === 'Files',
-					containsFile = dataTransfer.getFilesCount() === 1;
-
-				return isFileOnly && containsFile;
+				return dataTransfer.isFileTransfer();
 			}
 
 			editor.on( 'paste', function( evt ) {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -197,7 +197,7 @@
 					return false;
 				}
 
-				return dataTransfer.isFileTransfer();
+				return dataTransfer.isFileTransfer() && dataTransfer.getFilesCount() === 1;
 			}
 
 			editor.on( 'paste', function( evt ) {

--- a/tests/plugins/clipboard/manual/pasteimage.md
+++ b/tests/plugins/clipboard/manual/pasteimage.md
@@ -1,10 +1,10 @@
 @bender-ui: collapsed
-@bender-tags: 4.6.2, bug, clipboard
+@bender-tags: 4.6.2, 4.17.0, bug, clipboard, 3757
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image, clipboard, sourcearea
 
 ## Scenario:
 
  * Paste image from your clipboard into the editor.
- 
+
 **Expected**: Image is pasted as base64 encoded file.
 

--- a/tests/plugins/clipboard/manual/pasteimage.md
+++ b/tests/plugins/clipboard/manual/pasteimage.md
@@ -1,10 +1,16 @@
 @bender-ui: collapsed
-@bender-tags: 4.6.2, bug, clipboard
+@bender-tags: 4.6.2, 4.17.0, bug, clipboard, 3757
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image, clipboard, sourcearea
 
 ## Scenario:
 
- * Paste image from your clipboard into the editor.
- 
-**Expected**: Image is pasted as base64 encoded file.
+1. Paste image from your clipboard into the editor.
+
+	### Expected result
+
+	* Image is pasted as base64 encoded file.
+
+	### Unexpected result
+
+	* Nothing happens.
 

--- a/tests/plugins/clipboard/manual/pasteimage.md
+++ b/tests/plugins/clipboard/manual/pasteimage.md
@@ -1,16 +1,10 @@
 @bender-ui: collapsed
-@bender-tags: 4.6.2, 4.17.0, bug, clipboard, 3757
+@bender-tags: 4.6.2, bug, clipboard
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image, clipboard, sourcearea
 
 ## Scenario:
 
-1. Paste image from your clipboard into the editor.
-
-	### Expected result
-
-	* Image is pasted as base64 encoded file.
-
-	### Unexpected result
-
-	* Nothing happens.
+ * Paste image from your clipboard into the editor.
+ 
+**Expected**: Image is pasted as base64 encoded file.
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3757](https://github.com/ckeditor/ckeditor4/issues/3757): [Firefox] Fixed: pasted images are not inserted as Base64-encoded images.
```

## What changes did you make?

It seems that fix for #4604 also fixed this issue. I've just slightly adjusted the solution to use the new `CKEDITOR.plugins.clipboard.dataTransfer#isFileTransfer()` method. I've also updated manual test. I didn't add new unit tests as it seems that we are covered enough in this matter.

## Which issues does your PR resolve?

Closes #3757.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
