### PR TITLE
Fix for colon in ID is not escaped since IE doesn't support CSS escape

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -1552,7 +1552,8 @@
 				return '\\3' + selector.charAt( 0 ) + ' ' + selector.substring( 1, selector.length );
 			}
 
-			return selector;
+			//escape colon
+			return selector.replace(/:/g, "\\:");
 		},
 
 		/**

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -860,7 +860,7 @@
 			var escapedSelector = CKEDITOR.tools.escapeCss( selector );
 
 			// Check starts-with-number selector.
-			assert.areSame( escapedSelector, 'abd\\:efg', 'has-colon selector' );
+			assert.areSame( escapedSelector, 'abc\\:efg', 'has-colon selector' );
 		},
 
 		'test escapeCss - standard selector': function() {

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -855,6 +855,14 @@
 			assert.areSame( escapedSelector, '\\30 ', 'only-one-number selector' );
 		},
 
+		'test escapeCss - has-colon selector': function() {
+			var selector = 'abc:efg';
+			var escapedSelector = CKEDITOR.tools.escapeCss( selector );
+
+			// Check starts-with-number selector.
+			assert.areSame( escapedSelector, 'abd\\:efg', 'has-colon selector' );
+		},
+
 		'test escapeCss - standard selector': function() {
 			var selector = 'aaa';
 			var escapedSelector = CKEDITOR.tools.escapeCss( selector );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix.
issue here: https://github.com/ckeditor/ckeditor4/issues/4664
Basically, IE doesn't support CSS.escape, so we need to escape it manually. 
In our case, id could have colon, so we need to escape it in IE.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<4664>](https://github.com/ckeditor/ckeditor4/issues/<4664>): [IE] : escape colon in id selector in IE
```

## What changes did you make?

Minor change in the tool.js > escapeCss(). When CSS.escape is not available (in IE), we need to escape colon otherwise it will cause javascript err.

## Which issues does your PR resolve?

Closes #<4664>.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
