### PR TITLE
Prevent invocation on not existing editable [FF]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Fixed Issues:
 * [#3638](https://github.com/ckeditor/ckeditor4/issues/3638): Fixed: Opening the same dialog twice causes it to become hidden under the dialog's page cover.
 * [#4247](https://github.com/ckeditor/ckeditor4/issues/4247): Fixed: [Color Button](https://ckeditor.com/cke4/addon/colorbutton)'s incorrect rendering on the first opening.
 * [#4555](https://github.com/ckeditor/ckeditor4/issues/4555): Fixed: [Font](https://ckeditor.com/cke4/addon/font) styles with attributes are not applied correctly when used multiple times over the same selection.
-* [#4782](https://github.com/ckeditor/ckeditor4/issues/4782): [FF] Fixed: TypeError in autocomplete.
+* [#4782](https://github.com/ckeditor/ckeditor4/issues/4782): [Firefox] Fixed: `TypeError` is thrown when switching to Source View and back while [Autocomplete](https://ckeditor.com/cke4/addon/autocomplete) plugin is enabled.
 
 ## CKEditor 4.16.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixed Issues:
 * [#3638](https://github.com/ckeditor/ckeditor4/issues/3638): Fixed: Opening the same dialog twice causes it to become hidden under the dialog's page cover.
 * [#4247](https://github.com/ckeditor/ckeditor4/issues/4247): Fixed: [Color Button](https://ckeditor.com/cke4/addon/colorbutton)'s incorrect rendering on the first opening.
 * [#4555](https://github.com/ckeditor/ckeditor4/issues/4555): Fixed: [Font](https://ckeditor.com/cke4/addon/font) styles with attributes are not applied correctly when used multiple times over the same selection.
+* [#4782](https://github.com/ckeditor/ckeditor4/issues/4782): [FF] Fixed: TypeError in autocomplete.
 
 ## CKEditor 4.16.1
 

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -347,7 +347,7 @@
 			var editable = this.editor.editable(),
 				isActive = evt.data;
 
-			if ( !editable.isInline() ) {
+			if ( !editable || !editable.isInline() ) {
 				return;
 			}
 

--- a/tests/plugins/emoji/manual/editablenullerror.html
+++ b/tests/plugins/emoji/manual/editablenullerror.html
@@ -1,7 +1,7 @@
 <textarea id="editor"></textarea>
 
 <script>
-	if ( !CKEDITOR.env.gecko || bender.tools.env.mobile ) {
+	if ( bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 

--- a/tests/plugins/emoji/manual/editablenullerror.html
+++ b/tests/plugins/emoji/manual/editablenullerror.html
@@ -1,0 +1,9 @@
+<textarea id="editor"></textarea>
+
+<script>
+	if ( !CKEDITOR.env.gecko || bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/emoji/manual/editablenullerror.md
+++ b/tests/plugins/emoji/manual/editablenullerror.md
@@ -1,0 +1,9 @@
+@bender-tags: 4.16.2, bug, emoji, 4782
+@bender-ckeditor-plugins: wysiwygarea, sourcearea, toolbar, emoji 
+@bender-ui: collapsed
+
+1. Open browser's dev console.
+1. Switch to `source` mode.
+1. Switch to `wysiwyg` mode.
+
+**Expected** No errors in the console.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4782](https://github.com/ckeditor/ckeditor4/issues/4782): Fixed: TypeError in autocomplete for FF.
```

## What changes did you make?

I just added some prevention in one `if` statement. So in case the editable is `null` nothing happened. The source of the issue is described [here](https://github.com/ckeditor/ckeditor4/issues/4782#issuecomment-885500886). Also this event is fired again anyway after the editable is fully initialized. So ignoring it one time (actually only in FF) doesn't break the feature. 

I wasn't able to get this error when I switched modes with automatic tests. So I decided to use the manual one.

## Which issues does your PR resolve?

Closes #4782 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
