### PR TITLE
Fix for broken dialogs after opening the same one twice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 CKEditor 4 Changelog
 ====================
 
+## CKEditor 4.16.2
+
+Fixed Issues:
+* [#3638](https://github.com/ckeditor/ckeditor4/issues/3638): Fixed: opening the same dialog twice causes it to become hidden under the dialog's page cover.
+
 ## CKEditor 4.16.1
 
 Fixed Issues:

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -905,7 +905,8 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				CKEDITOR.dialog._.currentTop = this;
 				this._.parentDialog = null;
 				showCover( this._.editor );
-			} else {
+			} else if ( CKEDITOR.dialog._.currentTop !== this ) {
+				// Do the magic with z-indexes only if the current dialog is not already visible (#3638).
 				this._.parentDialog = CKEDITOR.dialog._.currentTop;
 
 				var parentElement = this._.parentDialog.getElement().getFirst();

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -906,7 +906,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				this._.parentDialog = null;
 				showCover( this._.editor );
 			} else if ( CKEDITOR.dialog._.currentTop !== this ) {
-				// Do the magic with z-indexes only if the current dialog is not already visible (#3638).
+				// Reposition the new dialog only if the current dialog is not already on the top (#3638).
 				this._.parentDialog = CKEDITOR.dialog._.currentTop;
 
 				var parentElement = this._.parentDialog.getElement().getFirst();

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -401,8 +401,18 @@
 			editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialog' ) );
 			editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialog' ) );
 			editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialog' ) );
-		}
+		},
 
+		// Closes all opened dialogs.
+		closeAllDialogs: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+
+			while ( dialog ) {
+				dialog.hide();
+
+				dialog = CKEDITOR.dialog.getCurrent();
+			}
+		}
 	};
 
 	window.dialogTools = dialogTools;

--- a/tests/plugins/dialog/manual/hidingcover.html
+++ b/tests/plugins/dialog/manual/hidingcover.html
@@ -1,0 +1,21 @@
+<p>
+	<button id="trigger">Open dialogs</button>
+</p>
+<div id="editor">
+	<p>Hello there!</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor;
+
+				CKEDITOR.document.getById( 'trigger' ).on( 'click', function() {
+					editor.execCommand( 'link' );
+					editor.execCommand( 'link' );
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/dialog/manual/hidingcover.md
+++ b/tests/plugins/dialog/manual/hidingcover.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.16.1, bug, 3638
+@bender-tags: 4.16.2, bug, 3638
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link, image
 

--- a/tests/plugins/dialog/manual/hidingcover.md
+++ b/tests/plugins/dialog/manual/hidingcover.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.16.1, bug, 3638
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link, image
+
+1. Click the button above the editor.
+
+	**Expected:** Dialog is above the cover and you can interact with it.
+
+	**Unexpected:** Dialog is hidden under the cover.
+2. Close dialog.
+
+  **Expected:** Cover disappears and you can interact with the page and the editor.
+
+  **Unexpected:** Cover is stubborn and prevents access to the page and the editor.

--- a/tests/plugins/dialog/manual/hidingcover.md
+++ b/tests/plugins/dialog/manual/hidingcover.md
@@ -7,8 +7,9 @@
 	**Expected:** Dialog is above the cover and you can interact with it.
 
 	**Unexpected:** Dialog is hidden under the cover.
+
 2. Close dialog.
 
-  **Expected:** Cover disappears and you can interact with the page and the editor.
+	**Expected:** Cover disappears and you can interact with the page and the editor.
 
-  **Unexpected:** Cover is stubborn and prevents access to the page and the editor.
+	**Unexpected:** Cover is stubborn and prevents access to the page and the editor.

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -81,6 +81,16 @@
 	bender.editor = {};
 
 	bender.test( {
+		tearDown: function() {
+			var dialog = CKEDITOR.dialog.getCurrent();
+
+			while ( dialog ) {
+				dialog.hide();
+
+				dialog = CKEDITOR.dialog.getCurrent();
+			}
+		},
+
 		// (#4262)
 		'test stylesLoaded is not polluting global context': function() {
 			assert.isUndefined( window.stylesLoaded );
@@ -115,25 +125,25 @@
 		},
 
 		// (#2423)
-		'test open dialog forces model': function() {
-			var tc = this,
-				editor = this.editor,
-				model = {};
+		// 'test open dialog forces model': function() {
+		// 	var tc = this,
+		// 		editor = this.editor,
+		// 		model = {};
 
-			editor.openDialog( 'testGetModel', function( dialog1 ) {
-				assert.areSame( model, dialog1.getModel() );
+		// 	editor.openDialog( 'testGetModel', function( dialog1 ) {
+		// 		assert.areSame( model, dialog1.getModel() );
 
-				dialog1.hide();
+		// 		dialog1.hide();
 
-				editor.openDialog( 'testGetModel', function( dialog2 ) {
-					tc.resume( function() {
-						assert.areNotSame( model, dialog2.getModel() );
-					} );
-				} );
-			}, model );
+		// 		editor.openDialog( 'testGetModel', function( dialog2 ) {
+		// 			tc.resume( function() {
+		// 				assert.areNotSame( model, dialog2.getModel() );
+		// 			} );
+		// 		} );
+		// 	}, model );
 
-			tc.wait();
-		},
+		// 	tc.wait();
+		// },
 
 		// Code of this test is poor (checking isVisible and operations on DOM), but that's caused
 		// by very closed and poor dialog API.
@@ -557,6 +567,19 @@
 					dialog: CKEDITOR.dialog.getCurrent(),
 					definition: sinon.match.instanceOf( Object )
 				} ) );
+			} );
+		},
+
+		// (#3638)
+		'test updating current dialog after closing the dialog opened twice': function() {
+			var editorBot = this.editorBot;
+
+			editorBot.dialog( 'testDialog1', function() {
+				editorBot.dialog( 'testDialog1', function( dialog ) {
+					dialog.getButton( 'cancel' ).click();
+
+					assert.isNull( CKEDITOR.dialog.getCurrent(), 'There is no current dialog' );
+				} );
 			} );
 		}
 	} );

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -1,5 +1,7 @@
 /* bender-tags: editor, dialog */
 /* bender-ckeditor-plugins: dialog */
+/* bender-include: _helpers/tools.js */
+/* global dialogTools */
 
 ( function() {
 	'use strict';
@@ -81,15 +83,7 @@
 	bender.editor = {};
 
 	bender.test( {
-		tearDown: function() {
-			var dialog = CKEDITOR.dialog.getCurrent();
-
-			while ( dialog ) {
-				dialog.hide();
-
-				dialog = CKEDITOR.dialog.getCurrent();
-			}
-		},
+		tearDown: dialogTools.closeAllDialogs,
 
 		// (#4262)
 		'test stylesLoaded is not polluting global context': function() {

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -125,25 +125,24 @@
 		},
 
 		// (#2423)
-		// 'test open dialog forces model': function() {
-		// 	var tc = this,
-		// 		editor = this.editor,
-		// 		model = {};
+		'test open dialog forces model': function() {
+			var tc = this,
+				editor = this.editor,
+				editorBot = this.editorBot,
+				model = {};
 
-		// 	editor.openDialog( 'testGetModel', function( dialog1 ) {
-		// 		assert.areSame( model, dialog1.getModel() );
+			editor.openDialog( 'testGetModel', function( dialog1 ) {
+				assert.areSame( model, dialog1.getModel() );
 
-		// 		dialog1.hide();
+				dialog1.hide();
 
-		// 		editor.openDialog( 'testGetModel', function( dialog2 ) {
-		// 			tc.resume( function() {
-		// 				assert.areNotSame( model, dialog2.getModel() );
-		// 			} );
-		// 		} );
-		// 	}, model );
+				editorBot.dialog( 'testGetModel', function( dialog2 ) {
+					assert.areNotSame( model, dialog2.getModel() );
+				} );
+			}, model );
 
-		// 	tc.wait();
-		// },
+			tc.wait();
+		},
 
 		// Code of this test is poor (checking isVisible and operations on DOM), but that's caused
 		// by very closed and poor dialog API.

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -229,7 +229,8 @@
 
 					dialog.getButton( 'cancel' ).click();
 
-					assert.isTrue( dialogZIndex > coverZIndex, 'Dialog should be above the cover' );
+					assert.isTrue( dialogZIndex > coverZIndex, 'Dialog should be above the cover (dialog z-index: ' +
+						dialogZIndex + ', cover z-index: ' + coverZIndex + ')' );
 				} );
 			} );
 		},

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -221,6 +221,38 @@
 					} );
 				} );
 			} );
+		},
+
+		// (#3638)
+		'test dialog is positioned above the cover after opening the same dialog twice': function() {
+			var editorBot = this.editorBot;
+
+			editorBot.dialog( 'link', function() {
+				editorBot.dialog( 'link', function( dialog ) {
+					var cover = CKEDITOR.document.findOne( '.cke_dialog_background_cover' ),
+						coverZIndex = cover.getStyle( 'z-index' ),
+						dialogZIndex = dialog.getElement().getStyle( 'z-index' );
+
+					dialog.getButton( 'cancel' ).click();
+
+					assert.isTrue( dialogZIndex > coverZIndex, 'Dialog should be above the cover' );
+				} );
+			} );
+		},
+
+		// (#3638)
+		'test dialog cover disappears after opening the same dialog twice and closing it': function() {
+			var editorBot = this.editorBot;
+
+			editorBot.dialog( 'link', function() {
+				editorBot.dialog( 'link', function( dialog ) {
+					var cover = CKEDITOR.document.findOne( '.cke_dialog_background_cover' );
+
+					dialog.getButton( 'cancel' ).click();
+
+					assert.areEqual( 'none', cover.getStyle( 'display' ), 'Dialog cover should not be visible' );
+				} );
+			} );
 		}
 	} );
 

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -13,8 +13,11 @@
 		},
 		tearDown: function() {
 			var dialog = CKEDITOR.dialog.getCurrent();
-			if ( dialog ) {
+
+			while ( dialog ) {
 				dialog.hide();
+
+				dialog = CKEDITOR.dialog.getCurrent();
 			}
 		},
 
@@ -219,7 +222,6 @@
 				} );
 			} );
 		}
-
 	} );
 
 	function mockWindowGetViewPaneSize( viewPaneSize ) {

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -230,8 +230,8 @@
 			editorBot.dialog( 'link', function() {
 				editorBot.dialog( 'link', function( dialog ) {
 					var cover = CKEDITOR.document.findOne( '.cke_dialog_background_cover' ),
-						coverZIndex = cover.getStyle( 'z-index' ),
-						dialogZIndex = dialog.getElement().getStyle( 'z-index' );
+						coverZIndex = parseInt( cover.getStyle( 'z-index' ), 10 ),
+						dialogZIndex = parseInt( dialog.getElement().getStyle( 'z-index' ), 10 );
 
 					dialog.getButton( 'cancel' ).click();
 

--- a/tests/plugins/dialog/positioning.js
+++ b/tests/plugins/dialog/positioning.js
@@ -1,5 +1,7 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: dialog, link, toolbar, colorbutton, colordialog */
+/* bender-include: _helpers/tools.js */
+/* global dialogTools */
 
 ( function() {
 	'use strict';
@@ -11,15 +13,7 @@
 			// Make sure page is scrollable on vertical screens.
 			CKEDITOR.document.getBody().appendHtml( '<div style="height:4000px"></div>' );
 		},
-		tearDown: function() {
-			var dialog = CKEDITOR.dialog.getCurrent();
-
-			while ( dialog ) {
-				dialog.hide();
-
-				dialog = CKEDITOR.dialog.getCurrent();
-			}
-		},
+		tearDown: dialogTools.closeAllDialogs,
 
 		// (#2395).
 		'test body has hidden scrollbars when dialog is opened': function() {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3638](https://github.com/ckeditor/ckeditor4/issues/3638): Fixed: opening the same dialog twice causes it to become hidden under the dialog's page cover.
```

## What changes did you make?

I've just added a simple check if the current dialog (`CKEDITOR.dialog._.currentTop`) is the same as the one being opened. If it's the case, the positioning logic is skipped.

Additionally I've polished some tests to always close dialogs.

## Which issues does your PR resolve?

Closes #3638.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
