### PR TITLE
Add notification on drop and paste for unsupported file formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ New Features:
 * [#4462](https://github.com/ckeditor/ckeditor4/issues/4462): Added support for editor functions after reattaching its element to DOM.
 * [#4612](https://github.com/ckeditor/ckeditor4/issues/4612): Allow pasting images as Base64 from [clipboard](https://ckeditor.com/cke4/addon/clipboard) in all browsers except IE.
 * [#4681](https://github.com/ckeditor/ckeditor4/issues/4681): Allow drag and drop images as Base64.
-
+* [#4750](https://github.com/ckeditor/ckeditor4/issues/4750): Added notification for pasting and dropping unsupported file types into the editor.
 
 Fixed Issues:
 

--- a/dev/langtool/meta/ckeditor.plugin-clipboard/meta.txt
+++ b/dev/langtool/meta/ckeditor.plugin-clipboard/meta.txt
@@ -9,3 +9,4 @@ paste = Toolbar button tooltip for the Paste feature and a label for the Paste d
 pasteNotification = A notification message shown when the browser is blocking pasting, and the user should use the keyboard instead. The %1 sequence is replaced with a keystroke that - when pressed - will perform the action.
 pasteArea = WAI-ARIA label for the paste area.
 pasteMsg = A help message urging the user to paste the text into the dialog window by using the keyboard.
+fileFormatNotSupportedNotification = A notification message shown when the user drops or paste into the editor a file in unsupported format.

--- a/plugins/clipboard/lang/af.js
+++ b/plugins/clipboard/lang/af.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'af', {
 	pasteNotification: 'Druk %1 om by te voeg. You leser ondersteun nie die toolbar knoppie of inoud kieslysie opsie nie. ',
 	pasteArea: 'Area byvoeg',
 	pasteMsg: 'Voeg jou inhoud in die gebied onder by en druk OK',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/af.js
+++ b/plugins/clipboard/lang/af.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'af', {
 	pasteNotification: 'Druk %1 om by te voeg. You leser ondersteun nie die toolbar knoppie of inoud kieslysie opsie nie. ',
 	pasteArea: 'Area byvoeg',
 	pasteMsg: 'Voeg jou inhoud in die gebied onder by en druk OK',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/af.js
+++ b/plugins/clipboard/lang/af.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'af', {
 	paste: 'Byvoeg',
 	pasteNotification: 'Druk %1 om by te voeg. You leser ondersteun nie die toolbar knoppie of inoud kieslysie opsie nie. ',
 	pasteArea: 'Area byvoeg',
-	pasteMsg: 'Voeg jou inhoud in die gebied onder by en druk OK'
+	pasteMsg: 'Voeg jou inhoud in die gebied onder by en druk OK',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ar.js
+++ b/plugins/clipboard/lang/ar.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ar', {
 	paste: 'لصق',
 	pasteNotification: 'اضغط %1 للصق. اللصق عن طريق شريط الادوات او القائمة غير مدعوم من المتصفح المستخدم من قبلك.',
 	pasteArea: 'منطقة اللصق',
-	pasteMsg: 'الصق المحتوى بداخل المساحة المخصصة ادناه ثم اضغط على OK'
+	pasteMsg: 'الصق المحتوى بداخل المساحة المخصصة ادناه ثم اضغط على OK',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ar.js
+++ b/plugins/clipboard/lang/ar.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ar', {
 	pasteNotification: 'اضغط %1 للصق. اللصق عن طريق شريط الادوات او القائمة غير مدعوم من المتصفح المستخدم من قبلك.',
 	pasteArea: 'منطقة اللصق',
 	pasteMsg: 'الصق المحتوى بداخل المساحة المخصصة ادناه ثم اضغط على OK',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ar.js
+++ b/plugins/clipboard/lang/ar.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ar', {
 	pasteNotification: 'اضغط %1 للصق. اللصق عن طريق شريط الادوات او القائمة غير مدعوم من المتصفح المستخدم من قبلك.',
 	pasteArea: 'منطقة اللصق',
 	pasteMsg: 'الصق المحتوى بداخل المساحة المخصصة ادناه ثم اضغط على OK',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/az.js
+++ b/plugins/clipboard/lang/az.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'az', {
 	paste: 'Əlavə et',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/az.js
+++ b/plugins/clipboard/lang/az.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'az', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/az.js
+++ b/plugins/clipboard/lang/az.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'az', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/bg.js
+++ b/plugins/clipboard/lang/bg.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bg', {
 	pasteNotification: 'Натиснете %1 за да вмъкнете. Вашият браузър не поддържа поставяне с бутон от лентата с инструменти или от контекстното меню.',
 	pasteArea: 'Зона за поставяне',
 	pasteMsg: 'Поставете съдържанието в зоната отдолу и натиснете OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/bg.js
+++ b/plugins/clipboard/lang/bg.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bg', {
 	paste: 'Вмъкни',
 	pasteNotification: 'Натиснете %1 за да вмъкнете. Вашият браузър не поддържа поставяне с бутон от лентата с инструменти или от контекстното меню.',
 	pasteArea: 'Зона за поставяне',
-	pasteMsg: 'Поставете съдържанието в зоната отдолу и натиснете OK.'
+	pasteMsg: 'Поставете съдържанието в зоната отдолу и натиснете OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/bg.js
+++ b/plugins/clipboard/lang/bg.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bg', {
 	pasteNotification: 'Натиснете %1 за да вмъкнете. Вашият браузър не поддържа поставяне с бутон от лентата с инструменти или от контекстното меню.',
 	pasteArea: 'Зона за поставяне',
 	pasteMsg: 'Поставете съдържанието в зоната отдолу и натиснете OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/bn.js
+++ b/plugins/clipboard/lang/bn.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bn', {
 	paste: 'পেস্ট',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/bn.js
+++ b/plugins/clipboard/lang/bn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bn', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/bn.js
+++ b/plugins/clipboard/lang/bn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bn', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/bs.js
+++ b/plugins/clipboard/lang/bs.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bs', {
 	paste: 'Zalijepi',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/bs.js
+++ b/plugins/clipboard/lang/bs.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bs', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/bs.js
+++ b/plugins/clipboard/lang/bs.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'bs', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ca.js
+++ b/plugins/clipboard/lang/ca.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ca', {
 	paste: 'Enganxar',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Àrea d\'enganxat',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ca.js
+++ b/plugins/clipboard/lang/ca.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ca', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Àrea d\'enganxat',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ca.js
+++ b/plugins/clipboard/lang/ca.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ca', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Àrea d\'enganxat',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/cs.js
+++ b/plugins/clipboard/lang/cs.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cs', {
 	paste: 'Vložit',
 	pasteNotification: 'Stiskněte %1 pro vložení. Váš prohlížeč nepodporuje vkládání pomocí tlačítka na panelu nástrojů nebo volby kontextového menu.',
 	pasteArea: 'Oblast vkládání',
-	pasteMsg: 'Vložte svůj obsah do oblasti níže a stiskněte OK.'
+	pasteMsg: 'Vložte svůj obsah do oblasti níže a stiskněte OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/cs.js
+++ b/plugins/clipboard/lang/cs.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cs', {
 	pasteNotification: 'Stiskněte %1 pro vložení. Váš prohlížeč nepodporuje vkládání pomocí tlačítka na panelu nástrojů nebo volby kontextového menu.',
 	pasteArea: 'Oblast vkládání',
 	pasteMsg: 'Vložte svůj obsah do oblasti níže a stiskněte OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/cs.js
+++ b/plugins/clipboard/lang/cs.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cs', {
 	pasteNotification: 'Stiskněte %1 pro vložení. Váš prohlížeč nepodporuje vkládání pomocí tlačítka na panelu nástrojů nebo volby kontextového menu.',
 	pasteArea: 'Oblast vkládání',
 	pasteMsg: 'Vložte svůj obsah do oblasti níže a stiskněte OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/cy.js
+++ b/plugins/clipboard/lang/cy.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cy', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Ardal Gludo',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/cy.js
+++ b/plugins/clipboard/lang/cy.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cy', {
 	paste: 'Gludo',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Ardal Gludo',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/cy.js
+++ b/plugins/clipboard/lang/cy.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'cy', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Ardal Gludo',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/da.js
+++ b/plugins/clipboard/lang/da.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'da', {
 	paste: 'Indsæt',
 	pasteNotification: 'Tryk %1 for at sætte ind. Din browser understøtter ikke indsættelse med værktøjslinje knappen eller kontekst menuen.',
 	pasteArea: 'Indsættelses område',
-	pasteMsg: 'Indsæt dit indhold i området nedenfor og tryk OK.'
+	pasteMsg: 'Indsæt dit indhold i området nedenfor og tryk OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/da.js
+++ b/plugins/clipboard/lang/da.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'da', {
 	pasteNotification: 'Tryk %1 for at sætte ind. Din browser understøtter ikke indsættelse med værktøjslinje knappen eller kontekst menuen.',
 	pasteArea: 'Indsættelses område',
 	pasteMsg: 'Indsæt dit indhold i området nedenfor og tryk OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/da.js
+++ b/plugins/clipboard/lang/da.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'da', {
 	pasteNotification: 'Tryk %1 for at sætte ind. Din browser understøtter ikke indsættelse med værktøjslinje knappen eller kontekst menuen.',
 	pasteArea: 'Indsættelses område',
 	pasteMsg: 'Indsæt dit indhold i området nedenfor og tryk OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/de-ch.js
+++ b/plugins/clipboard/lang/de-ch.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de-ch', {
 	pasteNotification: 'Drücken Sie %1 zum Einfügen. Ihr Browser unterstützt nicht das Einfügen über dem Knopf in der Werkzeugleiste oder dem Kontextmenü.',
 	pasteArea: 'Einfügebereich',
 	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/de-ch.js
+++ b/plugins/clipboard/lang/de-ch.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de-ch', {
 	paste: 'Einfügen',
 	pasteNotification: 'Drücken Sie %1 zum Einfügen. Ihr Browser unterstützt nicht das Einfügen über dem Knopf in der Werkzeugleiste oder dem Kontextmenü.',
 	pasteArea: 'Einfügebereich',
-	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.'
+	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/de-ch.js
+++ b/plugins/clipboard/lang/de-ch.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de-ch', {
 	pasteNotification: 'Drücken Sie %1 zum Einfügen. Ihr Browser unterstützt nicht das Einfügen über dem Knopf in der Werkzeugleiste oder dem Kontextmenü.',
 	pasteArea: 'Einfügebereich',
 	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/de.js
+++ b/plugins/clipboard/lang/de.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de', {
 	pasteNotification: 'Drücken Sie %1 zum Einfügen. Ihr Browser unterstützt nicht das Einfügen über dem Knopf in der Toolbar oder dem Kontextmenü.',
 	pasteArea: 'Einfügebereich',
 	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/de.js
+++ b/plugins/clipboard/lang/de.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de', {
 	paste: 'Einfügen',
 	pasteNotification: 'Drücken Sie %1 zum Einfügen. Ihr Browser unterstützt nicht das Einfügen über dem Knopf in der Toolbar oder dem Kontextmenü.',
 	pasteArea: 'Einfügebereich',
-	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.'
+	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/de.js
+++ b/plugins/clipboard/lang/de.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'de', {
 	pasteNotification: 'Drücken Sie %1 zum Einfügen. Ihr Browser unterstützt nicht das Einfügen über dem Knopf in der Toolbar oder dem Kontextmenü.',
 	pasteArea: 'Einfügebereich',
 	pasteMsg: 'Fügen Sie den Inhalt in den unteren Bereich ein und drücken Sie OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/el.js
+++ b/plugins/clipboard/lang/el.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'el', {
 	paste: 'Επικόλληση',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Περιοχή Επικόλλησης',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/el.js
+++ b/plugins/clipboard/lang/el.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'el', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Περιοχή Επικόλλησης',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/el.js
+++ b/plugins/clipboard/lang/el.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'el', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Περιοχή Επικόλλησης',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-au.js
+++ b/plugins/clipboard/lang/en-au.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-au', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Paste your content inside the area below and press OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-au.js
+++ b/plugins/clipboard/lang/en-au.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-au', {
 	paste: 'Paste',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
-	pasteMsg: 'Paste your content inside the area below and press OK.'
+	pasteMsg: 'Paste your content inside the area below and press OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-au.js
+++ b/plugins/clipboard/lang/en-au.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-au', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Paste your content inside the area below and press OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-ca.js
+++ b/plugins/clipboard/lang/en-ca.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-ca', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-ca.js
+++ b/plugins/clipboard/lang/en-ca.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-ca', {
 	paste: 'Paste',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-ca.js
+++ b/plugins/clipboard/lang/en-ca.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-ca', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-gb.js
+++ b/plugins/clipboard/lang/en-gb.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-gb', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-gb.js
+++ b/plugins/clipboard/lang/en-gb.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-gb', {
 	paste: 'Paste',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/en-gb.js
+++ b/plugins/clipboard/lang/en-gb.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en-gb', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/en.js
+++ b/plugins/clipboard/lang/en.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en', {
 	paste: 'Paste',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
-	pasteMsg: 'Paste your content inside the area below and press OK.'
+	pasteMsg: 'Paste your content inside the area below and press OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.'
 } );

--- a/plugins/clipboard/lang/en.js
+++ b/plugins/clipboard/lang/en.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Paste your content inside the area below and press OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.'
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.'
 } );

--- a/plugins/clipboard/lang/en.js
+++ b/plugins/clipboard/lang/en.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'en', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.',
 	pasteArea: 'Paste Area',
 	pasteMsg: 'Paste your content inside the area below and press OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.'
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.'
 } );

--- a/plugins/clipboard/lang/eo.js
+++ b/plugins/clipboard/lang/eo.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eo', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Intergluoareo',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/eo.js
+++ b/plugins/clipboard/lang/eo.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eo', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Intergluoareo',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/eo.js
+++ b/plugins/clipboard/lang/eo.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eo', {
 	paste: 'Interglui',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Intergluoareo',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/es-mx.js
+++ b/plugins/clipboard/lang/es-mx.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es-mx', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/es-mx.js
+++ b/plugins/clipboard/lang/es-mx.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es-mx', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/es-mx.js
+++ b/plugins/clipboard/lang/es-mx.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es-mx', {
 	paste: 'Pegar',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/es.js
+++ b/plugins/clipboard/lang/es.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Zona de pegado',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/es.js
+++ b/plugins/clipboard/lang/es.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es', {
 	paste: 'Pegar',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Zona de pegado',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/es.js
+++ b/plugins/clipboard/lang/es.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'es', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Zona de pegado',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/et.js
+++ b/plugins/clipboard/lang/et.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'et', {
 	pasteNotification: 'Asetamiseks vajuta %1. Sinu brauser ei toeta asetamist tööriistariba nupu või kontekstimenüü valikuga.',
 	pasteArea: 'Asetamise ala',
 	pasteMsg: 'Aseta sisu alumisse kasti ja vajuta OK nupule.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/et.js
+++ b/plugins/clipboard/lang/et.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'et', {
 	pasteNotification: 'Asetamiseks vajuta %1. Sinu brauser ei toeta asetamist tööriistariba nupu või kontekstimenüü valikuga.',
 	pasteArea: 'Asetamise ala',
 	pasteMsg: 'Aseta sisu alumisse kasti ja vajuta OK nupule.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/et.js
+++ b/plugins/clipboard/lang/et.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'et', {
 	paste: 'Aseta',
 	pasteNotification: 'Asetamiseks vajuta %1. Sinu brauser ei toeta asetamist tööriistariba nupu või kontekstimenüü valikuga.',
 	pasteArea: 'Asetamise ala',
-	pasteMsg: 'Aseta sisu alumisse kasti ja vajuta OK nupule.'
+	pasteMsg: 'Aseta sisu alumisse kasti ja vajuta OK nupule.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/eu.js
+++ b/plugins/clipboard/lang/eu.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eu', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Itsasteko area',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/eu.js
+++ b/plugins/clipboard/lang/eu.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eu', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Itsasteko area',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/eu.js
+++ b/plugins/clipboard/lang/eu.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'eu', {
 	paste: 'Itsatsi',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Itsasteko area',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/fa.js
+++ b/plugins/clipboard/lang/fa.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fa', {
 	pasteNotification: '1% را فشاردهید تا قرار داده شود. مرورگر شما از قراردهی با دکمه نوارابزار یا گزینه منوی زمینه پشتیبانی نمیکند',
 	pasteArea: 'محل چسباندن',
 	pasteMsg: 'محتوای خود را در ناحیه زیر قرار دهید و OK را فشار دهید',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/fa.js
+++ b/plugins/clipboard/lang/fa.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fa', {
 	pasteNotification: '1% را فشاردهید تا قرار داده شود. مرورگر شما از قراردهی با دکمه نوارابزار یا گزینه منوی زمینه پشتیبانی نمیکند',
 	pasteArea: 'محل چسباندن',
 	pasteMsg: 'محتوای خود را در ناحیه زیر قرار دهید و OK را فشار دهید',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/fa.js
+++ b/plugins/clipboard/lang/fa.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fa', {
 	paste: 'چسباندن',
 	pasteNotification: '1% را فشاردهید تا قرار داده شود. مرورگر شما از قراردهی با دکمه نوارابزار یا گزینه منوی زمینه پشتیبانی نمیکند',
 	pasteArea: 'محل چسباندن',
-	pasteMsg: 'محتوای خود را در ناحیه زیر قرار دهید و OK را فشار دهید'
+	pasteMsg: 'محتوای خود را در ناحیه زیر قرار دهید و OK را فشار دهید',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/fi.js
+++ b/plugins/clipboard/lang/fi.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fi', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Leikealue',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/fi.js
+++ b/plugins/clipboard/lang/fi.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fi', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Leikealue',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/fi.js
+++ b/plugins/clipboard/lang/fi.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fi', {
 	paste: 'Liitä',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Leikealue',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/fo.js
+++ b/plugins/clipboard/lang/fo.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fo', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Avritingarumráði',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/fo.js
+++ b/plugins/clipboard/lang/fo.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fo', {
 	paste: 'Innrita',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Avritingarumráði',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/fo.js
+++ b/plugins/clipboard/lang/fo.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fo', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Avritingarumráði',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr-ca.js
+++ b/plugins/clipboard/lang/fr-ca.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr-ca', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Coller la zone',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr-ca.js
+++ b/plugins/clipboard/lang/fr-ca.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr-ca', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Coller la zone',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr-ca.js
+++ b/plugins/clipboard/lang/fr-ca.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr-ca', {
 	paste: 'Coller',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Coller la zone',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr.js
+++ b/plugins/clipboard/lang/fr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr', {
 	pasteNotification: 'Utilisez le raccourci %1 pour coller. Votre navigateur n\'accepte pas de coller à l\'aide du bouton ou du menu contextuel.',
 	pasteArea: 'Coller la zone',
 	pasteMsg: 'Collez votre contenu dans la zone de saisie ci-dessous et cliquez OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr.js
+++ b/plugins/clipboard/lang/fr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr', {
 	pasteNotification: 'Utilisez le raccourci %1 pour coller. Votre navigateur n\'accepte pas de coller à l\'aide du bouton ou du menu contextuel.',
 	pasteArea: 'Coller la zone',
 	pasteMsg: 'Collez votre contenu dans la zone de saisie ci-dessous et cliquez OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/fr.js
+++ b/plugins/clipboard/lang/fr.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'fr', {
 	paste: 'Coller',
 	pasteNotification: 'Utilisez le raccourci %1 pour coller. Votre navigateur n\'accepte pas de coller à l\'aide du bouton ou du menu contextuel.',
 	pasteArea: 'Coller la zone',
-	pasteMsg: 'Collez votre contenu dans la zone de saisie ci-dessous et cliquez OK.'
+	pasteMsg: 'Collez votre contenu dans la zone de saisie ci-dessous et cliquez OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/gl.js
+++ b/plugins/clipboard/lang/gl.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gl', {
 	paste: 'Pegar',
 	pasteNotification: 'Prema %1 para pegar. O seu navegador non admite pegar co botón da barra de ferramentas ou coa opción do menú contextual.',
 	pasteArea: 'Zona de pegado',
-	pasteMsg: 'Pegue o contido dentro da área de abaixo e prema Aceptar.'
+	pasteMsg: 'Pegue o contido dentro da área de abaixo e prema Aceptar.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/gl.js
+++ b/plugins/clipboard/lang/gl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gl', {
 	pasteNotification: 'Prema %1 para pegar. O seu navegador non admite pegar co botón da barra de ferramentas ou coa opción do menú contextual.',
 	pasteArea: 'Zona de pegado',
 	pasteMsg: 'Pegue o contido dentro da área de abaixo e prema Aceptar.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/gl.js
+++ b/plugins/clipboard/lang/gl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gl', {
 	pasteNotification: 'Prema %1 para pegar. O seu navegador non admite pegar co botón da barra de ferramentas ou coa opción do menú contextual.',
 	pasteArea: 'Zona de pegado',
 	pasteMsg: 'Pegue o contido dentro da área de abaixo e prema Aceptar.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/gu.js
+++ b/plugins/clipboard/lang/gu.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gu', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'પેસ્ટ કરવાની જગ્યા',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/gu.js
+++ b/plugins/clipboard/lang/gu.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gu', {
 	paste: 'પેસ્ટ',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'પેસ્ટ કરવાની જગ્યા',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/gu.js
+++ b/plugins/clipboard/lang/gu.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'gu', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'પેસ્ટ કરવાની જગ્યા',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/he.js
+++ b/plugins/clipboard/lang/he.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'he', {
 	paste: 'הדבקה',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'איזור הדבקה',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/he.js
+++ b/plugins/clipboard/lang/he.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'he', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'איזור הדבקה',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/he.js
+++ b/plugins/clipboard/lang/he.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'he', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'איזור הדבקה',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/hi.js
+++ b/plugins/clipboard/lang/hi.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hi', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/hi.js
+++ b/plugins/clipboard/lang/hi.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hi', {
 	paste: 'पेस्ट',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/hi.js
+++ b/plugins/clipboard/lang/hi.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hi', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/hr.js
+++ b/plugins/clipboard/lang/hr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hr', {
 	pasteNotification: 'Vaš preglednik Vam ne dozvoljava lijepljenje običnog teksta na ovaj način. Za lijepljenje, pritisnite %1.',
 	pasteArea: 'Okvir za lijepljenje',
 	pasteMsg: 'Zalijepite vaš sadržaj u okvir ispod i pritisnite OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/hr.js
+++ b/plugins/clipboard/lang/hr.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hr', {
 	paste: 'Zalijepi',
 	pasteNotification: 'Vaš preglednik Vam ne dozvoljava lijepljenje običnog teksta na ovaj način. Za lijepljenje, pritisnite %1.',
 	pasteArea: 'Okvir za lijepljenje',
-	pasteMsg: 'Zalijepite vaš sadržaj u okvir ispod i pritisnite OK.'
+	pasteMsg: 'Zalijepite vaš sadržaj u okvir ispod i pritisnite OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/hr.js
+++ b/plugins/clipboard/lang/hr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hr', {
 	pasteNotification: 'Vaš preglednik Vam ne dozvoljava lijepljenje običnog teksta na ovaj način. Za lijepljenje, pritisnite %1.',
 	pasteArea: 'Okvir za lijepljenje',
 	pasteMsg: 'Zalijepite vaš sadržaj u okvir ispod i pritisnite OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/hu.js
+++ b/plugins/clipboard/lang/hu.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hu', {
 	pasteNotification: 'Nyomja meg a %1 gombot a beillesztéshez. A böngésző nem támogatja a beillesztést az eszköztárról vagy a menüből.',
 	pasteArea: 'Beillesztési terület',
 	pasteMsg: 'Illessze be a tartalmat az alábbi mezőbe, és nyomja meg az OK-t.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/hu.js
+++ b/plugins/clipboard/lang/hu.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hu', {
 	paste: 'Beillesztés',
 	pasteNotification: 'Nyomja meg a %1 gombot a beillesztéshez. A böngésző nem támogatja a beillesztést az eszköztárról vagy a menüből.',
 	pasteArea: 'Beillesztési terület',
-	pasteMsg: 'Illessze be a tartalmat az alábbi mezőbe, és nyomja meg az OK-t.'
+	pasteMsg: 'Illessze be a tartalmat az alábbi mezőbe, és nyomja meg az OK-t.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/hu.js
+++ b/plugins/clipboard/lang/hu.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'hu', {
 	pasteNotification: 'Nyomja meg a %1 gombot a beillesztéshez. A böngésző nem támogatja a beillesztést az eszköztárról vagy a menüből.',
 	pasteArea: 'Beillesztési terület',
 	pasteMsg: 'Illessze be a tartalmat az alábbi mezőbe, és nyomja meg az OK-t.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/id.js
+++ b/plugins/clipboard/lang/id.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'id', {
 	paste: 'Tempel',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Area Tempel',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/id.js
+++ b/plugins/clipboard/lang/id.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'id', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Area Tempel',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/id.js
+++ b/plugins/clipboard/lang/id.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'id', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Area Tempel',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/is.js
+++ b/plugins/clipboard/lang/is.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'is', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/is.js
+++ b/plugins/clipboard/lang/is.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'is', {
 	paste: 'Líma',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/is.js
+++ b/plugins/clipboard/lang/is.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'is', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/it.js
+++ b/plugins/clipboard/lang/it.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'it', {
 	paste: 'Incolla',
 	pasteNotification: 'Premere %1 per incollare. Il tuo browser non permette di incollare tramite il pulsante della barra degli strumenti o tramite la voce del menu contestuale.',
 	pasteArea: 'Area dove incollare',
-	pasteMsg: 'Incollare il proprio contenuto all\'interno dell\'area sottostante e premere OK.'
+	pasteMsg: 'Incollare il proprio contenuto all\'interno dell\'area sottostante e premere OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/it.js
+++ b/plugins/clipboard/lang/it.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'it', {
 	pasteNotification: 'Premere %1 per incollare. Il tuo browser non permette di incollare tramite il pulsante della barra degli strumenti o tramite la voce del menu contestuale.',
 	pasteArea: 'Area dove incollare',
 	pasteMsg: 'Incollare il proprio contenuto all\'interno dell\'area sottostante e premere OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/it.js
+++ b/plugins/clipboard/lang/it.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'it', {
 	pasteNotification: 'Premere %1 per incollare. Il tuo browser non permette di incollare tramite il pulsante della barra degli strumenti o tramite la voce del menu contestuale.',
 	pasteArea: 'Area dove incollare',
 	pasteMsg: 'Incollare il proprio contenuto all\'interno dell\'area sottostante e premere OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ja.js
+++ b/plugins/clipboard/lang/ja.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ja', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '貼り付け場所',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ja.js
+++ b/plugins/clipboard/lang/ja.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ja', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '貼り付け場所',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ja.js
+++ b/plugins/clipboard/lang/ja.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ja', {
 	paste: '貼り付け',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '貼り付け場所',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ka.js
+++ b/plugins/clipboard/lang/ka.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ka', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'ჩასმის არე',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ka.js
+++ b/plugins/clipboard/lang/ka.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ka', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'ჩასმის არე',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ka.js
+++ b/plugins/clipboard/lang/ka.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ka', {
 	paste: 'ჩასმა',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'ჩასმის არე',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/km.js
+++ b/plugins/clipboard/lang/km.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'km', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'តំបន់​បិទ​ភ្ជាប់',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/km.js
+++ b/plugins/clipboard/lang/km.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'km', {
 	paste: 'បិទ​ភ្ជាប់',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'តំបន់​បិទ​ភ្ជាប់',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/km.js
+++ b/plugins/clipboard/lang/km.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'km', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'តំបន់​បិទ​ភ្ជាប់',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ko.js
+++ b/plugins/clipboard/lang/ko.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ko', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '붙여넣기 범위',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ko.js
+++ b/plugins/clipboard/lang/ko.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ko', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '붙여넣기 범위',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ko.js
+++ b/plugins/clipboard/lang/ko.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ko', {
 	paste: '붙여넣기',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: '붙여넣기 범위',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ku.js
+++ b/plugins/clipboard/lang/ku.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ku', {
 	pasteNotification: 'کلیک بکە لەسەر %1 بۆ لکاندنی. وێبگەڕەکەت پشتیوانی لکاندن ناکات بە دوگمەی تولامراز یان ئامرازی ناوەڕۆکی لیستە -  کلیکی دەستی ڕاست. ',
 	pasteArea: 'ناوچەی لکاندن',
 	pasteMsg: 'ناوەڕۆکەکەت لەم پانتایی خوارەوە بلکێنە',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ku.js
+++ b/plugins/clipboard/lang/ku.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ku', {
 	pasteNotification: 'کلیک بکە لەسەر %1 بۆ لکاندنی. وێبگەڕەکەت پشتیوانی لکاندن ناکات بە دوگمەی تولامراز یان ئامرازی ناوەڕۆکی لیستە -  کلیکی دەستی ڕاست. ',
 	pasteArea: 'ناوچەی لکاندن',
 	pasteMsg: 'ناوەڕۆکەکەت لەم پانتایی خوارەوە بلکێنە',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ku.js
+++ b/plugins/clipboard/lang/ku.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ku', {
 	paste: 'لکاندن',
 	pasteNotification: 'کلیک بکە لەسەر %1 بۆ لکاندنی. وێبگەڕەکەت پشتیوانی لکاندن ناکات بە دوگمەی تولامراز یان ئامرازی ناوەڕۆکی لیستە -  کلیکی دەستی ڕاست. ',
 	pasteArea: 'ناوچەی لکاندن',
-	pasteMsg: 'ناوەڕۆکەکەت لەم پانتایی خوارەوە بلکێنە'
+	pasteMsg: 'ناوەڕۆکەکەت لەم پانتایی خوارەوە بلکێنە',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/lt.js
+++ b/plugins/clipboard/lang/lt.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lt', {
 	paste: 'Įdėti',
 	pasteNotification: 'Spauskite %1 kad įkliuotumėte. Jūsų naršyklė nepalaiko įklijavimo paspaudus mygtuką arba kontekstinio menių galimybės.',
 	pasteArea: 'Įkelti dalį',
-	pasteMsg: 'Įklijuokite savo turinį į žemiau esantį lauką ir paspauskite OK.'
+	pasteMsg: 'Įklijuokite savo turinį į žemiau esantį lauką ir paspauskite OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/lt.js
+++ b/plugins/clipboard/lang/lt.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lt', {
 	pasteNotification: 'Spauskite %1 kad įkliuotumėte. Jūsų naršyklė nepalaiko įklijavimo paspaudus mygtuką arba kontekstinio menių galimybės.',
 	pasteArea: 'Įkelti dalį',
 	pasteMsg: 'Įklijuokite savo turinį į žemiau esantį lauką ir paspauskite OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/lt.js
+++ b/plugins/clipboard/lang/lt.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lt', {
 	pasteNotification: 'Spauskite %1 kad įkliuotumėte. Jūsų naršyklė nepalaiko įklijavimo paspaudus mygtuką arba kontekstinio menių galimybės.',
 	pasteArea: 'Įkelti dalį',
 	pasteMsg: 'Įklijuokite savo turinį į žemiau esantį lauką ir paspauskite OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/lv.js
+++ b/plugins/clipboard/lang/lv.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lv', {
 	pasteNotification: 'Nospied %1 lai ielīmētu. Tavs pārlūks neatbalsta ielīmēšanu ar rīkjoslas pogām vai uznirstošās izvēlnes opciju.',
 	pasteArea: 'Ielīmēšanas zona',
 	pasteMsg: 'Ielīmē saturu zemāk esošajā laukā un nospied OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/lv.js
+++ b/plugins/clipboard/lang/lv.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lv', {
 	pasteNotification: 'Nospied %1 lai ielīmētu. Tavs pārlūks neatbalsta ielīmēšanu ar rīkjoslas pogām vai uznirstošās izvēlnes opciju.',
 	pasteArea: 'Ielīmēšanas zona',
 	pasteMsg: 'Ielīmē saturu zemāk esošajā laukā un nospied OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/lv.js
+++ b/plugins/clipboard/lang/lv.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'lv', {
 	paste: 'Ielīmēt',
 	pasteNotification: 'Nospied %1 lai ielīmētu. Tavs pārlūks neatbalsta ielīmēšanu ar rīkjoslas pogām vai uznirstošās izvēlnes opciju.',
 	pasteArea: 'Ielīmēšanas zona',
-	pasteMsg: 'Ielīmē saturu zemāk esošajā laukā un nospied OK.'
+	pasteMsg: 'Ielīmē saturu zemāk esošajā laukā un nospied OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/mk.js
+++ b/plugins/clipboard/lang/mk.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mk', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Простор за залепување',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/mk.js
+++ b/plugins/clipboard/lang/mk.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mk', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Простор за залепување',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/mk.js
+++ b/plugins/clipboard/lang/mk.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mk', {
 	paste: 'Залепи (Paste)',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Простор за залепување',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/mn.js
+++ b/plugins/clipboard/lang/mn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mn', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/mn.js
+++ b/plugins/clipboard/lang/mn.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mn', {
 	paste: 'Буулгах',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/mn.js
+++ b/plugins/clipboard/lang/mn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'mn', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ms.js
+++ b/plugins/clipboard/lang/ms.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ms', {
 	paste: 'Tampal',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ms.js
+++ b/plugins/clipboard/lang/ms.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ms', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ms.js
+++ b/plugins/clipboard/lang/ms.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ms', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/nb.js
+++ b/plugins/clipboard/lang/nb.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nb', {
 	paste: 'Lim inn',
 	pasteNotification: 'Trykk %1 for å lime inn. Nettleseren din støtter ikke å lime inn med knappen i verktøylinjen eller høyreklikkmenyen.',
 	pasteArea: 'Innlimingsområde',
-	pasteMsg: 'Lim inn innholdet i området nedenfor og klikk OK.'
+	pasteMsg: 'Lim inn innholdet i området nedenfor og klikk OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/nb.js
+++ b/plugins/clipboard/lang/nb.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nb', {
 	pasteNotification: 'Trykk %1 for å lime inn. Nettleseren din støtter ikke å lime inn med knappen i verktøylinjen eller høyreklikkmenyen.',
 	pasteArea: 'Innlimingsområde',
 	pasteMsg: 'Lim inn innholdet i området nedenfor og klikk OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/nb.js
+++ b/plugins/clipboard/lang/nb.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nb', {
 	pasteNotification: 'Trykk %1 for å lime inn. Nettleseren din støtter ikke å lime inn med knappen i verktøylinjen eller høyreklikkmenyen.',
 	pasteArea: 'Innlimingsområde',
 	pasteMsg: 'Lim inn innholdet i området nedenfor og klikk OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/nl.js
+++ b/plugins/clipboard/lang/nl.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nl', {
 	paste: 'Plakken',
 	pasteNotification: 'Plakken met de knop in de werkbalk wordt niet ondersteund door de browser. Gebruik de sneltoets %1 van het toetsenbord.',
 	pasteArea: 'Plakgebied',
-	pasteMsg: 'Plak de inhoud in het vak hieronder en druk op OK.'
+	pasteMsg: 'Plak de inhoud in het vak hieronder en druk op OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/nl.js
+++ b/plugins/clipboard/lang/nl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nl', {
 	pasteNotification: 'Plakken met de knop in de werkbalk wordt niet ondersteund door de browser. Gebruik de sneltoets %1 van het toetsenbord.',
 	pasteArea: 'Plakgebied',
 	pasteMsg: 'Plak de inhoud in het vak hieronder en druk op OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/nl.js
+++ b/plugins/clipboard/lang/nl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'nl', {
 	pasteNotification: 'Plakken met de knop in de werkbalk wordt niet ondersteund door de browser. Gebruik de sneltoets %1 van het toetsenbord.',
 	pasteArea: 'Plakgebied',
 	pasteMsg: 'Plak de inhoud in het vak hieronder en druk op OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/no.js
+++ b/plugins/clipboard/lang/no.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'no', {
 	paste: 'Lim inn',
 	pasteNotification: 'Trykk %1 for å lime inn. På grunn av manglende støtte i nettleseren din, kan du ikke lime inn via knapperaden eller kontekstmenyen.',
 	pasteArea: 'Innlimingsområde',
-	pasteMsg: 'Lim inn innholdet i området nedenfor og trykk OK.'
+	pasteMsg: 'Lim inn innholdet i området nedenfor og trykk OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/no.js
+++ b/plugins/clipboard/lang/no.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'no', {
 	pasteNotification: 'Trykk %1 for å lime inn. På grunn av manglende støtte i nettleseren din, kan du ikke lime inn via knapperaden eller kontekstmenyen.',
 	pasteArea: 'Innlimingsområde',
 	pasteMsg: 'Lim inn innholdet i området nedenfor og trykk OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/no.js
+++ b/plugins/clipboard/lang/no.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'no', {
 	pasteNotification: 'Trykk %1 for å lime inn. På grunn av manglende støtte i nettleseren din, kan du ikke lime inn via knapperaden eller kontekstmenyen.',
 	pasteArea: 'Innlimingsområde',
 	pasteMsg: 'Lim inn innholdet i området nedenfor og trykk OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/oc.js
+++ b/plugins/clipboard/lang/oc.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'oc', {
 	paste: 'Pegar',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/oc.js
+++ b/plugins/clipboard/lang/oc.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'oc', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/oc.js
+++ b/plugins/clipboard/lang/oc.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'oc', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/pl.js
+++ b/plugins/clipboard/lang/pl.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pl', {
 	paste: 'Wklej',
 	pasteNotification: 'Naciśnij %1 by wkleić tekst. Twoja przeglądarka nie pozwala na wklejanie za pomocą przycisku paska narzędzi lub opcji menu kontekstowego.',
 	pasteArea: 'Miejsce do wklejenia treści',
-	pasteMsg: 'Wklej treść do obszaru poniżej i naciśnij OK.'
+	pasteMsg: 'Wklej treść do obszaru poniżej i naciśnij OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/pl.js
+++ b/plugins/clipboard/lang/pl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pl', {
 	pasteNotification: 'Naciśnij %1 by wkleić tekst. Twoja przeglądarka nie pozwala na wklejanie za pomocą przycisku paska narzędzi lub opcji menu kontekstowego.',
 	pasteArea: 'Miejsce do wklejenia treści',
 	pasteMsg: 'Wklej treść do obszaru poniżej i naciśnij OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/pl.js
+++ b/plugins/clipboard/lang/pl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pl', {
 	pasteNotification: 'Naciśnij %1 by wkleić tekst. Twoja przeglądarka nie pozwala na wklejanie za pomocą przycisku paska narzędzi lub opcji menu kontekstowego.',
 	pasteArea: 'Miejsce do wklejenia treści',
 	pasteMsg: 'Wklej treść do obszaru poniżej i naciśnij OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt-br.js
+++ b/plugins/clipboard/lang/pt-br.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt-br', {
 	pasteNotification: 'Pressione %1 para colar. Seu navegador não permite colar pelos botões da barra de tarefas ou pelo menu de contexto.',
 	pasteArea: 'Área para Colar',
 	pasteMsg: 'Cole o conteúdo na área abaixo e pressione OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt-br.js
+++ b/plugins/clipboard/lang/pt-br.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt-br', {
 	pasteNotification: 'Pressione %1 para colar. Seu navegador não permite colar pelos botões da barra de tarefas ou pelo menu de contexto.',
 	pasteArea: 'Área para Colar',
 	pasteMsg: 'Cole o conteúdo na área abaixo e pressione OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt-br.js
+++ b/plugins/clipboard/lang/pt-br.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt-br', {
 	paste: 'Colar',
 	pasteNotification: 'Pressione %1 para colar. Seu navegador não permite colar pelos botões da barra de tarefas ou pelo menu de contexto.',
 	pasteArea: 'Área para Colar',
-	pasteMsg: 'Cole o conteúdo na área abaixo e pressione OK.'
+	pasteMsg: 'Cole o conteúdo na área abaixo e pressione OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt.js
+++ b/plugins/clipboard/lang/pt.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Área de colagem',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt.js
+++ b/plugins/clipboard/lang/pt.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Área de colagem',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/pt.js
+++ b/plugins/clipboard/lang/pt.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'pt', {
 	paste: 'Colar',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Área de colagem',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ro.js
+++ b/plugins/clipboard/lang/ro.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ro', {
 	pasteNotification: 'Apasă %1 pentru adăugare. Navigatorul (browser) tău nu suportă adăugarea din clipboard cu butonul din toolbar sau cu opțiunea din meniul contextual.',
 	pasteArea: 'Suprafața de adăugare',
 	pasteMsg: 'Adaugă conținutul tău înăuntru zonei de mai jos și apasă OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ro.js
+++ b/plugins/clipboard/lang/ro.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ro', {
 	paste: 'Adaugă',
 	pasteNotification: 'Apasă %1 pentru adăugare. Navigatorul (browser) tău nu suportă adăugarea din clipboard cu butonul din toolbar sau cu opțiunea din meniul contextual.',
 	pasteArea: 'Suprafața de adăugare',
-	pasteMsg: 'Adaugă conținutul tău înăuntru zonei de mai jos și apasă OK.'
+	pasteMsg: 'Adaugă conținutul tău înăuntru zonei de mai jos și apasă OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ro.js
+++ b/plugins/clipboard/lang/ro.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ro', {
 	pasteNotification: 'Apasă %1 pentru adăugare. Navigatorul (browser) tău nu suportă adăugarea din clipboard cu butonul din toolbar sau cu opțiunea din meniul contextual.',
 	pasteArea: 'Suprafața de adăugare',
 	pasteMsg: 'Adaugă conținutul tău înăuntru zonei de mai jos și apasă OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ru.js
+++ b/plugins/clipboard/lang/ru.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ru', {
 	pasteNotification: 'Для вставки нажмите %1. Ваш браузер не поддерживает возможность вставки через панель инструментов или контекстное меню',
 	pasteArea: 'Область вставки',
 	pasteMsg: 'Вставьте контент в эту область и нажмите OK',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ru.js
+++ b/plugins/clipboard/lang/ru.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ru', {
 	pasteNotification: 'Для вставки нажмите %1. Ваш браузер не поддерживает возможность вставки через панель инструментов или контекстное меню',
 	pasteArea: 'Область вставки',
 	pasteMsg: 'Вставьте контент в эту область и нажмите OK',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ru.js
+++ b/plugins/clipboard/lang/ru.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ru', {
 	paste: 'Вставить',
 	pasteNotification: 'Для вставки нажмите %1. Ваш браузер не поддерживает возможность вставки через панель инструментов или контекстное меню',
 	pasteArea: 'Область вставки',
-	pasteMsg: 'Вставьте контент в эту область и нажмите OK'
+	pasteMsg: 'Вставьте контент в эту область и нажмите OK',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/si.js
+++ b/plugins/clipboard/lang/si.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'si', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'අලවන ප්‍රදේශ',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/si.js
+++ b/plugins/clipboard/lang/si.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'si', {
 	paste: 'අලවන්න',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'අලවන ප්‍රදේශ',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/si.js
+++ b/plugins/clipboard/lang/si.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'si', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'අලවන ප්‍රදේශ',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/sk.js
+++ b/plugins/clipboard/lang/sk.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sk', {
 	paste: 'Vložiť',
 	pasteNotification: 'Stlačte %1 na vloženie. Váš prehliadač nepodporuje vloženie prostredníctvom tlačidla v nástrojovej lište alebo voľby v kontextovom menu.',
 	pasteArea: 'Miesto pre vloženie',
-	pasteMsg: 'Vložte svoj obsah do nasledujúcej oblasti a stlačte OK.'
+	pasteMsg: 'Vložte svoj obsah do nasledujúcej oblasti a stlačte OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/sk.js
+++ b/plugins/clipboard/lang/sk.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sk', {
 	pasteNotification: 'Stlačte %1 na vloženie. Váš prehliadač nepodporuje vloženie prostredníctvom tlačidla v nástrojovej lište alebo voľby v kontextovom menu.',
 	pasteArea: 'Miesto pre vloženie',
 	pasteMsg: 'Vložte svoj obsah do nasledujúcej oblasti a stlačte OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/sk.js
+++ b/plugins/clipboard/lang/sk.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sk', {
 	pasteNotification: 'Stlačte %1 na vloženie. Váš prehliadač nepodporuje vloženie prostredníctvom tlačidla v nástrojovej lište alebo voľby v kontextovom menu.',
 	pasteArea: 'Miesto pre vloženie',
 	pasteMsg: 'Vložte svoj obsah do nasledujúcej oblasti a stlačte OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/sl.js
+++ b/plugins/clipboard/lang/sl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sl', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Prilepi območje',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/sl.js
+++ b/plugins/clipboard/lang/sl.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sl', {
 	paste: 'Prilepi',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Prilepi območje',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/sl.js
+++ b/plugins/clipboard/lang/sl.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sl', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Prilepi območje',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/sq.js
+++ b/plugins/clipboard/lang/sq.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sq', {
 	paste: 'Hidhe',
 	pasteNotification: 'Shtyp %1 për të hedhur tekstin. Shfletuesi juaj nuk mbështetë hedhjen me pullë shiriti ose alternativën e menysë kontekstuale.',
 	pasteArea: 'Hapësira e Hedhjes',
-	pasteMsg: 'Hidh përmbajtjen brenda hapësirës më poshtë dhe shtyp MIRË.'
+	pasteMsg: 'Hidh përmbajtjen brenda hapësirës më poshtë dhe shtyp MIRË.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/sq.js
+++ b/plugins/clipboard/lang/sq.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sq', {
 	pasteNotification: 'Shtyp %1 për të hedhur tekstin. Shfletuesi juaj nuk mbështetë hedhjen me pullë shiriti ose alternativën e menysë kontekstuale.',
 	pasteArea: 'Hapësira e Hedhjes',
 	pasteMsg: 'Hidh përmbajtjen brenda hapësirës më poshtë dhe shtyp MIRË.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/sq.js
+++ b/plugins/clipboard/lang/sq.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sq', {
 	pasteNotification: 'Shtyp %1 për të hedhur tekstin. Shfletuesi juaj nuk mbështetë hedhjen me pullë shiriti ose alternativën e menysë kontekstuale.',
 	pasteArea: 'Hapësira e Hedhjes',
 	pasteMsg: 'Hidh përmbajtjen brenda hapësirës më poshtë dhe shtyp MIRË.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr-latn.js
+++ b/plugins/clipboard/lang/sr-latn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr-latn', {
 	pasteNotification: '"Pritisnite taster %1 za lepljenje. Vaš pretraživač ne dozvoljava lepljenje iz alatne trake ili menia.',
 	pasteArea: 'Prostor za lepljenje',
 	pasteMsg: 'Nalepite sadržaj u sledeći prostor i pritisnite taster OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr-latn.js
+++ b/plugins/clipboard/lang/sr-latn.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr-latn', {
 	paste: 'Zalepi',
 	pasteNotification: '"Pritisnite taster %1 za lepljenje. Vaš pretraživač ne dozvoljava lepljenje iz alatne trake ili menia.',
 	pasteArea: 'Prostor za lepljenje',
-	pasteMsg: 'Nalepite sadržaj u sledeći prostor i pritisnite taster OK.'
+	pasteMsg: 'Nalepite sadržaj u sledeći prostor i pritisnite taster OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr-latn.js
+++ b/plugins/clipboard/lang/sr-latn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr-latn', {
 	pasteNotification: '"Pritisnite taster %1 za lepljenje. Vaš pretraživač ne dozvoljava lepljenje iz alatne trake ili menia.',
 	pasteArea: 'Prostor za lepljenje',
 	pasteMsg: 'Nalepite sadržaj u sledeći prostor i pritisnite taster OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr.js
+++ b/plugins/clipboard/lang/sr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr', {
 	pasteNotification: 'Притисните тастер %1 за лепљење. Ваш ретраживач не дозвољаба лепљење из алатне траке или мениа.',
 	pasteArea: 'Залепи зону',
 	pasteMsg: 'Налепите садржај у следећи простор и притисните тастер OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr.js
+++ b/plugins/clipboard/lang/sr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr', {
 	pasteNotification: 'Притисните тастер %1 за лепљење. Ваш ретраживач не дозвољаба лепљење из алатне траке или мениа.',
 	pasteArea: 'Залепи зону',
 	pasteMsg: 'Налепите садржај у следећи простор и притисните тастер OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/sr.js
+++ b/plugins/clipboard/lang/sr.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sr', {
 	paste: 'Залепи',
 	pasteNotification: 'Притисните тастер %1 за лепљење. Ваш ретраживач не дозвољаба лепљење из алатне траке или мениа.',
 	pasteArea: 'Залепи зону',
-	pasteMsg: 'Налепите садржај у следећи простор и притисните тастер OK.'
+	pasteMsg: 'Налепите садржај у следећи простор и притисните тастер OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/sv.js
+++ b/plugins/clipboard/lang/sv.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sv', {
 	pasteNotification: 'Tryck på %1 för att klistra in. Din webbläsare stödjer inte inklistring via verktygsfältet eller snabbmenyn.',
 	pasteArea: 'Inklistringsområde',
 	pasteMsg: 'Klistra in ditt innehåll i området nedan och tryck på OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/sv.js
+++ b/plugins/clipboard/lang/sv.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sv', {
 	paste: 'Klistra in',
 	pasteNotification: 'Tryck på %1 för att klistra in. Din webbläsare stödjer inte inklistring via verktygsfältet eller snabbmenyn.',
 	pasteArea: 'Inklistringsområde',
-	pasteMsg: 'Klistra in ditt innehåll i området nedan och tryck på OK.'
+	pasteMsg: 'Klistra in ditt innehåll i området nedan och tryck på OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/sv.js
+++ b/plugins/clipboard/lang/sv.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'sv', {
 	pasteNotification: 'Tryck på %1 för att klistra in. Din webbläsare stödjer inte inklistring via verktygsfältet eller snabbmenyn.',
 	pasteArea: 'Inklistringsområde',
 	pasteMsg: 'Klistra in ditt innehåll i området nedan och tryck på OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/th.js
+++ b/plugins/clipboard/lang/th.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'th', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/th.js
+++ b/plugins/clipboard/lang/th.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'th', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/th.js
+++ b/plugins/clipboard/lang/th.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'th', {
 	paste: 'วาง',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Paste Area', // MISSING
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/tr.js
+++ b/plugins/clipboard/lang/tr.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tr', {
 	paste: 'Yapıştır',
 	pasteNotification: '%1 tuşuna yapıştırmak için tıklayın. Tarayıcınız, Araç Çubuğu yada İçerik Menüsünü kullanarak yapıştırmayı desteklemiyor.',
 	pasteArea: 'Yapıştırma Alanı',
-	pasteMsg: 'İçeriğinizi alttaki bulunan alana yapıştırın ve TAMAM butonuna tıklayın'
+	pasteMsg: 'İçeriğinizi alttaki bulunan alana yapıştırın ve TAMAM butonuna tıklayın',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/tr.js
+++ b/plugins/clipboard/lang/tr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tr', {
 	pasteNotification: '%1 tuşuna yapıştırmak için tıklayın. Tarayıcınız, Araç Çubuğu yada İçerik Menüsünü kullanarak yapıştırmayı desteklemiyor.',
 	pasteArea: 'Yapıştırma Alanı',
 	pasteMsg: 'İçeriğinizi alttaki bulunan alana yapıştırın ve TAMAM butonuna tıklayın',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/tr.js
+++ b/plugins/clipboard/lang/tr.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tr', {
 	pasteNotification: '%1 tuşuna yapıştırmak için tıklayın. Tarayıcınız, Araç Çubuğu yada İçerik Menüsünü kullanarak yapıştırmayı desteklemiyor.',
 	pasteArea: 'Yapıştırma Alanı',
 	pasteMsg: 'İçeriğinizi alttaki bulunan alana yapıştırın ve TAMAM butonuna tıklayın',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/tt.js
+++ b/plugins/clipboard/lang/tt.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tt', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Өстәү мәйданы',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/tt.js
+++ b/plugins/clipboard/lang/tt.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tt', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Өстәү мәйданы',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/tt.js
+++ b/plugins/clipboard/lang/tt.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'tt', {
 	paste: 'Өстәү',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Өстәү мәйданы',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/ug.js
+++ b/plugins/clipboard/lang/ug.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ug', {
 	pasteNotification: 'چاپلانغىنى 1% . سىزنىڭ تور كۆرگۈچىڭىز قۇرال تەكچىسى ۋە سىيرىلما تاللاپ چاپلاش ئىقتىدارىنى قوللىمايدىكەن .',
 	pasteArea: 'چاپلاش دائىرىسى',
 	pasteMsg: 'مەزمۇنىڭىزنى تۆۋەندىكى رايونغا چاپلاپ ئاندىن OK نى بېسىڭ .',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/ug.js
+++ b/plugins/clipboard/lang/ug.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ug', {
 	pasteNotification: 'چاپلانغىنى 1% . سىزنىڭ تور كۆرگۈچىڭىز قۇرال تەكچىسى ۋە سىيرىلما تاللاپ چاپلاش ئىقتىدارىنى قوللىمايدىكەن .',
 	pasteArea: 'چاپلاش دائىرىسى',
 	pasteMsg: 'مەزمۇنىڭىزنى تۆۋەندىكى رايونغا چاپلاپ ئاندىن OK نى بېسىڭ .',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/ug.js
+++ b/plugins/clipboard/lang/ug.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'ug', {
 	paste: 'چاپلا',
 	pasteNotification: 'چاپلانغىنى 1% . سىزنىڭ تور كۆرگۈچىڭىز قۇرال تەكچىسى ۋە سىيرىلما تاللاپ چاپلاش ئىقتىدارىنى قوللىمايدىكەن .',
 	pasteArea: 'چاپلاش دائىرىسى',
-	pasteMsg: 'مەزمۇنىڭىزنى تۆۋەندىكى رايونغا چاپلاپ ئاندىن OK نى بېسىڭ .'
+	pasteMsg: 'مەزمۇنىڭىزنى تۆۋەندىكى رايونغا چاپلاپ ئاندىن OK نى بېسىڭ .',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/uk.js
+++ b/plugins/clipboard/lang/uk.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'uk', {
 	pasteNotification: 'Натисніть %1, щоб вставити. Ваш браузер не підтримує вставку за допомогою кнопки панелі інструментів або пункту контекстного меню.',
 	pasteArea: 'Область вставки',
 	pasteMsg: 'Вставте вміст у область нижче та натисніть OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/uk.js
+++ b/plugins/clipboard/lang/uk.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'uk', {
 	pasteNotification: 'Натисніть %1, щоб вставити. Ваш браузер не підтримує вставку за допомогою кнопки панелі інструментів або пункту контекстного меню.',
 	pasteArea: 'Область вставки',
 	pasteMsg: 'Вставте вміст у область нижче та натисніть OK.',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/uk.js
+++ b/plugins/clipboard/lang/uk.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'uk', {
 	paste: 'Вставити',
 	pasteNotification: 'Натисніть %1, щоб вставити. Ваш браузер не підтримує вставку за допомогою кнопки панелі інструментів або пункту контекстного меню.',
 	pasteArea: 'Область вставки',
-	pasteMsg: 'Вставте вміст у область нижче та натисніть OK.'
+	pasteMsg: 'Вставте вміст у область нижче та натисніть OK.',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/vi.js
+++ b/plugins/clipboard/lang/vi.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'vi', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Khu vực dán',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/vi.js
+++ b/plugins/clipboard/lang/vi.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'vi', {
 	paste: 'Dán',
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Khu vực dán',
-	pasteMsg: 'Paste your content inside the area below and press OK.' // MISSING
+	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/vi.js
+++ b/plugins/clipboard/lang/vi.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'vi', {
 	pasteNotification: 'Press %1 to paste. Your browser doesn‘t support pasting with the toolbar button or context menu option.', // MISSING
 	pasteArea: 'Khu vực dán',
 	pasteMsg: 'Paste your content inside the area below and press OK.', // MISSING
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh-cn.js
+++ b/plugins/clipboard/lang/zh-cn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh-cn', {
 	pasteNotification: '您的浏览器不支持通过工具栏或右键菜单进行粘贴，请按 %1 进行粘贴。',
 	pasteArea: '粘贴区域',
 	pasteMsg: '将您的内容粘贴到下方区域，然后按确定。',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh-cn.js
+++ b/plugins/clipboard/lang/zh-cn.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh-cn', {
 	paste: '粘贴',
 	pasteNotification: '您的浏览器不支持通过工具栏或右键菜单进行粘贴，请按 %1 进行粘贴。',
 	pasteArea: '粘贴区域',
-	pasteMsg: '将您的内容粘贴到下方区域，然后按确定。'
+	pasteMsg: '将您的内容粘贴到下方区域，然后按确定。',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh-cn.js
+++ b/plugins/clipboard/lang/zh-cn.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh-cn', {
 	pasteNotification: '您的浏览器不支持通过工具栏或右键菜单进行粘贴，请按 %1 进行粘贴。',
 	pasteArea: '粘贴区域',
 	pasteMsg: '将您的内容粘贴到下方区域，然后按确定。',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh.js
+++ b/plugins/clipboard/lang/zh.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh', {
 	pasteNotification: '請按下「%1」貼上。您的瀏覽器不支援工具列按鈕或是內容功能表選項。',
 	pasteArea: '貼上區',
 	pasteMsg: '請將您的內容貼於下方區域中並按下「OK」。',
-	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh.js
+++ b/plugins/clipboard/lang/zh.js
@@ -10,5 +10,6 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh', {
 	paste: '貼上',
 	pasteNotification: '請按下「%1」貼上。您的瀏覽器不支援工具列按鈕或是內容功能表選項。',
 	pasteArea: '貼上區',
-	pasteMsg: '請將您的內容貼於下方區域中並按下「OK」。'
+	pasteMsg: '請將您的內容貼於下方區域中並按下「OK」。',
+	fileFormatNotSupportedNotification: 'This file format is not supported.' // MISSING
 } );

--- a/plugins/clipboard/lang/zh.js
+++ b/plugins/clipboard/lang/zh.js
@@ -11,5 +11,5 @@ CKEDITOR.plugins.setLang( 'clipboard', 'zh', {
 	pasteNotification: '請按下「%1」貼上。您的瀏覽器不支援工具列按鈕或是內容功能表選項。',
 	pasteArea: '貼上區',
 	pasteMsg: '請將您的內容貼於下方區域中並按下「OK」。',
-	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: PNG, JPG or GIF.' // MISSING
+	fileFormatNotSupportedNotification: 'This file format is not supported. You can try with one of the supported formats: ${formats}.' // MISSING
 } );

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -151,14 +151,7 @@
 			// Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
 			if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported || CKEDITOR.plugins.clipboard.isFileApiSupported ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],
-					humanReadableImageTypes = CKEDITOR.tools.array.map( supportedImageTypes, function( imageType ) {
-						var splittedMimeType = imageType.split( '/' ),
-							imageFormat = splittedMimeType[ 1 ].toUpperCase();
-
-						return imageFormat;
-					} ).join( ', ' ),
-					notificationMsg = editor.lang.clipboard.fileFormatNotSupportedNotification.
-						replace( /\${formats\}/g, humanReadableImageTypes ),
+					unsupportedTypeMsg = createNotificationMessage( supportedImageTypes ),
 					latestId;
 
 				editor.on( 'paste', function( evt ) {
@@ -172,7 +165,7 @@
 						var file = dataTransfer.getFile( 0 );
 
 						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) === -1 ) {
-							editor.showNotification( notificationMsg, 'info', editor.config.clipboard_notificationDuration );
+							editor.showNotification( unsupportedTypeMsg, 'info', editor.config.clipboard_notificationDuration );
 
 							return;
 						}
@@ -206,6 +199,21 @@
 						evt.stop();
 					}
 				}, null, null, 1 );
+			}
+
+			// Prepare content for unsupported image type notification (#4750).
+			function createNotificationMessage( imageTypes ) {
+				var humanReadableImageTypes = CKEDITOR.tools.array.map( imageTypes, function( imageType ) {
+					var splittedMimeType = imageType.split( '/' ),
+						imageFormat = splittedMimeType[ 1 ].toUpperCase();
+
+					return imageFormat;
+				} ).join( ', ' ),
+
+				message = editor.lang.clipboard.fileFormatNotSupportedNotification.
+					replace( /\${formats\}/g, humanReadableImageTypes );
+
+				return message;
 			}
 
 			// Only dataTransfer objects containing only file should be considered

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -162,35 +162,42 @@
 					// Allow both dragging and dropping and pasting images as base64 (#4681).
 					if ( !data && isFileData( evt, dataTransfer ) ) {
 						var file = dataTransfer.getFile( 0 );
-						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) != -1 ) {
-							var fileReader = new FileReader();
 
-							// Convert image file to img tag with base64 image.
-							fileReader.addEventListener( 'load', function() {
-								evt.data.dataValue = '<img src="' + fileReader.result + '" />';
-								editor.fire( 'paste', evt.data );
-							}, false );
+						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) === -1 ) {
+							var msg = editor.lang.clipboard.fileFormatNotSupportedNotification;
 
-							// Proceed with normal flow if reading file was aborted.
-							fileReader.addEventListener( 'abort', function() {
-								// (#4681)
-								setCustomIEEventAttribute( evt );
-								editor.fire( 'paste', evt.data );
-							}, false );
+							editor.showNotification( msg, 'info', editor.config.clipboard_notificationDuration );
 
-							// Proceed with normal flow if reading file failed.
-							fileReader.addEventListener( 'error', function() {
-								// (#4681)
-								setCustomIEEventAttribute( evt );
-								editor.fire( 'paste', evt.data );
-							}, false );
-
-							fileReader.readAsDataURL( file );
-
-							latestId = dataObj.dataTransfer.id;
-
-							evt.stop();
+							return;
 						}
+
+						var fileReader = new FileReader();
+
+						// Convert image file to img tag with base64 image.
+						fileReader.addEventListener( 'load', function() {
+							evt.data.dataValue = '<img src="' + fileReader.result + '" />';
+							editor.fire( 'paste', evt.data );
+						}, false );
+
+						// Proceed with normal flow if reading file was aborted.
+						fileReader.addEventListener( 'abort', function() {
+							// (#4681)
+							setCustomIEEventAttribute( evt );
+							editor.fire( 'paste', evt.data );
+						}, false );
+
+						// Proceed with normal flow if reading file failed.
+						fileReader.addEventListener( 'error', function() {
+							// (#4681)
+							setCustomIEEventAttribute( evt );
+							editor.fire( 'paste', evt.data );
+						}, false );
+
+						fileReader.readAsDataURL( file );
+
+						latestId = dataObj.dataTransfer.id;
+
+						evt.stop();
 					}
 				}, null, null, 1 );
 			}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -151,6 +151,14 @@
 			// Do it as the first step as the conversion is asynchronous and should hold all further paste processing.
 			if ( CKEDITOR.plugins.clipboard.isCustomDataTypesSupported || CKEDITOR.plugins.clipboard.isFileApiSupported ) {
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ],
+					humanReadableImageTypes = CKEDITOR.tools.array.map( supportedImageTypes, function( imageType ) {
+						var splittedMimeType = imageType.split( '/' ),
+							imageFormat = splittedMimeType[ 1 ].toUpperCase();
+
+						return imageFormat;
+					} ).join( ', ' ),
+					notificationMsg = editor.lang.clipboard.fileFormatNotSupportedNotification.
+						replace( /\${formats\}/g, humanReadableImageTypes ),
 					latestId;
 
 				editor.on( 'paste', function( evt ) {
@@ -164,9 +172,7 @@
 						var file = dataTransfer.getFile( 0 );
 
 						if ( CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) === -1 ) {
-							var msg = editor.lang.clipboard.fileFormatNotSupportedNotification;
-
-							editor.showNotification( msg, 'info', editor.config.clipboard_notificationDuration );
+							editor.showNotification( notificationMsg, 'info', editor.config.clipboard_notificationDuration );
 
 							return;
 						}

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -44,9 +44,15 @@
 			FileReader.setReadResult( 'load' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
+			assertDropImage( {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				}
 			} );
 		},
 
@@ -59,9 +65,15 @@
 			FileReader.setReadResult( 'load' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
+			assertDropImage( {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				}
 			} );
 		},
 
@@ -74,9 +86,15 @@
 			FileReader.setReadResult( 'load' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
+			assertDropImage( {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				}
 			} );
 		},
 
@@ -89,9 +107,15 @@
 			FileReader.setReadResult( 'load' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
+			assertDropImage( {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				}
 			} );
 		},
 
@@ -107,15 +131,22 @@
 			FileReader.setReadResult( 'load' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
-			}, function() {
-				spy.restore();
+			assertDropImage(  {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				},
+				callback: function() {
+					spy.restore();
 
-				assert.areSame( 1, spy.callCount, 'There was only one notification' );
-				assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
-					'The notification had correct message' );
+					assert.areSame( 1, spy.callCount, 'There was only one notification' );
+					assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
+						'The notification had correct message' );
+				}
 			} );
 		},
 
@@ -128,9 +159,15 @@
 			FileReader.setReadResult( 'abort' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
+			assertDropImage( {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				}
 			} );
 		},
 
@@ -143,9 +180,15 @@
 			FileReader.setReadResult( 'error' );
 
 			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertDropImage( this.editor, dropEvt, imageType, expected, {
-				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-				dropOffset: 17
+			assertDropImage( {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expected: expected,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				}
 			} );
 		}
 	};
@@ -167,11 +210,17 @@
 		return dataTransfer.$;
 	}
 
-	function assertDropImage( editor, evt, type, expected, config ) {
-		var dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor ),
+	function assertDropImage( options ) {
+		var editor = options.editor,
+			evt = options.event,
+			type = options.type,
+			expected = options.expected,
+			callback = options.callback,
+			dropRangeOptions = options.dropRange,
+			dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor ),
 			range = new CKEDITOR.dom.range( editor.document );
 
-		range.setStart( config.dropContainer, config.dropOffset );
+		range.setStart( dropRangeOptions.dropContainer, dropRangeOptions.dropOffset );
 		evt.testRange = range;
 
 		// Push data into clipboard and invoke paste event
@@ -180,14 +229,18 @@
 		onDrop = function( dropEvt ) {
 			var dropRange = dropEvt.data.dropRange;
 
-			dropRange.startContainer = config.dropContainer;
-			dropRange.startOffset = config.dropOffset;
-			dropRange.endOffset = config.dropOffset;
+			dropRange.startContainer = dropRangeOptions.dropContainer;
+			dropRange.startOffset = dropRangeOptions.dropOffset;
+			dropRange.endOffset = dropRangeOptions.dropOffset;
 		};
 
 		onPaste = function() {
 			resume( function() {
 				assert.beautified.html( expected, editor.getData() );
+
+				if ( callback ) {
+					callback();
+				}
 			} );
 		};
 

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -48,7 +48,7 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expected,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
@@ -69,7 +69,7 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expected,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
@@ -90,7 +90,7 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expected,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
@@ -111,7 +111,7 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expected,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
@@ -120,13 +120,13 @@
 		},
 
 		// (#4750)
-		'test showing notification for dropping unsupported image type': function() {
+		'test dropping unsupported image type shows notification': function() {
 			var dropEvt = bender.tools.mockDropEvent(),
 				imageType = 'application/pdf',
-				expected = '<p class="p">Paste image here:</p>',
+				expectedData = '<p class="p">Paste image here:</p>',
 				expectedMsg = this.editor.lang.clipboard.fileFormatNotSupportedNotification,
 				expectedDuration = this.editor.config.clipboard_notificationDuration,
-				spy = sinon.spy( this.editor, 'showNotification' );
+				notificationSpy = sinon.spy( this.editor, 'showNotification' );
 
 			FileReader.setFileMockType( imageType );
 			FileReader.setReadResult( 'load' );
@@ -136,20 +136,20 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expectedData,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
 				},
 				callback: function() {
-					spy.restore();
+					notificationSpy.restore();
 
-					assert.areSame( 1, spy.callCount, 'There was only one notification' );
-					assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
+					assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
+					assert.areSame( expectedMsg, notificationSpy.getCall( 0 ).args[ 0 ],
 						'The notification had correct message' );
-					assert.areSame( 'info', spy.getCall( 0 ).args[ 1 ],
+					assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
 					'The notification had correct type' );
-					assert.areSame( expectedDuration, spy.getCall( 0 ).args[ 2 ],
+					assert.areSame( expectedDuration, notificationSpy.getCall( 0 ).args[ 2 ],
 						'The notification had correct duration' );
 				}
 			} );
@@ -168,7 +168,7 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expected,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
@@ -189,7 +189,7 @@
 				editor: this.editor,
 				event: dropEvt,
 				type: imageType,
-				expected: expected,
+				expectedData: expected,
 				dropRange: {
 					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 					dropOffset: 17
@@ -219,7 +219,7 @@
 		var editor = options.editor,
 			evt = options.event,
 			type = options.type,
-			expected = options.expected,
+			expectedData = options.expectedData,
 			callback = options.callback,
 			dropRangeOptions = options.dropRange,
 			dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor ),
@@ -241,7 +241,7 @@
 
 		onPaste = function() {
 			resume( function() {
-				assert.beautified.html( expected, editor.getData() );
+				assert.beautified.html( expectedData, editor.getData() );
 
 				if ( callback ) {
 					callback();

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -125,6 +125,7 @@
 				imageType = 'application/pdf',
 				expected = '<p class="p">Paste image here:</p>',
 				expectedMsg = this.editor.lang.clipboard.fileFormatNotSupportedNotification,
+				expectedDuration = this.editor.config.clipboard_notificationDuration,
 				spy = sinon.spy( this.editor, 'showNotification' );
 
 			FileReader.setFileMockType( imageType );
@@ -146,6 +147,10 @@
 					assert.areSame( 1, spy.callCount, 'There was only one notification' );
 					assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
 						'The notification had correct message' );
+					assert.areSame( 'info', spy.getCall( 0 ).args[ 1 ],
+					'The notification had correct type' );
+					assert.areSame( expectedDuration, spy.getCall( 0 ).args[ 2 ],
+						'The notification had correct duration' );
 				}
 			} );
 		},

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -13,7 +13,8 @@
 
 	bender.editor = {
 		config: {
-			allowedContent: true
+			allowedContent: true,
+			language: 'en'
 		}
 	};
 
@@ -91,6 +92,30 @@
 			assertDropImage( this.editor, dropEvt, imageType, expected, {
 				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
 				dropOffset: 17
+			} );
+		},
+
+		// (#4750)
+		'test showing notification for dropping unsupported image type': function() {
+			var dropEvt = bender.tools.mockDropEvent(),
+				imageType = 'application/pdf',
+				expected = '<p class="p">Paste image here:</p>',
+				expectedMsg = this.editor.lang.clipboard.fileFormatNotSupportedNotification,
+				spy = sinon.spy( this.editor, 'showNotification' );
+
+			FileReader.setFileMockType( imageType );
+			FileReader.setReadResult( 'load' );
+
+			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
+			assertDropImage( this.editor, dropEvt, imageType, expected, {
+				dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+				dropOffset: 17
+			}, function() {
+				spy.restore();
+
+				assert.areSame( 1, spy.callCount, 'There was only one notification' );
+				assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
+					'The notification had correct message' );
 			} );
 		},
 

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -124,7 +124,7 @@
 			var dropEvt = bender.tools.mockDropEvent(),
 				imageType = 'application/pdf',
 				expectedData = '<p class="p">Paste image here:</p>',
-				expectedMsg = this.editor.lang.clipboard.fileFormatNotSupportedNotification,
+				expectedMsgRegex  = prepareNotificationRegex( this.editor.lang.clipboard.fileFormatNotSupportedNotification ),
 				expectedDuration = this.editor.config.clipboard_notificationDuration,
 				notificationSpy = sinon.spy( this.editor, 'showNotification' );
 
@@ -145,7 +145,7 @@
 					notificationSpy.restore();
 
 					assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
-					assert.areSame( expectedMsg, notificationSpy.getCall( 0 ).args[ 0 ],
+					assert.isMatching( expectedMsgRegex, notificationSpy.getCall( 0 ).args[ 0 ],
 						'The notification had correct message' );
 					assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
 					'The notification had correct type' );
@@ -255,5 +255,12 @@
 		dropTarget.fire( 'drop', evt );
 
 		wait();
+	}
+
+	function prepareNotificationRegex( notification ) {
+		var formatsGroup = '[a-z,\\s]+',
+			regexp = '^' + notification.replace( /\$\{formats\}/g, formatsGroup ) + '$';
+
+		return new RegExp( regexp, 'gi' );
 	}
 } )();

--- a/tests/plugins/clipboard/manual/draganddropfilenotification.html
+++ b/tests/plugins/clipboard/manual/draganddropfilenotification.html
@@ -1,0 +1,24 @@
+<h2>Classic editor</h2>
+<div id="editor">
+	<p>Drag and drop image here.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true" style="border:1px solid #000000;">
+	<p>Drag and drop image here.</p>
+</div>
+
+<script>
+	var editor = CKEDITOR.replace( 'editor', {
+			language: 'en'
+		} ),
+		inline = CKEDITOR.inline( 'inline', {
+			language: 'en'
+		} );
+
+	editor.on( 'loaded', function() {
+		if( !CKEDITOR.plugins.clipboard.isFileApiSupported ){
+			bender.ignore();
+		}
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/draganddropfilenotification.md
+++ b/tests/plugins/clipboard/manual/draganddropfilenotification.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.17.0, feature, 4750
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, sourcearea, clipboard, undo, image, floatingspace
+
+1. Drag and drop into the editor file in format unsupported by editor, e.g. SVG or WebP image, PDF file, Word document etc.
+
+	**Expected:** Notifaction with "This file format is not supported." message is displayed.
+
+	**Unexpected:** Nothing happens.
+2. Repeat steps for each editor.

--- a/tests/plugins/clipboard/manual/draganddropfilenotification.md
+++ b/tests/plugins/clipboard/manual/draganddropfilenotification.md
@@ -4,7 +4,7 @@
 
 1. Drag and drop into the editor file in format unsupported by editor, e.g. SVG or WebP image, PDF file, Word document etc.
 
-	**Expected** Notifaction with "This file format is not supported." message is displayed.
+	**Expected** Notification with "This file format is not supported." message is displayed.
 
 	**Unexpected** Nothing happens.
 

--- a/tests/plugins/clipboard/manual/draganddropfilenotification.md
+++ b/tests/plugins/clipboard/manual/draganddropfilenotification.md
@@ -4,7 +4,8 @@
 
 1. Drag and drop into the editor file in format unsupported by editor, e.g. SVG or WebP image, PDF file, Word document etc.
 
-	**Expected:** Notifaction with "This file format is not supported." message is displayed.
+	**Expected** Notifaction with "This file format is not supported." message is displayed.
 
-	**Unexpected:** Nothing happens.
+	**Unexpected** Nothing happens.
+
 2. Repeat steps for each editor.

--- a/tests/plugins/clipboard/manual/pastefilenotification.html
+++ b/tests/plugins/clipboard/manual/pastefilenotification.html
@@ -1,0 +1,24 @@
+<h2>Classic editor</h2>
+<div id="editor">
+	<p>Paste image here.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true" style="border:1px solid #000000;">
+	<p>Paste image here.</p>
+</div>
+
+<script>
+	var editor = CKEDITOR.replace( 'editor', {
+			language: 'en'
+		} ),
+		inline = CKEDITOR.inline( 'inline', {
+			language: 'en'
+		} );
+
+	editor.on( 'loaded', function() {
+		if( !CKEDITOR.plugins.clipboard.isFileApiSupported ){
+			bender.ignore();
+		}
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/pastefilenotification.md
+++ b/tests/plugins/clipboard/manual/pastefilenotification.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.17.0, feature, 4750
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, clipboard, undo, image, floatingspace
+
+1. Paste into the editor file in format unsupported by editor, e.g. SVG or WebP image, PDF file, Word document etc.
+
+	**Expected:** Notifaction with "This file format is not supported." message is displayed.
+
+	**Unexpected:** Nothing happens.
+
+	**Note:** Depending on OS, browsers can lack support for pasting files other than images. In such a case, test with images only. Please also note that copying a file (e.g. via context menu) is a different thing than copying a _content_ of this file. These two operations are the same only for images.
+2. Repeat steps for each editor.

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -77,7 +77,7 @@
 		// (#4750)
 		'test pasting unsupported file type shows notification': function() {
 			var editor = this.editor,
-				expectedMsg = editor.lang.clipboard.fileFormatNotSupportedNotification,
+				expectedMsgRegex  = prepareNotificationRegex( this.editor.lang.clipboard.fileFormatNotSupportedNotification ),
 				expectedDuration = editor.config.clipboard_notificationDuration,
 				notificationSpy = sinon.spy( editor, 'showNotification' );
 
@@ -92,7 +92,7 @@
 					notificationSpy.restore();
 
 					assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
-					assert.areSame( expectedMsg, notificationSpy.getCall( 0 ).args[ 0 ],
+					assert.isMatching( expectedMsgRegex, notificationSpy.getCall( 0 ).args[ 0 ],
 						'The notification had correct message' );
 					assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
 						'The notification had correct type' );
@@ -191,5 +191,12 @@
 			method: 'paste',
 			type: 'auto'
 		} );
+	}
+
+	function prepareNotificationRegex( notification ) {
+		var formatsGroup = '[a-z,\\s]+',
+			regexp = '^' + notification.replace( /\$\{formats\}/g, formatsGroup ) + '$';
+
+		return new RegExp( regexp, 'gi' );
 	}
 } )();

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -78,6 +78,7 @@
 		'test showing notification for unsupported file type': function() {
 			var editor = this.editor,
 				expectedMsg = editor.lang.clipboard.fileFormatNotSupportedNotification,
+				expectedDuration = editor.config.clipboard_notificationDuration,
 				spy = sinon.spy( editor, 'showNotification' );
 
 			FileReader.setFileMockType( 'application/pdf' );
@@ -93,6 +94,10 @@
 					assert.areSame( 1, spy.callCount, 'There was only one notification' );
 					assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
 						'The notification had correct message' );
+					assert.areSame( 'info', spy.getCall( 0 ).args[ 1 ],
+						'The notification had correct type' );
+					assert.areSame( expectedDuration, spy.getCall( 0 ).args[ 2 ],
+						'The notification had correct duration' );
 				}
 			} );
 		},

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -35,8 +35,10 @@
 			FileReader.setReadResult( 'load' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'image/png',
-				'<p>Paste image here:<img data-cke-saved-src="data:image/png;base64,fileMockBase64=" src="data:image/png;base64,fileMockBase64=" />^@</p>' );
+			this.assertPaste( {
+				type: 'image/png',
+				expected: '<p>Paste image here:<img data-cke-saved-src="data:image/png;base64,fileMockBase64=" src="data:image/png;base64,fileMockBase64=" />^@</p>'
+			} );
 		},
 
 		'test paste .jpeg from clipboard': function() {
@@ -44,8 +46,10 @@
 			FileReader.setReadResult( 'load' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'image/jpeg',
-				'<p>Paste image here:<img data-cke-saved-src="data:image/jpeg;base64,fileMockBase64=" src="data:image/jpeg;base64,fileMockBase64=" />^@</p>' );
+			this.assertPaste( {
+				type: 'image/jpeg',
+				expected: '<p>Paste image here:<img data-cke-saved-src="data:image/jpeg;base64,fileMockBase64=" src="data:image/jpeg;base64,fileMockBase64=" />^@</p>'
+			} );
 		},
 
 		'test paste .gif from clipboard': function() {
@@ -53,8 +57,10 @@
 			FileReader.setReadResult( 'load' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'image/gif',
-				'<p>Paste image here:<img data-cke-saved-src="data:image/gif;base64,fileMockBase64=" src="data:image/gif;base64,fileMockBase64=" />^@</p>' );
+			this.assertPaste( {
+				type: 'image/gif',
+				expected: '<p>Paste image here:<img data-cke-saved-src="data:image/gif;base64,fileMockBase64=" src="data:image/gif;base64,fileMockBase64=" />^@</p>'
+			} );
 		},
 
 		'test unsupported file type': function() {
@@ -62,8 +68,10 @@
 			FileReader.setReadResult( 'load' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'application/pdf',
-				'<p>Paste image here:^@</p>' );
+			this.assertPaste( {
+				type: 'application/pdf',
+				expected: '<p>Paste image here:^@</p>'
+			} );
 		},
 
 		// (#4750)
@@ -76,16 +84,17 @@
 			FileReader.setReadResult( 'load' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'application/pdf',
-				'<p>Paste image here:^@</p>', undefined, {
-					callback: function() {
-						spy.restore();
+			this.assertPaste( {
+				type: 'application/pdf',
+				expected: '<p>Paste image here:^@</p>',
+				callback: function() {
+					spy.restore();
 
-						assert.areSame( 1, spy.callCount, 'There was only one notification' );
-						assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
-							'The notification had correct message' );
-					}
-				} );
+					assert.areSame( 1, spy.callCount, 'There was only one notification' );
+					assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
+						'The notification had correct message' );
+				}
+			} );
 		},
 
 		'test aborted paste': function() {
@@ -93,8 +102,10 @@
 			FileReader.setReadResult( 'abort' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'image/png',
-				'<p>Paste image here:^@</p>' );
+			this.assertPaste( {
+				type: 'image/png',
+				expected: '<p>Paste image here:^@</p>'
+			} );
 		},
 
 		'test failed paste': function() {
@@ -102,8 +113,10 @@
 			FileReader.setReadResult( 'error' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>Paste image here:{}</p>' );
-			this.assertPaste( 'image/png',
-				'<p>Paste image here:^@</p>' );
+			this.assertPaste( {
+				type: 'image/png',
+				expected: '<p>Paste image here:^@</p>'
+			} );
 		},
 
 		// (#3585, #3625)
@@ -112,13 +125,21 @@
 			FileReader.setReadResult( 'load' );
 
 			bender.tools.selection.setWithHtml( this.editor, '<p>{}</p>' );
-			this.assertPaste( 'image/png', '<p><strong>whateva^</strong>@</p><p></p>', [
-				{ type: 'text/html', data: '<strong>whateva</strong>' }
-			] );
+			this.assertPaste( {
+				type: 'image/png',
+				expected: '<p><strong>whateva^</strong>@</p><p></p>',
+				additionalData: [
+					{ type: 'text/html', data: '<strong>whateva</strong>' }
+				]
+			} );
 		},
 
-		assertPaste: function( type, expected, additionalData, options ) {
-			options = options || {};
+		assertPaste: function( options ) {
+			var type = options.type,
+				expected = options.expected,
+				additionalData = options.additionalData,
+				callback = options.callback;
+
 			this.editor.once( 'paste', function() {
 				resume( function() {
 					assert.isInnerHtmlMatching( expected, bender.tools.selection.getWithHtml( this.editor ), {
@@ -128,8 +149,8 @@
 						normalizeSelection: true
 					} );
 
-					if ( options.callback ) {
-						options.callback();
+					if ( callback ) {
+						callback();
 					}
 				} );
 			}, this, null, 9999 );

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -75,7 +75,7 @@
 		},
 
 		// (#4750)
-		'test showing notification for unsupported file type': function() {
+		'test pasting unsupported file type shows notification': function() {
 			var editor = this.editor,
 				expectedMsg = editor.lang.clipboard.fileFormatNotSupportedNotification,
 				expectedDuration = editor.config.clipboard_notificationDuration,

--- a/tests/plugins/clipboard/pasteimage.js
+++ b/tests/plugins/clipboard/pasteimage.js
@@ -79,7 +79,7 @@
 			var editor = this.editor,
 				expectedMsg = editor.lang.clipboard.fileFormatNotSupportedNotification,
 				expectedDuration = editor.config.clipboard_notificationDuration,
-				spy = sinon.spy( editor, 'showNotification' );
+				notificationSpy = sinon.spy( editor, 'showNotification' );
 
 			FileReader.setFileMockType( 'application/pdf' );
 			FileReader.setReadResult( 'load' );
@@ -89,14 +89,14 @@
 				type: 'application/pdf',
 				expected: '<p>Paste image here:^@</p>',
 				callback: function() {
-					spy.restore();
+					notificationSpy.restore();
 
-					assert.areSame( 1, spy.callCount, 'There was only one notification' );
-					assert.areSame( expectedMsg, spy.getCall( 0 ).args[ 0 ],
+					assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
+					assert.areSame( expectedMsg, notificationSpy.getCall( 0 ).args[ 0 ],
 						'The notification had correct message' );
-					assert.areSame( 'info', spy.getCall( 0 ).args[ 1 ],
+					assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
 						'The notification had correct type' );
-					assert.areSame( expectedDuration, spy.getCall( 0 ).args[ 2 ],
+					assert.areSame( expectedDuration, notificationSpy.getCall( 0 ).args[ 2 ],
 						'The notification had correct duration' );
 				}
 			} );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4750](https://github.com/ckeditor/ckeditor4/issues/4750): Added notification for pasting and dropping unsupported file types into the editor.
```

## What changes did you make?

I've added a simple guard clause that displays notification if the file type is not supported. I've also updated language files accordingly.

Additionally I've refactored unit tests a bit to introduce `options` object pattern. I've also switched `pasteimage` test to external `FileReader` mock. This way both tests use the same mock.

## Which issues does your PR resolve?

Closes #4750.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
