### PR TITLE
Skip a11ydivarea manual test on mobile

### DIFF
--- a/tests/plugins/autocomplete/manual/a11ydivarea.html
+++ b/tests/plugins/autocomplete/manual/a11ydivarea.html
@@ -5,7 +5,7 @@
 </div>
 
 <script>
-	// (4712).
+	// (#4712).
 	if ( bender.tools.env.mobile ) {
 		bender.ignore();
 	}

--- a/tests/plugins/autocomplete/manual/a11ydivarea.html
+++ b/tests/plugins/autocomplete/manual/a11ydivarea.html
@@ -5,6 +5,7 @@
 </div>
 
 <script>
+	// (4712).
 	if ( bender.tools.env.mobile ) {
 		bender.ignore();
 	}

--- a/tests/plugins/autocomplete/manual/a11ydivarea.html
+++ b/tests/plugins/autocomplete/manual/a11ydivarea.html
@@ -5,6 +5,10 @@
 </div>
 
 <script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+	
 	bender.tools.ignoreUnsupportedEnvironment( 'autocomplete' );
 
 	CKEDITOR.replace( 'editor1', {


### PR DESCRIPTION
## What is the purpose of this pull request?

Failing mobile test.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

skip

## What changes did you make?

Skipped mobile manual test that cannot be reproduced on mobile. 
* `tests/plugins/autocomplete/manual/a11ydivarea`

## Which issues does your PR resolve?

Closes [#4712](https://github.com/ckeditor/ckeditor4/issues/4712).