### PR TITLE
Switch CI testing to benderjs runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ git:
   depth: false
 
 env:
-  - FULL_RUN=$(if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then echo "fullRun"; else echo ""; fi)
+  - FULL_RUN=fullRun
+  #- FULL_RUN=$(if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then echo "fullRun"; else echo ""; fi)
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ node_js: 10
 git:
   depth: false
 
+env:
+  - FULL_RUN=$(if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then echo "fullRun"; else echo ""; fi)
+
 jobs:
   include:
     - name: Chrome (Linux)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ git:
   depth: false
 
 env:
-  - FULL_RUN=fullRun
-  #- FULL_RUN=$(if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then echo "fullRun"; else echo ""; fi)
+  - FULL_RUN=$(if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then echo "fullRun"; else echo ""; fi)
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       script:
         - pwd
         - echo "Running tests based on diff between $TARGET_BRANCH and $CURRENT_BRANCH"
-        - npm run start "../../ckeditor4-benderjs-runner-tests/bender-runner.config.json" "$TARGET_BRANCH" "$CURRENT_BRANCH" "chrome" $FULL_RUN
+        - npm run start "../../ckeditor4/bender-runner.config.json" "$TARGET_BRANCH" "$CURRENT_BRANCH" "chrome" $FULL_RUN
 
     - name: Firefox (Linux)
       services:
@@ -76,4 +76,4 @@ jobs:
       script:
         - pwd
         - echo "Running tests based on diff between $TARGET_BRANCH and $CURRENT_BRANCH"
-        - npm run start "../../ckeditor4-benderjs-runner-tests/bender-runner.config.json" "$TARGET_BRANCH" "$CURRENT_BRANCH" "firefox" $FULL_RUN
+        - npm run start "../../ckeditor4/bender-runner.config.json" "$TARGET_BRANCH" "$CURRENT_BRANCH" "firefox" $FULL_RUN

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ jobs:
         - pwd
         - git clone https://github.com/ckeditor/ckeditor4-benderjs-runner.git
         - cd ckeditor4-benderjs-runner
-        - git checkout t/1
         - npm i
       script:
         - pwd
@@ -73,7 +72,6 @@ jobs:
         - pwd
         - git clone https://github.com/ckeditor/ckeditor4-benderjs-runner.git
         - cd ckeditor4-benderjs-runner
-        - git checkout t/1
         - npm i
       script:
         - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-sudo: required
+os: linux
 dist: xenial
-services:
-  - xvfb
 
 branches:
   only:
@@ -13,32 +11,71 @@ branches:
   - /^release\/\d+\.\d+\.x$/
 
 language: node_js
+node_js: 10
 
-node_js:
-  - 10
+git:
+  depth: false
 
-env:
-  - BUILD=0 BROWSER=Chrome
-  - BUILD=1 BROWSER=Chrome
-  - BUILD=0 BROWSER=Firefox MOZ_HEADLESS=1
-  - BUILD=1 BROWSER=Firefox MOZ_HEADLESS=1
+jobs:
+  include:
+    - name: Chrome (Linux)
+      services:
+        - xvfb
+      addons:
+        chrome: stable
+      before_script:
+        # Setup xvfb
+        - 'export DISPLAY=:99.0'
+        - 'sleep 3'
+        # Define target branches
+        - TARGET_BRANCH="origin/$TRAVIS_BRANCH"
+        - CURRENT_BRANCH="origin/$TRAVIS_PULL_REQUEST_BRANCH"
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+               sh -e TARGET_BRANCH="origin/HEAD^" && CURRENT_BRANCH="origin/HEAD";
+          fi'
+        # Setup CKEditor 4 testing environment
+        - pwd
+        - npm install benderjs-cli -g
+        - npm i
+        # Setup bender test runner
+        - cd ..
+        - pwd
+        - git clone https://github.com/ckeditor/ckeditor4-benderjs-runner.git
+        - cd ckeditor4-benderjs-runner
+        - git checkout t/1
+        - npm i
+      script:
+        - pwd
+        - echo "Running tests based on diff between $TARGET_BRANCH and $CURRENT_BRANCH"
+        - npm run start "../../ckeditor4-benderjs-runner-tests/bender-runner.config.json" "$TARGET_BRANCH" "$CURRENT_BRANCH" "chrome" $FULL_RUN
 
-addons:
-  firefox: "latest"
-  chrome: stable
-
-before_script:
-  # Prepare environment.
-  - 'npm install benderjs-cli -g'
-  - 'export DISPLAY=:99.0'
-  - 'sleep 3'
-
-  # The $TRAVIS_BRANCH points to target branch for PRs and for other branches it is the current branch name.
-  - 'BUILD_PATH=0'
-  - 'if [ "$BUILD" = "1" ] && ( [ "$TRAVIS_BRANCH" = "master" ] || [ "$TRAVIS_BRANCH" = "major" ] ); then
-        sh -e ./dev/travis/build.sh $TRAVIS_BRANCH && BUILD_PATH="$(sh -e ./dev/travis/buildpath.sh)";
-    fi'
-
-script:
-  - 'if [ "$BUILD" = "0" ]; then bender run -c bender.ci.js; fi'
-  - 'if [ "$BUILD" = "1" ] && [ "$BUILD_PATH" != "0" ]; then cd $BUILD_PATH && bender run -c bender.ci.js; fi'
+    - name: Firefox (Linux)
+      services:
+        - xvfb
+      addons:
+        firefox: latest
+      before_script:
+        # Setup xvfb
+        - 'export DISPLAY=:99.0'
+        - 'sleep 3'
+        # Define target branches
+        - TARGET_BRANCH="origin/$TRAVIS_BRANCH"
+        - CURRENT_BRANCH="origin/$TRAVIS_PULL_REQUEST_BRANCH"
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+               sh -e TARGET_BRANCH="origin/HEAD^" && CURRENT_BRANCH="origin/HEAD";
+          fi'
+        # Setup CKEditor 4 testing environment
+        - pwd
+        - npm install benderjs-cli -g
+        - npm i
+        # Setup bender test runner
+        - cd ..
+        - pwd
+        - git clone https://github.com/ckeditor/ckeditor4-benderjs-runner.git
+        - cd ckeditor4-benderjs-runner
+        - git checkout t/1
+        - npm i
+      script:
+        - pwd
+        - echo "Running tests based on diff between $TARGET_BRANCH and $CURRENT_BRANCH"
+        - npm run start "../../ckeditor4-benderjs-runner-tests/bender-runner.config.json" "$TARGET_BRANCH" "$CURRENT_BRANCH" "firefox" $FULL_RUN

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
       addons:
         chrome: stable
       before_script:
+        - echo $TRAVIS_EVENT_TYPE
         # Setup xvfb
         - 'export DISPLAY=:99.0'
         - 'sleep 3'
@@ -54,6 +55,7 @@ jobs:
       addons:
         firefox: latest
       before_script:
+        - echo $TRAVIS_EVENT_TYPE
         # Setup xvfb
         - 'export DISPLAY=:99.0'
         - 'sleep 3'

--- a/bender-runner.config.json
+++ b/bender-runner.config.json
@@ -1,0 +1,15 @@
+{
+  "bender": {
+    "port": 9001
+  },
+  "server": {
+    "port": 9002
+  },
+  "paths": {
+    "ckeditor4": "../ckeditor4-benderjs-runner-tests/",
+    "runner": "./src/runner.html"
+  },
+  "browsers": {
+    "linux": [ "chrome", "firefox" ]
+  }
+}

--- a/bender-runner.config.json
+++ b/bender-runner.config.json
@@ -6,7 +6,7 @@
     "port": 9002
   },
   "paths": {
-    "ckeditor4": "../ckeditor4-benderjs-runner-tests/",
+    "ckeditor4": "../ckeditor4/",
     "runner": "./src/runner.html"
   },
   "browsers": {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Skip.
```

## What changes did you make?

This PR switches our Travis job to custom benderjs/browser launcher. The main purpose and motivation was to allow testing on browser launched by any 3rd-party mechanism instead of benderjs build-in browser launcher outdated and not really working dependency.

The full description how it works can be read here: https://github.com/ckeditor/ckeditor4-benderjs-runner#ckeditor-4-bender-runner.

It was already tested with a fork of `ckeditor4` repository in https://github.com/ckeditor/ckeditor4-benderjs-runner-tests/pull/3.

## Which issues does your PR resolve?

Closes #4630.
Closes ckeditor/ckeditor4-benderjs-runner#2.
Closes ckeditor/ckeditor4-benderjs-runner-tests#3.
