### PR TITLE
Enable paste images as base64 from clipboard.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Features:
 
 * [#4461](https://github.com/ckeditor/ckeditor4/issues/4461): Introduced possibility to delay editor initialization while it is in detached DOM element.
 * [#4462](https://github.com/ckeditor/ckeditor4/issues/4462): Added support for editor functions after reattaching its element to DOM.
+* [#4612](https://github.com/ckeditor/ckeditor4/issues/4612): Allow pasting images as Base64 from [clipboard](https://ckeditor.com/cke4/addon/clipboard) in all browsers except IE.
 
 Fixed Issues:
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -147,7 +147,7 @@
 			CKEDITOR.dialog.add( 'paste', CKEDITOR.getUrl( this.path + 'dialogs/paste.js' ) );
 
 			// Convert image file (if present) to base64 string for modern browsers except IE (#4612).
-            // Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
+			// Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
 			if ( !CKEDITOR.env.ie ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],
 				latestId;
@@ -166,18 +166,18 @@
 
 						// Convert image file to img tag with base64 image.
 							fileReader.addEventListener( 'load', function() {
-							evt.data.dataValue = '<img src="' + fileReader.result + '" />';
-							editor.fire( 'paste', evt.data );
+								evt.data.dataValue = '<img src="' + fileReader.result + '" />';
+								editor.fire( 'paste', evt.data );
 							}, false );
 
 						// Proceed with normal flow if reading file was aborted.
 							fileReader.addEventListener( 'abort', function() {
-							editor.fire( 'paste', evt.data );
+								editor.fire( 'paste', evt.data );
 							}, false );
 
 						// Proceed with normal flow if reading file failed.
 							fileReader.addEventListener( 'error', function() {
-							editor.fire( 'paste', evt.data );
+								editor.fire( 'paste', evt.data );
 							}, false );
 
 							fileReader.readAsDataURL( file );

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -148,7 +148,7 @@
 
 			// Convert image file (if present) to base64 string for modern browsers except IE (#4612).
 			// Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
-			if ( !CKEDITOR.env.ie ) {
+			if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],
 					latestId;
 

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -150,12 +150,12 @@
 			// Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
 			if ( !CKEDITOR.env.ie ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],
-				latestId;
+					latestId;
 
 				editor.on( 'paste', function( evt ) {
 					var dataObj = evt.data,
-					data = dataObj.dataValue,
-					dataTransfer = dataObj.dataTransfer;
+						data = dataObj.dataValue,
+						dataTransfer = dataObj.dataTransfer;
 
 					// If data empty check for image content inside data transfer. https://dev.ckeditor.com/ticket/16705
 					if ( !data && dataObj.method == 'paste' && isFileData( dataTransfer ) ) {

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -157,25 +157,25 @@
 					data = dataObj.dataValue,
 					dataTransfer = dataObj.dataTransfer;
 
-				// If data empty check for image content inside data transfer. https://dev.ckeditor.com/ticket/16705
+					// If data empty check for image content inside data transfer. https://dev.ckeditor.com/ticket/16705
 					if ( !data && dataObj.method == 'paste' && isFileData( dataTransfer ) ) {
 						var file = dataTransfer.getFile( 0 );
 
 						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) != -1 ) {
 							var fileReader = new FileReader();
 
-						// Convert image file to img tag with base64 image.
+							// Convert image file to img tag with base64 image.
 							fileReader.addEventListener( 'load', function() {
 								evt.data.dataValue = '<img src="' + fileReader.result + '" />';
 								editor.fire( 'paste', evt.data );
 							}, false );
 
-						// Proceed with normal flow if reading file was aborted.
+							// Proceed with normal flow if reading file was aborted.
 							fileReader.addEventListener( 'abort', function() {
 								editor.fire( 'paste', evt.data );
 							}, false );
 
-						// Proceed with normal flow if reading file failed.
+							// Proceed with normal flow if reading file failed.
 							fileReader.addEventListener( 'error', function() {
 								editor.fire( 'paste', evt.data );
 							}, false );

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -146,7 +146,8 @@
 
 			CKEDITOR.dialog.add( 'paste', CKEDITOR.getUrl( this.path + 'dialogs/paste.js' ) );
 
-			// Convert image file (if present) to base64 string for modern browsers except IE (#4612).
+			// Convert image file (if present) to base64 string for modern browsers except IE, as it does not support
+			// custom MIME types in clipboard (#4612).
 			// Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
 			if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -146,38 +146,38 @@
 
 			CKEDITOR.dialog.add( 'paste', CKEDITOR.getUrl( this.path + 'dialogs/paste.js' ) );
 
-			// Convert image file (if present) to base64 string for Firefox. Do it as the first
-			// step as the conversion is asynchronous and should hold all further paste processing.
-			if ( CKEDITOR.env.gecko ) {
+			// Convert image file (if present) to base64 string for modern browsers except IE (#4612).
+            // Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
+			if ( !CKEDITOR.env.ie ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],
-					latestId;
+				latestId;
 
 				editor.on( 'paste', function( evt ) {
 					var dataObj = evt.data,
-						data = dataObj.dataValue,
-						dataTransfer = dataObj.dataTransfer;
+					data = dataObj.dataValue,
+					dataTransfer = dataObj.dataTransfer;
 
-					// If data empty check for image content inside data transfer. https://dev.ckeditor.com/ticket/16705
+				// If data empty check for image content inside data transfer. https://dev.ckeditor.com/ticket/16705
 					if ( !data && dataObj.method == 'paste' && isFileData( dataTransfer ) ) {
 						var file = dataTransfer.getFile( 0 );
 
 						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) != -1 ) {
 							var fileReader = new FileReader();
 
-							// Convert image file to img tag with base64 image.
+						// Convert image file to img tag with base64 image.
 							fileReader.addEventListener( 'load', function() {
-								evt.data.dataValue = '<img src="' + fileReader.result + '" />';
-								editor.fire( 'paste', evt.data );
+							evt.data.dataValue = '<img src="' + fileReader.result + '" />';
+							editor.fire( 'paste', evt.data );
 							}, false );
 
-							// Proceed with normal flow if reading file was aborted.
+						// Proceed with normal flow if reading file was aborted.
 							fileReader.addEventListener( 'abort', function() {
-								editor.fire( 'paste', evt.data );
+							editor.fire( 'paste', evt.data );
 							}, false );
 
-							// Proceed with normal flow if reading file failed.
+						// Proceed with normal flow if reading file failed.
 							fileReader.addEventListener( 'error', function() {
-								editor.fire( 'paste', evt.data );
+							editor.fire( 'paste', evt.data );
 							}, false );
 
 							fileReader.readAsDataURL( file );

--- a/tests/plugins/clipboard/manual/pasteimage.html
+++ b/tests/plugins/clipboard/manual/pasteimage.html
@@ -5,7 +5,6 @@
 <script>
 	var editor = CKEDITOR.replace( 'editor' );
 	editor.on( 'loaded', function() {
-		// (#4612).
 		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 			bender.ignore();
 		}

--- a/tests/plugins/clipboard/manual/pasteimage.html
+++ b/tests/plugins/clipboard/manual/pasteimage.html
@@ -3,7 +3,7 @@
 </div>
 
 <script>
-	if ( !CKEDITOR.env.gecko ) {
+	if ( CKEDITOR.env.ie ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/clipboard/manual/pasteimage.html
+++ b/tests/plugins/clipboard/manual/pasteimage.html
@@ -3,9 +3,11 @@
 </div>
 
 <script>
-	if ( CKEDITOR.env.ie ) {
-		bender.ignore();
-	}
-
-	CKEDITOR.replace( 'editor' );
+	var editor = CKEDITOR.replace( 'editor' );
+	editor.on( 'loaded', function() {
+		// (#4612).
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+			bender.ignore();
+		}
+	} );
 </script>

--- a/tests/plugins/clipboard/manual/pasteimage.md
+++ b/tests/plugins/clipboard/manual/pasteimage.md
@@ -1,5 +1,5 @@
 @bender-ui: collapsed
-@bender-tags: 4.6.2, 4.17.0, bug, clipboard, 3757
+@bender-tags: 4.6.2, 4.17.0, bug, clipboard, 3757, 4612
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles, image, clipboard, sourcearea
 
 ## Scenario:

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -82,7 +82,8 @@
 
 	bender.test( {
 		setUp: function() {
-			if ( CKEDITOR.env.ie ) {
+			// (#4612).
+			if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
 				assert.ignore();
 			}
 			FileReader.setFileMockType();

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -82,7 +82,7 @@
 
 	bender.test( {
 		setUp: function() {
-			if ( !CKEDITOR.env.gecko ) {
+			if ( CKEDITOR.env.ie ) {
 				assert.ignore();
 			}
 			FileReader.setFileMockType();
@@ -94,54 +94,54 @@
 			FileReader.setFileMockType( 'image/png' );
 			FileReader.setReadResult( 'load' );
 
-			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here: {}</p>' );
+			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
 			this.assertPaste( 'image/png',
-				'<p>Paste image here: <img data-cke-saved-src="data:image/png;base64,fileMockBase64=" src="data:image/png;base64,fileMockBase64=" />^@</p>' );
+				'<p>Paste image here:<img data-cke-saved-src="data:image/png;base64,fileMockBase64=" src="data:image/png;base64,fileMockBase64=" />^@</p>' );
 		},
 
 		'test paste .jpeg from clipboard': function() {
 			FileReader.setFileMockType( 'image/jpeg' );
 			FileReader.setReadResult( 'load' );
 
-			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here: {}</p>' );
+			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
 			this.assertPaste( 'image/jpeg',
-				'<p>Paste image here: <img data-cke-saved-src="data:image/jpeg;base64,fileMockBase64=" src="data:image/jpeg;base64,fileMockBase64=" />^@</p>' );
+				'<p>Paste image here:<img data-cke-saved-src="data:image/jpeg;base64,fileMockBase64=" src="data:image/jpeg;base64,fileMockBase64=" />^@</p>' );
 		},
 
 		'test paste .gif from clipboard': function() {
 			FileReader.setFileMockType( 'image/gif' );
 			FileReader.setReadResult( 'load' );
 
-			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here: {}</p>' );
+			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
 			this.assertPaste( 'image/gif',
-				'<p>Paste image here: <img data-cke-saved-src="data:image/gif;base64,fileMockBase64=" src="data:image/gif;base64,fileMockBase64=" />^@</p>' );
+				'<p>Paste image here:<img data-cke-saved-src="data:image/gif;base64,fileMockBase64=" src="data:image/gif;base64,fileMockBase64=" />^@</p>' );
 		},
 
 		'test unsupported file type': function() {
 			FileReader.setFileMockType( 'application/pdf' );
 			FileReader.setReadResult( 'load' );
 
-			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here: {}</p>' );
+			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
 			this.assertPaste( 'application/pdf',
-				'<p>Paste image here: ^@</p>' );
+				'<p>Paste image here:^@</p>' );
 		},
 
 		'test aborted paste': function() {
 			FileReader.setFileMockType( 'image/png' );
 			FileReader.setReadResult( 'abort' );
 
-			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here: {}</p>' );
+			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
 			this.assertPaste( 'image/png',
-				'<p>Paste image here: ^@</p>' );
+				'<p>Paste image here:^@</p>' );
 		},
 
 		'test failed paste': function() {
 			FileReader.setFileMockType( 'image/png' );
 			FileReader.setReadResult( 'error' );
 
-			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here: {}</p>' );
+			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
 			this.assertPaste( 'image/png',
-				'<p>Paste image here: ^@</p>' );
+				'<p>Paste image here:^@</p>' );
 		},
 
 		// (#3585, #3625)


### PR DESCRIPTION
## What is the purpose of this pull request?

 New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4612](https://github.com/ckeditor/ckeditor4/issues/4612): Allow pasting images as Base64 in all browsers
```

## What changes did you make?

Enabling pasting images as base64 from clipboard in all browsers(before it was work only in Firefox) except IE's.

Only in Safari, the unit tests failed because there was a whitespace problem. 
This is probably some kind of browser normalization. In testing combined with pasting an image, I removed all white spaces to test properly in Safari and other browsers. 
This test does not check the correctness of white space, but pasting an image, so we can changed it.

## Which issues does your PR resolve?

Closes #4612.
