### PR TITLE
When using bbcode tags not terminated it fails

### DIFF
--- a/plugins/bbcode/plugin.js
+++ b/plugins/bbcode/plugin.js
@@ -340,39 +340,41 @@
 				newPendingInline = [],
 				candidate = currentNode;
 
-			while ( candidate.type && candidate.name != tagName ) {
-				// If this is an inline element, add it to the pending list, if we're
-				// really closing one of the parents element later, they will continue
-				// after it.
-				if ( !candidate._.isBlockLike )
-					newPendingInline.unshift( candidate );
-
-				// This node should be added to it's parent at this point. But,
-				// it should happen only if the closing tag is really closing
-				// one of the nodes. So, for now, we just cache it.
-				pendingAdd.push( candidate );
-
-				candidate = candidate.parent;
-			}
-
-			if ( candidate.type ) {
-				// Add all elements that have been found in the above loop.
-				for ( i = 0; i < pendingAdd.length; i++ ) {
-					var node = pendingAdd[ i ];
-					addElement( node, node.parent );
+			if (candidate ==!null) {
+				while ( candidate.type && candidate.name != tagName ) {
+					// If this is an inline element, add it to the pending list, if we're
+					// really closing one of the parents element later, they will continue
+					// after it.
+					if ( !candidate._.isBlockLike )
+						newPendingInline.unshift( candidate );
+	
+					// This node should be added to it's parent at this point. But,
+					// it should happen only if the closing tag is really closing
+					// one of the nodes. So, for now, we just cache it.
+					pendingAdd.push( candidate );
+	
+					candidate = candidate.parent;
 				}
-
-				currentNode = candidate;
-
-
-				addElement( candidate, candidate.parent );
-
-				// The parent should start receiving new nodes now, except if
-				// addElement changed the currentNode.
-				if ( candidate == currentNode )
-					currentNode = currentNode.parent;
-
-				pendingInline = pendingInline.concat( newPendingInline );
+	
+				if ( candidate.type ) {
+					// Add all elements that have been found in the above loop.
+					for ( i = 0; i < pendingAdd.length; i++ ) {
+						var node = pendingAdd[ i ];
+						addElement( node, node.parent );
+					}
+	
+					currentNode = candidate;
+	
+	
+					addElement( candidate, candidate.parent );
+	
+					// The parent should start receiving new nodes now, except if
+					// addElement changed the currentNode.
+					if ( candidate == currentNode )
+						currentNode = currentNode.parent;
+	
+					pendingInline = pendingInline.concat( newPendingInline );
+				}
 			}
 		};
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

It's related to this issue : https://github.com/ckeditor/ckeditor4/issues/4730

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ x ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4730](https://github.com/ckeditor/ckeditor4/issues/4730): Workaround to avoid the editor fails completly when the bbcode aren't terminated
```

## What changes did you make?

*Give an overview…*

## Which issues does your PR resolve?

Closes #<ISSUE_NUMBER>.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
