### PR TITLE
Allow maximize editor on iOS

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -1607,6 +1607,16 @@
 		 */
 		isDestroyed: function() {
 			return this.status === 'destroyed';
+		},
+
+		/**
+		 * Provides information whether the editor's maximized.
+		 *
+		 * @since 4.17.0
+		 * @return {Boolean} true if editor is maximized.
+		*/
+		isMaximized: function() {
+			return this.getCommand( 'maximize' ).state === CKEDITOR.TRISTATE_ON;
 		}
 	} );
 

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -122,8 +122,7 @@
 			var savedState = CKEDITOR.TRISTATE_OFF;
 
 			editor.addCommand( 'maximize', {
-				// Disabled on iOS (https://dev.ckeditor.com/ticket/8307).
-				modes: { wysiwyg: !CKEDITOR.env.iOS, source: !CKEDITOR.env.iOS },
+				modes: { wysiwyg: 1, source: 1 },
 				readOnly: 1,
 				editorFocus: false,
 				exec: function() {

--- a/tests/core/editor/editor.js
+++ b/tests/core/editor/editor.js
@@ -391,5 +391,24 @@ bender.test( {
 
 			assert.isTrue( editor.isDestroyed() );
 		} );
+	},
+
+	'test isMaximized method should return a proper value': function() {
+		bender.editorBot.create( {
+			name: 'test_ismaximized',
+			config: {
+				plugins: 'maximize'
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			assert.isFalse( editor.isMaximized(), 'isMaximized method return ' + editor.isMaximized() + ' instead of false' );
+			editor.execCommand( 'maximize' );
+
+			assert.isTrue( editor.isMaximized(), 'isMaximized method return ' + editor.isMaximized() + ' instead of true' );
+			editor.execCommand( 'maximize' );
+
+			assert.isFalse( editor.isMaximized(), 'isMaximized method return ' + editor.isMaximized() + ' instead of false' );
+		} );
 	}
 } );

--- a/tests/plugins/maximize/manual/maximizeios.html
+++ b/tests/plugins/maximize/manual/maximizeios.html
@@ -1,0 +1,44 @@
+<div id="editor">
+	<h1>Lenna</h1>
+
+	<p><strong>Lenna</strong> or <strong>Lena</strong> is the name given to a <a href="http://en.wikipedia.org/wiki/Standard_test_image" title="Standard test image">standard test image</a> widely used in the field of image processing since 1973. It is a picture of <a href="http://en.wikipedia.org/wiki/Lena_S%C3%B6derberg" title="Lena Söderberg">Lena Söderberg</a>, shot by photographer <a href="http://en.wikipedia.org/wiki/Dwight_Hooker" title="Dwight Hooker">Dwight Hooker</a>, cropped from the <a href="http://en.wikipedia.org/wiki/Centerfold" title="Centerfold">centerfold</a> of the November 1972 issue of <em><a href="http://en.wikipedia.org/wiki/Playboy" title="Playboy">Playboy</a></em> magazine. Given the nature of the image and its source, several academics have criticized its continued use in scientific publications and <a href="http://en.wikipedia.org/wiki/Higher_education" title="Higher education">higher education</a> as both sexist and unprofessional.</p>
+
+	<figure class="image"><img alt="Lena Söderberg" src="/tests/_assets/lena.jpg" width="150" />
+
+		<figcaption>Image of <a href="http://en.wikipedia.org/wiki/Lena_S%C3%B6derberg">Lena Söderberg</a> used in<br />
+		many image processing experiments.</figcaption>
+	</figure>
+
+	<p>The spelling "Lenna" comes from the <a href="http://en.wikipedia.org/wiki/Anglicisation" title="Anglicisation">anglicisation</a> used in the original <i>Playboy</i> article.</p>
+
+	<h1>JavaScript</h1>
+
+	<p>JavaScript code:</p>
+
+	<pre>
+	<code class="language-javascript">function isEmpty( object ) {
+		for ( var i in object ) {
+			if ( object.hasOwnProperty( i ) )
+				return false;
+		}
+		return true;
+	}</code></pre>
+
+	<h1>Apollo 11</h1>
+
+	<h2>Broadcasting and <em>quotes</em> <a id="quotes" name="quotes"></a></h2>
+
+	<p>Broadcast on live TV to a world-wide audience, Armstrong stepped onto the lunar surface and described the event as:</p>
+
+	<blockquote>
+	<p>One small step for [a] man, one giant leap for mankind.</p>
+	</blockquote>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.iOS ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/maximize/manual/maximizeios.md
+++ b/tests/plugins/maximize/manual/maximizeios.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.16.2, bugfix,
+@bender-tags: 4.17.0, feature,
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, basicstyles, image2, codesnippet, link, elementspath, blockquote, format, maximize
 

--- a/tests/plugins/maximize/manual/maximizeios.md
+++ b/tests/plugins/maximize/manual/maximizeios.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.16.2, bugfix,
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, basicstyles, image2, codesnippet, link, elementspath, blockquote, format, maximize
+
+1. Maximize editor.
+1. Try scrolling the content.
+
+**Expected**
+
+The editor is displayed in full screen mode correctly and scrolling is available.
+
+**Unexpected**
+
+Scrolling is locked, full screen mode is broken.

--- a/tests/plugins/maximize/maximize.js
+++ b/tests/plugins/maximize/maximize.js
@@ -4,13 +4,6 @@
 bender.editor = true;
 
 bender.test( {
-	setUp: function() {
-		// Maximize plugin is disabled on iOS (https://dev.ckeditor.com/ticket/8307).
-		if ( CKEDITOR.env.iOS ) {
-			assert.ignore();
-		}
-	},
-
 	// https://dev.ckeditor.com/ticket/4355
 	'test command exec not require editor focus': function() {
 		if ( this.editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE )


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4427](https://github.com/ckeditor/ckeditor4/issues/4427): Fix: [iOS] Enable maximize plugin on IOS.
```

## What changes did you make?

I unlocked the maximize button of the editor on iOS.
The editor behaves differently than on other systems. Now focus is activated every time we toggle maximize. Other browsers remember state of focus. This is related to this [fix](https://dev.ckeditor.com/ticket/12381)(problem with tap on dissabled buttons) that was present in iOS 6-7 and as of version iOS8+ this problem no longer occurs, so we can eaisily change it.

## Which issues does your PR resolve?

Closes [#4427](https://github.com/ckeditor/ckeditor4/issues/4427).