### PR TITLE
Fix: Html comments in widgets not processed correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ CKEditor 4 Changelog
 ## CKEditor 4.16.2
 
 Fixed Issues:
+* [#4777](https://github.com/ckeditor/ckeditor4/issues/4777): Fixed: HTML comments in widgets not processed correctly.
 * [#4733](https://github.com/ckeditor/ckeditor4/pull/4733): Fixed: [Link](https://ckeditor.com/cke4/addon/link) prevent duplicate anchors in text with styles.
 	* [#4728](https://github.com/ckeditor/ckeditor4/issues/4728): Fixed: Multiple anchors in one line and multi-line with text style.
 	* [#3863](https://github.com/ckeditor/ckeditor4/issues/3863): Fixed: Multiple anchors in single word with text style.

--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -321,6 +321,15 @@
 		 */
 		unprotectSource: function( html ) {
 			return unprotectSource( html, this.editor );
+		},
+
+		/**
+		 * @since 4.16.2
+		 * @private
+		 * @param {String} html
+		 */
+		unprotectRealComments: function( html ) {
+			return unprotectRealComments( html );
 		}
 	};
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1928,7 +1928,7 @@
 			}
 			this._.initialSetData = false;
 
-			// Unprotect comments, to get rid of additionall characters (#4777).
+			// Unprotect comments, to get rid of additional characters (#4777).
 			data = this.editor.dataProcessor.unprotectRealComments( data );
 
 			// Unescape protected content to prevent double escaping and corruption of content (#4060, #4509).

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1928,6 +1928,9 @@
 			}
 			this._.initialSetData = false;
 
+			// Unprotect comments, to get rid of additionall characters (#4777).
+			data = this.editor.dataProcessor.unprotectRealComments( data );
+
 			// Unescape protected content to prevent double escaping and corruption of content (#4060, #4509).
 			data = this.editor.dataProcessor.unprotectSource( data );
 			data = this.editor.dataProcessor.toHtml( data, {

--- a/tests/plugins/widget/nestedwidgets.js
+++ b/tests/plugins/widget/nestedwidgets.js
@@ -422,7 +422,7 @@
 				'</div>';
 
 			this.editorBots.editor.setData( expectedContent, function() {
-				assert.areEqual( editor.getData(), expectedContent, 'There are artifacts left after comments parsing in widget.' );
+				assert.areEqual( editor.getData(), expectedContent, 'There are artifacts left after comments parsing in widget' );
 			} );
 		}
 	} );

--- a/tests/plugins/widget/nestedwidgets.js
+++ b/tests/plugins/widget/nestedwidgets.js
@@ -409,6 +409,22 @@
 				assert.areSame( 'nestedcol1', widgetNested.editables.col1.getId(), 'nested widget has editable .col1 with id' );
 				assert.areSame( 'nestedcol2', widgetNested.editables.col2.getId(), 'nested widget has editable .col2 with id' );
 			} );
+		},
+
+		// (#4777)
+		'test comments in nested widget are parsed without artifacts': function() {
+			var editor = this.editors.editor,
+				content = '<div data-widget="testcontainer" id="w1">' +
+					'<div class="ned">' +
+						'<!--some comment inside-->' +
+						'<!--some other comment inside-->' +
+					'</div>' +
+				'</div>';
+
+			this.editorBots.editor.setData( content, function() {
+				var foundArtifactIndex = editor.getData().indexOf( '{C}<!--' );
+				assert.areEqual( -1, foundArtifactIndex, 'There are artifacts left after comments parsing in widget.' );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/widget/nestedwidgets.js
+++ b/tests/plugins/widget/nestedwidgets.js
@@ -412,18 +412,17 @@
 		},
 
 		// (#4777)
-		'test comments in nested widget are parsed without artifacts': function() {
+		'test comments in nested widget are correctly parsed': function() {
 			var editor = this.editors.editor,
-				content = '<div data-widget="testcontainer" id="w1">' +
+				expectedContent = '<div data-widget="testcontainer" id="w1">' +
 					'<div class="ned">' +
 						'<!--some comment inside-->' +
 						'<!--some other comment inside-->' +
 					'</div>' +
 				'</div>';
 
-			this.editorBots.editor.setData( content, function() {
-				var foundArtifactIndex = editor.getData().indexOf( '{C}<!--' );
-				assert.areEqual( -1, foundArtifactIndex, 'There are artifacts left after comments parsing in widget.' );
+			this.editorBots.editor.setData( expectedContent, function() {
+				assert.areEqual( editor.getData(), expectedContent );
 			} );
 		}
 	} );

--- a/tests/plugins/widget/nestedwidgets.js
+++ b/tests/plugins/widget/nestedwidgets.js
@@ -422,7 +422,7 @@
 				'</div>';
 
 			this.editorBots.editor.setData( expectedContent, function() {
-				assert.areEqual( editor.getData(), expectedContent );
+				assert.areEqual( editor.getData(), expectedContent, 'There are artifacts left after comments parsing in widget.' );
 			} );
 		}
 	} );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4777](https://github.com/ckeditor/ckeditor4/issues/4777): Fixed: Html comments in widgets not processed correctly
```

## What changes did you make?

The origin of this regression here is merge: https://github.com/ckeditor/ckeditor4/pull/4618

In older version: `unprotectSource` was also invoked, but data there was already cleared after comments protection. To restore previous data flow without breaks on last fix I simply unprotect html comments before the source is unprotected. This requires to make one more method from `htmldataprocessor` to be public: `unprotectRealComments`.

## Which issues does your PR resolve?

Closes #4777 .
