### PR TITLE
Fix incorrect nesting of font styles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixed Issues:
 	* [#641](https://github.com/ckeditor/ckeditor4/issues/641): Fixed: UploadImage Plugin Widgets not working in IE, Opera, Safari, PhantomJS.
 * [#3638](https://github.com/ckeditor/ckeditor4/issues/3638): Fixed: Opening the same dialog twice causes it to become hidden under the dialog's page cover.
 * [#4247](https://github.com/ckeditor/ckeditor4/issues/4247): Fixed: [Color Button](https://ckeditor.com/cke4/addon/colorbutton)'s incorrect rendering on the first opening.
+* [#4555](https://github.com/ckeditor/ckeditor4/issues/4555): Fixed: [Font](https://ckeditor.com/cke4/addon/font) styles with attributes are not applied correctly when used multiple times over the same selection.
 
 ## CKEditor 4.16.1
 

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -263,7 +263,37 @@
 			return false;
 		}
 
-		return CKEDITOR.style.getStyleText( styleA.getDefinition() ) === CKEDITOR.style.getStyleText( styleB.getDefinition() );
+		var hasEqualAttributes = compareAttributes( styleA, styleB ),
+			hasEqualStyles = compareStyles( styleA, styleB );
+
+		return hasEqualAttributes && hasEqualStyles;
+
+		function compareAttributes( styleA, styleB ) {
+			var styleADefinition = styleA.getDefinition(),
+				styleBDefinition = styleB.getDefinition(),
+				styleAAttributes = CKEDITOR.tools.object.entries( styleADefinition.attributes ),
+				styleBAttributes = CKEDITOR.tools.object.entries( styleBDefinition.attributes );
+
+			if ( styleAAttributes.length !== styleBAttributes.length ) {
+				return false;
+			}
+
+			return CKEDITOR.tools.array.every( styleAAttributes, function( attributeA, i ) {
+				var attributeB = styleBAttributes[ i ],
+					attributeAName = attributeA[ 0 ],
+					attributeAValue = attributeA[ 1 ],
+					attributeBName = attributeB[ 0 ],
+					attributeBValue = attributeB[ 1 ],
+					isSameName = attributeAName === attributeBName,
+					isSameValue = attributeAValue === attributeBValue;
+
+				return isSameName && isSameValue;
+			} );
+		}
+
+		function compareStyles( styleA, styleB ) {
+			return CKEDITOR.style.getStyleText( styleA.getDefinition() ) === CKEDITOR.style.getStyleText( styleB.getDefinition() );
+		}
 	}
 
 	//  * @param {Object} options

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -271,24 +271,10 @@
 		function compareAttributes( styleA, styleB ) {
 			var styleADefinition = styleA.getDefinition(),
 				styleBDefinition = styleB.getDefinition(),
-				styleAAttributes = CKEDITOR.tools.object.entries( styleADefinition.attributes ),
-				styleBAttributes = CKEDITOR.tools.object.entries( styleBDefinition.attributes );
+				styleAAttributes = styleADefinition.attributes,
+				styleBAttributes = styleBDefinition.attributes;
 
-			if ( styleAAttributes.length !== styleBAttributes.length ) {
-				return false;
-			}
-
-			return CKEDITOR.tools.array.every( styleAAttributes, function( attributeA, i ) {
-				var attributeB = styleBAttributes[ i ],
-					attributeAName = attributeA[ 0 ],
-					attributeAValue = attributeA[ 1 ],
-					attributeBName = attributeB[ 0 ],
-					attributeBValue = attributeB[ 1 ],
-					isSameName = attributeAName === attributeBName,
-					isSameValue = attributeAValue === attributeBValue;
-
-				return isSameName && isSameValue;
-			} );
+			return CKEDITOR.tools.objectCompare( styleAAttributes, styleBAttributes );
 		}
 
 		function compareStyles( styleA, styleB ) {

--- a/plugins/font/plugin.js
+++ b/plugins/font/plugin.js
@@ -269,10 +269,8 @@
 		return hasEqualAttributes && hasEqualStyles;
 
 		function compareAttributes( styleA, styleB ) {
-			var styleADefinition = styleA.getDefinition(),
-				styleBDefinition = styleB.getDefinition(),
-				styleAAttributes = styleADefinition.attributes,
-				styleBAttributes = styleBDefinition.attributes;
+			var styleAAttributes = styleA.getDefinition().attributes,
+				styleBAttributes = styleB.getDefinition().attributes;
 
 			return CKEDITOR.tools.objectCompare( styleAAttributes, styleBAttributes );
 		}

--- a/tests/plugins/font/customfontdefinition.js
+++ b/tests/plugins/font/customfontdefinition.js
@@ -7,31 +7,60 @@
 ( function() {
 	'use strict';
 
-	bender.editor = {
-		config: {
-			extraAllowedContent: 'span font(*){*}[*];strong em;',
-			font_style: {
-				element: 'font',
-				attributes: { 'face': '#(family)' },
-				overrides: [ {
-					element: 'font', attributes: { 'face': null }
-				} ]
-			},
-			fontSize_sizes: '1/1;2/2;3/3;4/4;5/5;6/6;7/7;',
-			fontSize_style: {
-				element: 'font',
-				attributes: { 'size': '#(size)' },
-				overrides: [ {
-					element: 'font', attributes: { 'size': null }
-				} ]
+	var classAttributes = {},
+		dataAttributes = {};
+
+	classAttributes[ 'class' ] = '#(size)';
+	dataAttributes[ 'data-font' ] = '#(size)';
+
+	bender.editors = {
+		font: {
+			config: {
+				extraAllowedContent: 'span font(*){*}[*];strong em;',
+				font_style: {
+					element: 'font',
+					attributes: { 'face': '#(family)' },
+					overrides: [ {
+						element: 'font', attributes: { 'face': null }
+					} ]
+				},
+				fontSize_sizes: '1/1;2/2;3/3;4/4;5/5;6/6;7/7;',
+				fontSize_style: {
+					element: 'font',
+					attributes: { 'size': '#(size)' },
+					overrides: [ {
+						element: 'font', attributes: { 'size': null }
+					} ]
+				}
+			}
+		},
+
+		classes: {
+			config: {
+				fontSize_sizes: 'small;medium',
+				fontSize_style: {
+					element: 'span',
+					attributes: classAttributes
+				}
+			}
+		},
+
+		attributes: {
+			config: {
+				extraAllowedContent: 'span[data-font]',
+				fontSize_sizes: 'small;medium',
+				fontSize_style: {
+					element: 'span',
+					attributes: dataAttributes
+				}
 			}
 		}
 	};
 
 	bender.test( {
 		'test setdata with font tag with face': function() {
-			var editor = this.editor,
-				bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bot.setData( '<p><font face="Courier New, Courier, monospace">foo bar baz</font></p>', function() {
 				assert.beautified.html( '<p><font face="Courier New, Courier, monospace">foo bar baz</font></p>', editor.getData() );
@@ -39,8 +68,8 @@
 		},
 
 		'test apply font tag with face': function() {
-			var editor = this.editor,
-				bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
 			richComboTools.assertCombo( {
@@ -53,8 +82,8 @@
 		},
 
 		'test change font tag with face': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p><font face="Arial, Helvetica, sans-serif">[foo]</font></p>' );
 			richComboTools.assertCombo( {
@@ -67,8 +96,8 @@
 		},
 
 		'test remove font tag with face': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p><font face="Courier New, Courier, monospace">[foo]</font></p>' );
 
@@ -82,8 +111,8 @@
 		},
 
 		'test apply font tag with face in nested html': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p><strong>[fo<em>o] bar</em> baz</strong></p>' );
 			richComboTools.assertCombo( {
@@ -96,8 +125,8 @@
 		},
 
 		'test setdata with font tag with size': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bot.setData( '<p><font size="7">foo bar baz</font></p>', function() {
 				assert.beautified.html( '<p><font size="7">foo bar baz</font></p>', editor.getData() );
@@ -105,8 +134,8 @@
 		},
 
 		'test apply font tag with size': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p>[foo]</p>' );
 			richComboTools.assertCombo( {
@@ -119,8 +148,8 @@
 		},
 
 		'test change font tag with size': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p><font size="2">[foo]</font></p>' );
 			richComboTools.assertCombo( {
@@ -133,8 +162,8 @@
 		},
 
 		'test remove font tag with size': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p><font size="6">[foo]</font></p>' );
 			richComboTools.assertCombo( {
@@ -147,8 +176,8 @@
 		},
 
 		'test apply font tag with size in nested html': function() {
-			var editor = this.editor,
-			bot = this.editorBot;
+			var editor = this.editors.font,
+				bot = this.editorBots.font;
 
 			bender.tools.selection.setWithHtml( editor, '<p><strong>[fo<em>o] bar</em> baz</strong></p>' );
 			richComboTools.assertCombo( {
@@ -158,7 +187,36 @@
 				bot: bot,
 				resultHtml: '<p><strong><font size="6">fo</font><em><font size="6">o</font> bar</em> baz</strong>@</p>'
 			} );
+		},
+
+		// (#4555)
+		'test applying font style with class attribute over already applied style with class attribute generates the content with only one font style': function() {
+			var editor = this.editors.classes,
+				bot = this.editorBots.classes;
+
+			bender.tools.selection.setWithHtml( editor, '<p>[<span class="small">foo</span>]</p>' );
+			richComboTools.assertCombo( {
+				comboName: 'FontSize',
+				comboValue: 'medium',
+				collapsed: false,
+				bot: bot,
+				resultHtml: '<p><span class="medium">foo</span>@</p>'
+			} );
+		},
+
+		// (#4555)
+		'test applying font style with custom attribute over already applied style with custom attribute generates the content with only one font style': function() {
+			var editor = this.editors.attributes,
+				bot = this.editorBots.attributes;
+
+			bender.tools.selection.setWithHtml( editor, '<p>[<span data-font="small">foo</span>]</p>' );
+			richComboTools.assertCombo( {
+				comboName: 'FontSize',
+				comboValue: 'medium',
+				collapsed: false,
+				bot: bot,
+				resultHtml: '<p><span data-font="medium">foo</span>@</p>'
+			} );
 		}
 	} );
-
 } )();

--- a/tests/plugins/font/manual/nestingclasses.html
+++ b/tests/plugins/font/manual/nestingclasses.html
@@ -3,14 +3,20 @@
 </div>
 
 <script>
-	CKEDITOR.addCss( '.small{font-size: 8px} .medium{font-size: 16px}' )
+	( function() {
+		var classAttributes = {};
 
-	CKEDITOR.replace( 'editor', {
-		fontSize_sizes: 'small;medium',
-		fontSize_style: {
-			element: 'span',
-			attributes: { class: '#(size)' }
-		}
-	} );
+		classAttributes[ 'class' ] = '#(size)';
+
+		CKEDITOR.addCss( '.small{font-size: 8px} .medium{font-size: 16px}' )
+
+		CKEDITOR.replace( 'editor', {
+			fontSize_sizes: 'small;medium',
+			fontSize_style: {
+				element: 'span',
+				attributes: classAttributes
+			}
+		} );
+	} )();
 </script>
 

--- a/tests/plugins/font/manual/nestingclasses.html
+++ b/tests/plugins/font/manual/nestingclasses.html
@@ -1,0 +1,16 @@
+<div id="editor">
+	<p>Hey, you, yes, you, what are you doing here?</p>
+</div>
+
+<script>
+	CKEDITOR.addCss( '.small{font-size: 8px} .medium{font-size: 16px}' )
+
+	CKEDITOR.replace( 'editor', {
+		fontSize_sizes: 'small;medium',
+		fontSize_style: {
+			element: 'span',
+			attributes: { class: '#(size)' }
+		}
+	} );
+</script>
+

--- a/tests/plugins/font/manual/nestingclasses.md
+++ b/tests/plugins/font/manual/nestingclasses.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.16.2, bug, 4555
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, font, enterkey, elementspath, basicstyles, sourcearea
+
+1. Select all content in the editor.
+2. Apply "small" font size.
+3. Apply "medium" font size.
+
+## Expected result
+
+* The font is visibly bigger after applying medium font size.
+* There is only one `span` element with `[class]` attribute inside the editor's content.
+
+## Unexpected result
+
+* The font size didn't change after applying medium font size.
+* There is more than one `span` element with `[class]` attribute inside the editor's content.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4555](https://github.com/ckeditor/ckeditor4/issues/4555): Fixed: [Font](https://ckeditor.com/cke4/addon/font) styles with attributes are not applied correctly when used multiple times over the same selection.
```

## What changes did you make?

The culprit was the `2dcda53bdcc36793925d6da8cff044e1c01615f5` commit. The brought back `isEqualStyle` function checked only if the styles are the same, ignoring other attributes. So I've added logic to check also other attributes.

## Which issues does your PR resolve?

Closes #4555.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
