### PR TITLE
Unify color handling

### DIFF
--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -50,31 +50,39 @@
 			/**
 			 * Gets hexadecimal color representation.
 			 *
+			 * @param {Boolean} [shorten=false] If it's possible, shorten the returned hex to the 3-number format.
 			 * @returns {String/*} Hexadecimal color code (e.g. `#FF00FF`) or default value.
 			 */
-			getHex: function() {
+			getHex: function( shorten ) {
 				if ( !this._.isValidColor ) {
 					return this._.defaultValue;
 				}
 
-				var color = this._.blendAlphaColor( this._.red, this._.green, this._.blue, this._.alpha );
+				var isShortenableRegex = /^#([a-f0-9])\1([a-f0-9])\2([a-f0-9])\3$/i,
+					color = this._.blendAlphaColor( this._.red, this._.green, this._.blue, this._.alpha ),
+					hex = this._.formatHexString( color[ 0 ], color[ 1 ], color[ 2 ] ),
+					isShortenable = isShortenableRegex.test( hex );
 
-				return this._.formatHexString( color[ 0 ], color[ 1 ], color[ 2 ] );
+				return shorten && isShortenable ? this._.shortenHex( hex ) : hex;
 			},
 
 			/**
 			 * Gets hexadecimal color representation with separate alpha channel.
 			 *
+			 * @param {Boolean} [shorten=false] If it's possible, shorten the returned hex to the 4-number format.
 			 * @returns {String/*} Hexadecimal color code (e.g. `#FF00FF00`) or default value.
 			 */
-			getHexWithAlpha: function() {
+			getHexWithAlpha: function( shorten ) {
 				if ( !this._.isValidColor ) {
 					return this._.defaultValue;
 				}
 
-				var alpha = Math.round( this._.alpha * CKEDITOR.tools.color.MAX_RGB_CHANNEL_VALUE );
+				var isShortenableRegex = /^#([a-f0-9])\1([a-f0-9])\2([a-f0-9])\3([a-f0-9])\4$/i,
+					alpha = Math.round( this._.alpha * CKEDITOR.tools.color.MAX_RGB_CHANNEL_VALUE ),
+					hex = this._.formatHexString( this._.red, this._.green, this._.blue, alpha ),
+					isShortenable = isShortenableRegex.test( hex );
 
-				return this._.formatHexString( this._.red, this._.green, this._.blue, alpha ) ;
+				return shorten && isShortenable ? this._.shortenHex( hex ) : hex;
 			},
 
 			/**
@@ -300,6 +308,24 @@
 				}
 
 				return hexColorCode.toUpperCase();
+			},
+
+			/**
+			 * Shorten provided hex to 3 or 4 numbers, depending on the input.
+			 *
+			 * @private
+			 * @param {String} hex 6- or 8-number hex (e.g. `#FFFF00` or `#DDCC00AA`).
+			 * @returns {String} Shorten hex (e.g. `#FF0` or `#DC0A`)
+			 */
+			shortenHex: function( hex ) {
+				var withAlpha = hex.length === 9,
+					shortHex = '#' + hex[ 1 ] + hex[ 3 ] + hex[ 5 ];
+
+				if ( withAlpha ) {
+					shortHex += hex[ 7 ];
+				}
+
+				return shortHex;
 			},
 
 			/**

--- a/core/tools/color.js
+++ b/core/tools/color.js
@@ -50,39 +50,49 @@
 			/**
 			 * Gets hexadecimal color representation.
 			 *
-			 * @param {Boolean} [shorten=false] If it's possible, shorten the returned hex to the 3-number format.
+			 * @param {Object} [options]
+			 * @param {Boolean} [options.shorten=false] If it's possible, shorten the returned hex to the 3-number format.
 			 * @returns {String/*} Hexadecimal color code (e.g. `#FF00FF`) or default value.
 			 */
-			getHex: function( shorten ) {
+			getHex: function( options ) {
 				if ( !this._.isValidColor ) {
 					return this._.defaultValue;
 				}
+
+				options = CKEDITOR.tools.object.merge( {
+					shorten: false
+				}, options );
 
 				var isShortenableRegex = /^#([a-f0-9])\1([a-f0-9])\2([a-f0-9])\3$/i,
 					color = this._.blendAlphaColor( this._.red, this._.green, this._.blue, this._.alpha ),
 					hex = this._.formatHexString( color[ 0 ], color[ 1 ], color[ 2 ] ),
 					isShortenable = isShortenableRegex.test( hex );
 
-				return shorten && isShortenable ? this._.shortenHex( hex ) : hex;
+				return ( options.shorten && isShortenable ) ? this._.shortenHex( hex ) : hex;
 			},
 
 			/**
 			 * Gets hexadecimal color representation with separate alpha channel.
 			 *
-			 * @param {Boolean} [shorten=false] If it's possible, shorten the returned hex to the 4-number format.
+			 * @param {Object} [options]
+			 * @param {Boolean} [options.shorten=false] If it's possible, shorten the returned hex to the 4-number format.
 			 * @returns {String/*} Hexadecimal color code (e.g. `#FF00FF00`) or default value.
 			 */
-			getHexWithAlpha: function( shorten ) {
+			getHexWithAlpha: function( options ) {
 				if ( !this._.isValidColor ) {
 					return this._.defaultValue;
 				}
+
+				options = CKEDITOR.tools.object.merge( {
+					shorten: false
+				}, options );
 
 				var isShortenableRegex = /^#([a-f0-9])\1([a-f0-9])\2([a-f0-9])\3([a-f0-9])\4$/i,
 					alpha = Math.round( this._.alpha * CKEDITOR.tools.color.MAX_RGB_CHANNEL_VALUE ),
 					hex = this._.formatHexString( this._.red, this._.green, this._.blue, alpha ),
 					isShortenable = isShortenableRegex.test( hex );
 
-				return shorten && isShortenable ? this._.shortenHex( hex ) : hex;
+				return ( options.shorten && isShortenable ) ? this._.shortenHex( hex ) : hex;
 			},
 
 			/**

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -311,7 +311,7 @@
 								}
 							}, null, colorData );
 						} else {
-							setColor( color && '#' + color, colorName, history );
+							setColor( color && color, colorName, history );
 						}
 
 						// The colors may be duplicated in both default palette and color history. If user reopens panel

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -529,7 +529,7 @@
 
 				// Replace 3-character hexadecimal notation with a 6-character hexadecimal notation (#1008).
 				// It also covers other cases, like colors with alpha channel (#4351).
-				return CKEDITOR.tools.normalizeHex( colorInstance.getHex() || '' );
+				return colorInstance.getHex() || '';
 			},
 
 			getAppliableColor: function( color ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -478,13 +478,15 @@
 	} );
 	ColorBox = CKEDITOR.tools.createClass( {
 		$: function( editor, colorData, clickFn ) {
-			var initialValue = colorData.color.getInitialValue();
+			var isValidColor = colorData.color._.isValidColor,
+				defaultLabel = colorData.color.getInitialValue();
 
 			this.$ = new CKEDITOR.dom.element( 'td' );
 
 			this.color = colorData.color;
 			this.clickFn = clickFn;
-			this.label = colorData.label || ColorBox.getColorName( editor, this.color ) || initialValue;
+			this.label = isValidColor ?
+				( colorData.label || ColorBox.getColorName( editor, this.color ) || defaultLabel ) : '';
 
 			this.setHtml();
 		},
@@ -530,6 +532,10 @@
 			},
 
 			getAppliableColor: function( color ) {
+				if ( !color._.isValidColor ) {
+					return '';
+				}
+
 				var initialValue = color.getInitialValue(),
 					isHexLike = initialValue.toLowerCase() ===
 						color.getHex( initialValue.length === 3 ).toLowerCase().substr( 1 ),
@@ -549,8 +555,8 @@
 			},
 
 			setHtml: function() {
-				var colorStr = this.color.getInitialValue(),
-					appliableColor = ColorBox.getAppliableColor( this.color );
+				var appliableColor = ColorBox.getAppliableColor( this.color ),
+					colorStr = appliableColor ? this.color.getInitialValue() : '';
 
 				this.getElement().setHtml( '<a class="cke_colorbox" _cke_focus=1 hidefocus=true' +
 						' title="' + this.label + '"' +

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -386,7 +386,8 @@
 						colorName = parts[ 0 ],
 						colorCode = parts[ 1 ] || colorName,
 						colorLabel = parts[ 1 ] ? colorName : undefined,
-						box = new ColorBox( editor, { color: colorCode, label: colorLabel }, clickFn );
+						color = new CKEDITOR.tools.color( colorCode, colorCode ),
+						box = new ColorBox( editor, { color: color, label: colorLabel }, clickFn );
 
 					box.setPositionIndex( startingPosition + i, total );
 					output.push( box.getHtml() );
@@ -477,11 +478,13 @@
 	} );
 	ColorBox = CKEDITOR.tools.createClass( {
 		$: function( editor, colorData, clickFn ) {
+			var initialValue = colorData.color.getInitialValue();
+
 			this.$ = new CKEDITOR.dom.element( 'td' );
 
-			this.color = CKEDITOR.tools._isValidColorFormat( colorData.color ) ? colorData.color : '';
+			this.color = colorData.color;
 			this.clickFn = clickFn;
-			this.label = colorData.label || ColorBox.colorNames( editor )[ this.color ] || this.color;
+			this.label = colorData.label || ColorBox.colorNames( editor )[ initialValue ] || initialValue;
 
 			this.setHtml();
 		},
@@ -535,16 +538,18 @@
 			},
 
 			setHtml: function() {
+				var colorStr = this.color.getInitialValue();
+
 				this.getElement().setHtml( '<a class="cke_colorbox" _cke_focus=1 hidefocus=true' +
 						' title="' + this.label + '"' +
 						' draggable="false"' +
 						' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
-						' onclick="CKEDITOR.tools.callFunction(' + this.clickFn + ',\'' + this.color + '\',\'' + this.label +  '\', this);' +
+						' onclick="CKEDITOR.tools.callFunction(' + this.clickFn + ',\'' + colorStr + '\',\'' + this.label +  '\', this);' +
 						' return false;"' +
-						' href="javascript:void(\'' + this.color + '\')"' +
-						' data-value="' + this.color + '"' +
+						' href="javascript:void(\'' + colorStr + '\')"' +
+						' data-value="' + colorStr + '"' +
 						' role="option">' +
-						'<span class="cke_colorbox" style="background-color:#' + this.color + '"></span>' +
+						'<span class="cke_colorbox" style="background-color:' + this.color.getHex() + '"></span>' +
 					'</a>' );
 			},
 
@@ -702,7 +707,9 @@
 			},
 
 			createAtBeginning: function( colorCode ) {
-				this._.moveToBeginning( new ColorBox( this.editor, { color: colorCode }, this.clickFn ) );
+				var color = new CKEDITOR.tools.color( colorCode, colorCode );
+
+				this._.moveToBeginning( new ColorBox( this.editor, { color: color }, this.clickFn ) );
 			},
 
 			addNewRow: function() {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -586,7 +586,7 @@
 
 			extractColorBox: function( colorCode ) {
 				var index = CKEDITOR.tools.getIndex( this.boxes, function( box ) {
-					return box.color === colorCode;
+					return box.color.getInitialValue() === colorCode;
 				} );
 
 				if ( index < 0 ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -515,8 +515,9 @@
 			 * * HSL/HSLA colors (e.g. `hsl( 100, 50%, 20%)` or `hsla( 100, 50%, 20%, 10%)`).
 			 *
 			 * @private
-			 * @param {String} color
+			 * @param {String/CKEDITOR.tools.color} color
 			 * @returns {String} Returns color in hex format, but without the hash at the beginning, e.g. `ff0000` for red.
+			 * In case of transparent colors, it returns `'transparent'` string.
 			 */
 			normalizeColor: function( color ) {
 				var colorInstance = ( color instanceof CKEDITOR.tools.color ) ? color : new CKEDITOR.tools.color( color, '' ),

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -495,7 +495,7 @@
 			getColorName: function( editor, color ) {
 				var names = ColorBox.colorNames( editor ),
 					hex = color.getHex().replace( /^#/g, '' ),
-					shortHex = color.getHex( true ).replace( /^#/g, '' );
+					shortHex = color.getHex( { shorten: true } ).replace( /^#/g, '' );
 
 				return names[ hex ] || names[ shortHex ];
 			},

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -484,12 +484,19 @@
 
 			this.color = colorData.color;
 			this.clickFn = clickFn;
-			this.label = colorData.label || ColorBox.colorNames( editor )[ initialValue ] || initialValue;
+			this.label = colorData.label || ColorBox.getColorName( editor, this.color ) || initialValue;
 
 			this.setHtml();
 		},
 
 		statics: {
+			getColorName: function( editor, color ) {
+				var names = ColorBox.colorNames( editor ),
+					hex = color.getHex().replace( /^#/g, '' );
+
+				return names[ hex ];
+			},
+
 			colorNames: function( editor ) {
 				return editor.lang.colorbutton.colors;
 			},

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -342,7 +342,7 @@
 
 					editor.execCommand( commandName, { newStyle: colorStyle } );
 					if ( color && colorHistory ) {
-						colorHistory.addColor( color.substr( 1 ).toUpperCase() );
+						colorHistory.addColor( color );
 						renumberElements( panelBlock );
 					}
 				}
@@ -517,7 +517,7 @@
 			 * @returns {String} Returns color in hex format, but without the hash at the beginning, e.g. `ff0000` for red.
 			 */
 			normalizeColor: function( color ) {
-				var colorInstance = new CKEDITOR.tools.color( color, '' ),
+				var colorInstance = ( color instanceof CKEDITOR.tools.color ) ? color : new CKEDITOR.tools.color( color, '' ),
 					isTransparent = Number( colorInstance._.alpha ) === 0;
 
 				if ( isTransparent ) {
@@ -597,9 +597,10 @@
 			},
 
 			extractColorBox: function( colorCode ) {
-				var index = CKEDITOR.tools.getIndex( this.boxes, function( box ) {
-					return box.color.getInitialValue() === colorCode;
-				} );
+				var normalizedColor = ColorBox.normalizeColor( colorCode ),
+					index = CKEDITOR.tools.getIndex( this.boxes, function( box ) {
+						return ColorBox.normalizeColor( box.color ) === normalizedColor;
+					} );
 
 				if ( index < 0 ) {
 					return null;

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -526,9 +526,11 @@
 
 			getAppliableColor: function( color ) {
 				var initialValue = color.getInitialValue(),
-					isHexLike = initialValue.toLowerCase() === color.getHex().toLowerCase().substr( 1 );
+					isHexLike = initialValue.toLowerCase() ===
+						color.getHex( initialValue.length === 3 ).toLowerCase().substr( 1 ),
+					isShortHexLike = isHexLike && initialValue.length === 3;
 
-				return isHexLike ? color.getHex() : initialValue;
+				return isHexLike ? color.getHex( isShortHexLike ) : initialValue;
 			}
 		},
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -493,20 +493,9 @@
 			getColorName: function( editor, color ) {
 				var names = ColorBox.colorNames( editor ),
 					hex = color.getHex().replace( /^#/g, '' ),
-					shortHex = getShortHex( hex );
+					shortHex = color.getHex( true ).replace( /^#/g, '' );
 
 				return names[ hex ] || names[ shortHex ];
-
-				function getShortHex( hex ) {
-					var isShortenableRegex = /([a-f0-9])\1([a-f0-9])\2([a-f0-9])\3/i,
-						isShortenable = isShortenableRegex.test( hex );
-
-					if ( !isShortenable ) {
-						return null;
-					}
-
-					return hex[ 0 ] + hex[ 2 ] + hex[ 4 ];
-				}
 			},
 
 			colorNames: function( editor ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -492,9 +492,21 @@
 		statics: {
 			getColorName: function( editor, color ) {
 				var names = ColorBox.colorNames( editor ),
-					hex = color.getHex().replace( /^#/g, '' );
+					hex = color.getHex().replace( /^#/g, '' ),
+					shortHex = getShortHex( hex );
 
-				return names[ hex ];
+				return names[ hex ] || names[ shortHex ];
+
+				function getShortHex( hex ) {
+					var isShortenableRegex = /([a-f0-9])\1([a-f0-9])\2([a-f0-9])\3/i,
+						isShortenable = isShortenableRegex.test( hex );
+
+					if ( !isShortenable ) {
+						return null;
+					}
+
+					return hex[ 0 ] + hex[ 2 ] + hex[ 4 ];
+				}
 			},
 
 			colorNames: function( editor ) {

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -539,10 +539,10 @@
 
 				var initialValue = color.getInitialValue(),
 					isHexLike = initialValue.toLowerCase() ===
-						color.getHex( initialValue.length === 3 ).toLowerCase().substr( 1 ),
+						color.getHex( { shorten: initialValue.length === 3 } ).toLowerCase().substr( 1 ),
 					isShortHexLike = isHexLike && initialValue.length === 3;
 
-				return isHexLike ? color.getHex( isShortHexLike ) : initialValue;
+				return isHexLike ? color.getHex( { shorten: isShortHexLike } ) : initialValue;
 			}
 		},
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -517,7 +517,12 @@
 			 * @returns {String} Returns color in hex format, but without the hash at the beginning, e.g. `ff0000` for red.
 			 */
 			normalizeColor: function( color ) {
-				var colorInstance = new CKEDITOR.tools.color( color );
+				var colorInstance = new CKEDITOR.tools.color( color, '' ),
+					isTransparent = Number( colorInstance._.alpha ) === 0;
+
+				if ( isTransparent ) {
+					return 'transparent';
+				}
 
 				// Replace 3-character hexadecimal notation with a 6-character hexadecimal notation (#1008).
 				// It also covers other cases, like colors with alpha channel (#4351).

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -521,6 +521,13 @@
 				// Replace 3-character hexadecimal notation with a 6-character hexadecimal notation (#1008).
 				// It also covers other cases, like colors with alpha channel (#4351).
 				return CKEDITOR.tools.normalizeHex( colorInstance.getHex() || '' );
+			},
+
+			getAppliableColor: function( color ) {
+				var initialValue = color.getInitialValue(),
+					isHexLike = initialValue.toLowerCase() === color.getHex().toLowerCase().substr( 1 );
+
+				return isHexLike ? color.getHex() : initialValue;
 			}
 		},
 
@@ -534,18 +541,19 @@
 			},
 
 			setHtml: function() {
-				var colorStr = this.color.getInitialValue();
+				var colorStr = this.color.getInitialValue(),
+					appliableColor = ColorBox.getAppliableColor( this.color );
 
 				this.getElement().setHtml( '<a class="cke_colorbox" _cke_focus=1 hidefocus=true' +
 						' title="' + this.label + '"' +
 						' draggable="false"' +
 						' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
-						' onclick="CKEDITOR.tools.callFunction(' + this.clickFn + ',\'' + colorStr + '\',\'' + this.label +  '\', this);' +
+						' onclick="CKEDITOR.tools.callFunction(' + this.clickFn + ',\'' + appliableColor + '\',\'' + this.label +  '\', this);' +
 						' return false;"' +
 						' href="javascript:void(\'' + colorStr + '\')"' +
 						' data-value="' + colorStr + '"' +
 						' role="option">' +
-						'<span class="cke_colorbox" style="background-color:' + this.color.getHex() + '"></span>' +
+						'<span class="cke_colorbox" style="background-color:' + appliableColor + '"></span>' +
 					'</a>' );
 			},
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -272,9 +272,9 @@
 								finalColor = '';
 							}
 							if ( type == 'fore' ) {
-								colorData.automaticTextColor = '#' + ColorBox.normalizeColor( automaticColor );
+								colorData.automaticTextColor = ColorBox.normalizeColor( automaticColor );
 							}
-							colorData.selectionColor = finalColor ? '#' + finalColor : '';
+							colorData.selectionColor = finalColor ? finalColor : '';
 
 							selectColor( panelBlock, finalColor );
 						}
@@ -509,22 +509,11 @@
 			 * @returns {String} Returns color in hex format, but without the hash at the beginning, e.g. `ff0000` for red.
 			 */
 			normalizeColor: function( color ) {
-				var alphaRegex = /^(rgb|hsl)a\(/g,
-					transparentRegex = /^rgba\((\s*0\s*,?){4}\)$/g,
-					isAlphaColor = alphaRegex.test( color ),
-					// Browsers tend to represent transparent color as rgba(0, 0, 0, 0), so we need to filter out this value.
-					isTransparentColor = transparentRegex.test( color ),
-					colorInstance;
-
-				// For colors with alpha channel we need to use CKEDITOR.tools.color normalization (#4351).
-				if ( isAlphaColor && !isTransparentColor ) {
-					colorInstance = new CKEDITOR.tools.color( color );
-
-					return CKEDITOR.tools.normalizeHex( colorInstance.getHex() || '' ).replace( /#/g, '' );
-				}
+				var colorInstance = new CKEDITOR.tools.color( color );
 
 				// Replace 3-character hexadecimal notation with a 6-character hexadecimal notation (#1008).
-				return CKEDITOR.tools.normalizeHex( '#' + CKEDITOR.tools.convertRgbToHex( color || '' ) ).replace( /#/g, '' );
+				// It also covers other cases, like colors with alpha channel (#4351).
+				return CKEDITOR.tools.normalizeHex( colorInstance.getHex() || '' );
 			}
 		},
 

--- a/tests/core/tools/color/_helpers/colorTools.js
+++ b/tests/core/tools/color/_helpers/colorTools.js
@@ -5,7 +5,7 @@ var colorTools = ( function() {
 		return function() {
 			var colorObj = new CKEDITOR.tools.color( inputColorCode, defaultValue );
 
-			var resultColorCode = colorObj[ getterMethod ]();
+			var resultColorCode = typeof getterMethod === 'function' ? getterMethod( colorObj ) : colorObj[ getterMethod ]();
 
 			assert.areSame( expectedColorCode, resultColorCode );
 		};

--- a/tests/core/tools/color/conversion.js
+++ b/tests/core/tools/color/conversion.js
@@ -13,6 +13,16 @@
 	'use strict';
 
 	bender.test( {
+		// Ignored due to #4717.
+		_should: {
+			ignore: {
+				'test converting 8-HEX to 4-HEX': true,
+				'test converting 8-HEX-like to 4-HEX': true,
+				'test not converting 8-HEX to 4-HEX when it is not possible': true,
+				'test not converting 8-HEX-like to 4-HEX when it is not possible': true
+			}
+		},
+
 		'test color from 6-HEX lower-case string returns 6-HEX': colorTools.testColorConversion( '#ffffff', '#FFFFFF', 'getHex' ),
 
 		'test color from 3-HEX lower-case string returns 6-HEX': colorTools.testColorConversion( '#fff', '#FFFFFF', 'getHex' ),

--- a/tests/core/tools/color/conversion.js
+++ b/tests/core/tools/color/conversion.js
@@ -111,42 +111,58 @@
 
 		// (#4592)
 		'test converting 6-HEX to 3-HEX': colorTools.testColorConversion( '#FF00FF', '#F0F', function( color ) {
-			return color.getHex( true );
+			return color.getHex( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test converting 6-HEX-like to 3-HEX': colorTools.testColorConversion( 'FF00FF', '#F0F', function( color ) {
-			return color.getHex( true );
+			return color.getHex( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test not converting 6-HEX to 3-HEX when it is not possible': colorTools.testColorConversion( '#FC00FF', '#FC00FF', function( color ) {
-			return color.getHex( true );
+			return color.getHex( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test not converting 6-HEX-like to 3-HEX when it is not possible': colorTools.testColorConversion( '#FC00FF', '#FC00FF', function( color ) {
-			return color.getHex( true );
+			return color.getHex( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test converting 8-HEX to 4-HEX': colorTools.testColorConversion( '#FF00FFDD', '#F0FD', function( color ) {
-			return color.getHexWithAlpha( true );
+			return color.getHexWithAlpha( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test converting 8-HEX-like to 4-HEX': colorTools.testColorConversion( 'FF00FFDD', '#F0FD', function( color ) {
-			return color.getHexWithAlpha( true );
+			return color.getHexWithAlpha( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test not converting 8-HEX to 4-HEX when it is not possible': colorTools.testColorConversion( '#FC00FFDD', '#FC00FFDD', function( color ) {
-			return color.getHexWithAlpha( true );
+			return color.getHexWithAlpha( {
+				shorten: true
+			} );
 		} ),
 
 		// (#4592)
 		'test not converting 8-HEX-like to 4-HEX when it is not possible': colorTools.testColorConversion( '#FC00FFDD', '#FC00FFDD', function( color ) {
-			return color.getHexWithAlpha( true );
+			return color.getHexWithAlpha( {
+				shorten: true
+			} );
 		} )
 	} );
 

--- a/tests/core/tools/color/conversion.js
+++ b/tests/core/tools/color/conversion.js
@@ -97,7 +97,47 @@
 		'test converting HSL (123, 0%, 50%) to HSLA value returns the original value with 1 opacity': colorTools.testColorConversion( 'hsl( 123, 0%, 50% )', 'hsla(123,0%,50%,1)', 'getHsla' ),
 
 		// (#4597)
-		'test converting HSLA (123, 0%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 0%, 50%, 0.5 )', 'hsla(123,0%,50%,0.5)', 'getHsla' )
+		'test converting HSLA (123, 0%, 50%, 0.5) to HSLA value returns the original value': colorTools.testColorConversion( 'hsla( 123, 0%, 50%, 0.5 )', 'hsla(123,0%,50%,0.5)', 'getHsla' ),
+
+		// (#4592)
+		'test converting 6-HEX to 3-HEX': colorTools.testColorConversion( '#FF00FF', '#F0F', function( color ) {
+			return color.getHex( true );
+		} ),
+
+		// (#4592)
+		'test converting 6-HEX-like to 3-HEX': colorTools.testColorConversion( 'FF00FF', '#F0F', function( color ) {
+			return color.getHex( true );
+		} ),
+
+		// (#4592)
+		'test not converting 6-HEX to 3-HEX when it is not possible': colorTools.testColorConversion( '#FC00FF', '#FC00FF', function( color ) {
+			return color.getHex( true );
+		} ),
+
+		// (#4592)
+		'test not converting 6-HEX-like to 3-HEX when it is not possible': colorTools.testColorConversion( '#FC00FF', '#FC00FF', function( color ) {
+			return color.getHex( true );
+		} ),
+
+		// (#4592)
+		'test converting 8-HEX to 4-HEX': colorTools.testColorConversion( '#FF00FFDD', '#F0FD', function( color ) {
+			return color.getHexWithAlpha( true );
+		} ),
+
+		// (#4592)
+		'test converting 8-HEX-like to 4-HEX': colorTools.testColorConversion( 'FF00FFDD', '#F0FD', function( color ) {
+			return color.getHexWithAlpha( true );
+		} ),
+
+		// (#4592)
+		'test not converting 8-HEX to 4-HEX when it is not possible': colorTools.testColorConversion( '#FC00FFDD', '#FC00FFDD', function( color ) {
+			return color.getHexWithAlpha( true );
+		} ),
+
+		// (#4592)
+		'test not converting 8-HEX-like to 4-HEX when it is not possible': colorTools.testColorConversion( '#FC00FFDD', '#FC00FFDD', function( color ) {
+			return color.getHexWithAlpha( true );
+		} )
 	} );
 
 } )();

--- a/tests/plugins/colorbutton/config.js
+++ b/tests/plugins/colorbutton/config.js
@@ -21,6 +21,14 @@
 				language: 'en'
 			}
 		},
+		colorLabelsLongHex: {
+			creator: 'inline',
+			name: 'colorLabelsLongHex',
+			config: {
+				colorButton_colors: 'F00,FF0000,#f00,#ff0000',
+				language: 'en'
+			}
+		},
 		colorAttributes: {
 			creator: 'inline',
 			name: 'colorAttributes',
@@ -101,6 +109,24 @@
 			colorOptions = bgColorBtn._.panel.getBlock( bgColorBtn._.id ).element.find( 'a.cke_colorbox' );
 
 			CKEDITOR.tools.array.map( colorOptions.toArray(), function( el, index ) {
+				assert.areSame( expectedLabels[ index ], colorOptions.getItem( index ).getAttribute( 'title' ), 'Title for color at index ' + index );
+			} );
+		},
+
+		// (#4592)
+		'test config.colorButton_colors labels with long hex and hexes with #': function() {
+			var editor = this.editors.colorLabelsLongHex,
+				bgColorBtn = editor.ui.get( 'BGColor' ),
+				expectedLabels = [ 'Red', 'Red', 'Red', 'Red' ],
+				colorOptions;
+
+			// Editor needs a focus, otherwise IE/Edge throws permission error.
+			editor.focus();
+			bgColorBtn.click( editor );
+
+			colorOptions = bgColorBtn._.panel.getBlock( bgColorBtn._.id ).element.find( 'a.cke_colorbox' );
+
+			CKEDITOR.tools.array.forEach( colorOptions.toArray(), function( el, index ) {
 				assert.areSame( expectedLabels[ index ], colorOptions.getItem( index ).getAttribute( 'title' ), 'Title for color at index ' + index );
 			} );
 		},

--- a/tests/plugins/colorbutton/contentcolors.js
+++ b/tests/plugins/colorbutton/contentcolors.js
@@ -131,7 +131,7 @@
 
 				firstColorBox = colorHistoryTools.findInPanel( '.cke_colorhistory_row .cke_colorbox', txtColorBtn );
 
-				assert.areEqual( 'E74C3C', firstColorBox.getAttribute( 'data-value' ), 'Order is incorrect.' );
+				assert.areEqual( '#E74C3C', firstColorBox.getAttribute( 'data-value' ), 'Order is incorrect.' );
 				assert.areEqual( '26', firstColorBox.getAttribute( 'aria-posinset' ), 'Aria-posinset is incorrect.' );
 				assert.areEqual( '28', firstColorBox.getAttribute( 'aria-setsize' ), 'Aria-setsize is incorrect.' );
 
@@ -160,11 +160,11 @@
 
 				firstColorBox = colorHistoryTools.findInPanel( '.cke_colorhistory_row .cke_colorbox', txtColorBtn );
 
-				assert.areEqual( '2ECC71', firstColorBox.getAttribute( 'data-value' ), 'Order is incorrect.' );
+				assert.areEqual( '#2ECC71', firstColorBox.getAttribute( 'data-value' ), 'Order is incorrect.' );
 				assert.areEqual( '26', firstColorBox.getAttribute( 'aria-posinset' ), 'Aria-posinset is incorrect.' );
 				assert.areEqual( '29', firstColorBox.getAttribute( 'aria-setsize' ), 'Aria-setsize is incorrect.' );
 
-				yellowColorBox = colorHistoryTools.findInPanel( '.cke_colorhistory_row [data-value="F1C40F"]', txtColorBtn );
+				yellowColorBox = colorHistoryTools.findInPanel( '.cke_colorhistory_row [data-value="#F1C40F"]', txtColorBtn );
 
 				assert.areEqual( 'Vivid Yellow', yellowColorBox.getAttribute( 'title' ), 'Color label is incorrect.' );
 				assert.areEqual( '28', yellowColorBox.getAttribute( 'aria-posinset' ), 'Aria-posinset is incorrect.' );

--- a/tests/plugins/colorbutton/customcolors.js
+++ b/tests/plugins/colorbutton/customcolors.js
@@ -77,7 +77,7 @@
 				assert.areEqual( '<p><span style="color:#f1c40f">Moo</span></p>', editor.getData(),
 					'Color box from color history should apply color change.' );
 
-				yellowColorBox = colorHistoryTools.findInPanel( ' .cke_colorhistory_row [data-value="F1C40F"]', txtColorBtn );
+				yellowColorBox = colorHistoryTools.findInPanel( ' .cke_colorhistory_row [data-value="#F1C40F"]', txtColorBtn );
 
 				assert.areEqual( 'Vivid Yellow', yellowColorBox.getAttribute( 'title' ), 'Color box label is incorrect.' );
 			} );

--- a/tests/plugins/colorbutton/customcolorsasync.js
+++ b/tests/plugins/colorbutton/customcolorsasync.js
@@ -43,7 +43,7 @@
 
 					assert.areEqual( 2, colorHistoryTools.findInPanel( '.cke_colorhistory_row', txtColorBtn ).getChildCount(),
 						'Row should contain two tiles.' );
-					assert.areEqual( 'FF00FF', colorHistoryTools.findInPanel( '.cke_colorhistory_row .cke_colorbox', txtColorBtn )
+					assert.areEqual( '#ff00ff', colorHistoryTools.findInPanel( '.cke_colorhistory_row .cke_colorbox', txtColorBtn )
 						.getAttribute( 'data-value' ), 'New color should be displayed first.' );
 				} );
 		},
@@ -65,7 +65,7 @@
 				.then( function( bot ) {
 					var txtColorBtn = bot.editor.ui.get( 'TextColor' );
 
-					assert.areEqual( '00FF00',
+					assert.areEqual( '#00ff00',
 						colorHistoryTools.findInPanel( '.cke_colorhistory_row .cke_colorbox', txtColorBtn ).getAttribute( 'data-value' ),
 						'Last chosen color should be displayed first.' );
 				} );
@@ -102,12 +102,12 @@
 
 					assert.areEqual( 4, colorHistoryRow.getChildCount(), 'There shouldn\'t be more colors in history than allowed limit.' );
 
-					firstTile = colorHistoryRow.findOne( '[data-value="888888"]' );
+					firstTile = colorHistoryRow.findOne( '[data-value="#888888"]' );
 
 					assert.areEqual( '26', firstTile.getAttribute( 'aria-posinset' ), 'Aria-posinset is incorrect.' );
 					assert.areEqual( '30', firstTile.getAttribute( 'aria-setsize' ), 'Aria-setsize is incorrect.' );
 
-					thirdTile = colorHistoryRow.findOne( '[data-value="22AAFF"]' );
+					thirdTile = colorHistoryRow.findOne( '[data-value="#22aaff"]' );
 
 					assert.areEqual( '28', thirdTile.getAttribute( 'aria-posinset' ), 'Aria-posinset is incorrect.' );
 					assert.areEqual( '30', thirdTile.getAttribute( 'aria-setsize' ), 'Aria-setsize is incorrect.' );
@@ -146,12 +146,12 @@
 
 					assert.areEqual( 4, firstHistoryRow.getChildCount(), 'There shouldn\'t be more colors in row than allowed limit.' );
 
-					firstTile = firstHistoryRow.findOne( '[data-value="888888"]' );
+					firstTile = firstHistoryRow.findOne( '[data-value="#888888"]' );
 
 					assert.areEqual( '26', firstTile.getAttribute( 'aria-posinset' ), 'Aria-posinset of 1st box is incorrect.' );
 					assert.areEqual( '31', firstTile.getAttribute( 'aria-setsize' ), 'Aria-setsize of 1st box is incorrect.' );
 
-					fifthTile = colorHistoryTools.findInPanel( '[data-value="00FF00"]', txtColorBtn );
+					fifthTile = colorHistoryTools.findInPanel( '[data-value="#00ff00"]', txtColorBtn );
 
 					assert.areEqual( '30', fifthTile.getAttribute( 'aria-posinset' ), 'Aria-posinset of 5th box is incorrect.' );
 					assert.areEqual( '31', fifthTile.getAttribute( 'aria-setsize' ), 'Aria-setsize of 5th is incorrect.' );

--- a/tests/plugins/colorbutton/highlightedcolor.js
+++ b/tests/plugins/colorbutton/highlightedcolor.js
@@ -82,6 +82,42 @@
 			bgColorBtn.click( editor );
 
 			wait();
+		},
+
+		// (#4592)
+		'test highlighted color with background color button and no color applied to the selection': function() {
+			var editor = this.editor,
+				bgColorBtn = editor.ui.get( 'BGColor' );
+
+			resume( function() {
+				assertSelectedAutomaticColor( bgColorBtn );
+			} );
+
+			bender.tools.selection.setWithHtml( editor, '<p>{Moo}</p>' );
+			bgColorBtn.click( editor );
+
+			wait();
+		},
+
+		// (#4592)
+		'test highlighted color with text color button and no color applied to the selection': function() {
+			var editor = this.editor,
+				textColorBtn = editor.ui.get( 'TextColor' );
+
+			resume( function() {
+				assertSelectedAutomaticColor( textColorBtn );
+			} );
+
+			bender.tools.selection.setWithHtml( editor, '<p>{Moo}</p>' );
+			textColorBtn.click( editor );
+
+			wait();
 		}
 	} );
+
+	// For now the best way to detect automatic color selection is checking if any color box seems to be selected.
+	// If not, it's automatic, duh. This should be changed after #4725 is fixed.
+	function assertSelectedAutomaticColor( colorButton ) {
+		assert.areSame( 0, colorButton._.panel.getBlock( colorButton._.id ).element.find( '[aria-selected=true]' ).count() );
+	}
 } )();

--- a/tests/plugins/colorbutton/manual/automaticcolorhighlight.html
+++ b/tests/plugins/colorbutton/manual/automaticcolorhighlight.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>Please, whatever you do, DO NOT release Zalgo…!</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/automaticcolorhighlight.md
+++ b/tests/plugins/colorbutton/manual/automaticcolorhighlight.md
@@ -1,0 +1,11 @@
+@bender-tags: bug, 4.17.0, 4592
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, sourcearea
+@bender-ui: collapsed
+
+1. Place selection inside the editor.
+2. Press "Text Color" button.
+
+	**Expected:** "Automatic" color is selected.
+
+	**Unexpected:** Some other color (e.g. black or white) is selected.
+3. Repeat the procedure for "Background Color" button.

--- a/tests/plugins/colorbutton/manual/colorbox.html
+++ b/tests/plugins/colorbutton/manual/colorbox.html
@@ -11,6 +11,6 @@
 <script>
 	CKEDITOR.replace( 'standard' );
 	CKEDITOR.replace( 'custom', {
-		colorButton_colors: 'A proper label/FF9900,FontColor2/Red,0F0'
+		colorButton_colors: 'A proper label/FF9900,FontColor2/F00,0F0'
 	} );
 </script>

--- a/tests/plugins/colorbutton/manual/colorbox.html
+++ b/tests/plugins/colorbutton/manual/colorbox.html
@@ -1,0 +1,16 @@
+<h2>Standard color pallette</h2>
+<div id="standard">
+	<p>Comandeer is the best!</p>
+</div>
+
+<h2>Custom color pallette</h2>
+<div id="custom">
+	<p>Comandeer is the best!</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'standard' );
+	CKEDITOR.replace( 'custom', {
+		colorButton_colors: 'A proper label/FF9900,FontColor2/Red,0F0'
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/colorbox.md
+++ b/tests/plugins/colorbutton/manual/colorbox.md
@@ -1,0 +1,27 @@
+@bender-tags: feature, 4.17.0, 4592
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, sourcearea
+@bender-ui: collapsed
+
+Do following steps for both text color button and background color button in both editors.
+
+1. Select some text in the editor.
+2. Click button.
+
+	**Expected:** Colors are rendered correctly.
+
+	**Unexpected:** Colors are not rendered.
+3. Hover any color until tooltip shows up.
+
+	**Expected:** Correct label is displayed in the tooltip.
+
+	**Unexpected:** `[object Object]` is displayed in the tooltip.
+4. Click any color to apply it.
+
+	**Expected:** Color is applied correctly.
+
+	**Unexpected:** Color is not applied.
+5. Click button.
+
+	**Expected:** The applied color is rendered in the color history.
+
+	**Unexpected:** The applied color is not rendered in the color history.

--- a/tests/plugins/colorbutton/manual/colorbox.md
+++ b/tests/plugins/colorbutton/manual/colorbox.md
@@ -22,6 +22,6 @@ Do following steps for both text color button and background color button in bot
 	**Unexpected:** Color is not applied.
 5. Click button.
 
-	**Expected:** The applied color is rendered in the color history.
+	**Expected:** The applied color is rendered in the color history. The correct color box is selected.
 
-	**Unexpected:** The applied color is not rendered in the color history.
+	**Unexpected:** The applied color is not rendered in the color history. The correct color box is not selected.

--- a/tests/plugins/colorbutton/manual/colorhistory/nonhexvalues.html
+++ b/tests/plugins/colorbutton/manual/colorhistory/nonhexvalues.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>Hello, there!</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/colorbutton/manual/colorhistory/nonhexvalues.md
+++ b/tests/plugins/colorbutton/manual/colorhistory/nonhexvalues.md
@@ -1,0 +1,19 @@
+@bender-tags: 4.17.0, bug, 4333
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea, removeformat, undo
+
+1. Click on "Text Color" button.
+2. Click "More colors" button.
+3. Type `red` in the color input.
+4. Press "OK".
+5. Press "Text Color" button.
+
+	**Expected:** Color history contains red box.
+
+	**Unexpected:** Color history contains transparent box or more than one red box.
+6. Repeat with other values:
+	* `rgb( 255, 0, 0 )`
+	* `rgba( 255, 0, 0, 1 )`
+	* `hsl( 0, 100%, 50% )`
+	* `hsla( 0, 100%, 50%, 1 )`
+7. Repeat in inline editor.

--- a/tests/plugins/colordialog/colordialog.js
+++ b/tests/plugins/colordialog/colordialog.js
@@ -103,9 +103,7 @@
 			} );
 		},
 
-		// (#4351)
-		// This particular value should be _broken_ until the whole flow is fixed in #4592.
-		// Otherwise automatic values in colorbutton become broken.
+		// (#4351, #4592)
 		'test converting transparent value to hex color': function() {
 			colorTools.assertSettingAndGettingColor( this.editor, {
 				inputColor: 'rgba(0,0,0,0)',

--- a/tests/plugins/colordialog/colordialog.js
+++ b/tests/plugins/colordialog/colordialog.js
@@ -109,7 +109,7 @@
 		'test converting transparent value to hex color': function() {
 			colorTools.assertSettingAndGettingColor( this.editor, {
 				inputColor: 'rgba(0,0,0,0)',
-				expectedColor: '#rgba(0, 0, 0, 0)',
+				expectedColor: '',
 				button: 'TextColor'
 			} );
 		}


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Fixed Issues:

* [#4333](https://github.com/ckeditor/ckeditor4/issues/4333): Fixed: [Color Button](https://ckeditor.com/cke4/addon/colorbutton) history does not render correctly colors passed in non-hex format.

API Changes:

* [#4726](https://github.com/ckeditor/ckeditor4/issues/4726): Added `options` parameter to both [`CKEDITOR.tools.color#getHex()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_color.html#method-getHex) and [`CKEDITOR.tools.color#getHexWithAlpha()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools_color.html#method-getHexWithAlpha) methods with `options.shorten` property to allow getting short hex from the given color.
```

## What changes did you make?

I've used `CKEDITOR.tools.color` wherever it was possible. Some places still need some love and refactor, but I'm not sure if it's worth it.

I've also introduced the ability to get short hex from `CKEDITOR.tools.color#getHex()` and `CKEDITOR.tools.color#getHexWithAlpha()` via a new parameter, `shorten`. However I'm not sure if it wouldn't be better to introduce `options` parameter. It would be more flexible 🤔

I've also changed the way in which colors in Color History are rendered.

## Which issues does your PR resolve?

Closes #4592.
Closes #4726.
Closes #4333.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
