### PR TITLE
Remove unnecessary autofocus on iOS

### DIFF
--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -195,11 +195,6 @@
 					selLocked = 0;
 				}
 				instance.execute();
-
-				// Fixed iOS focus issue when your press disabled button (https://dev.ckeditor.com/ticket/12381).
-				if ( env.iOS ) {
-					editor.focus();
-				}
 			} );
 
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1145,12 +1145,6 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				// Give a while before unlock, waiting for focus to return to the editable. (https://dev.ckeditor.com/ticket/172)
 				setTimeout( function() {
 					editor.focusManager.unlock();
-
-					// Fixed iOS focus issue (https://dev.ckeditor.com/ticket/12381).
-					// Keep in mind that editor.focus() does not work in this case.
-					if ( CKEDITOR.env.iOS ) {
-						editor.window.focus();
-					}
 				}, 0 );
 
 			} else {

--- a/tests/plugins/button/button.js
+++ b/tests/plugins/button/button.js
@@ -5,7 +5,7 @@ var customCls = 'my_btn';
 
 bender.editor = {
 	config: {
-		toolbar: [ [ 'custom_btn', 'expandable_btn', 'clickable_btn' ] ],
+		toolbar: [ [ 'custom_btn', 'expandable_btn', 'clickable_btn', 'disabled_btn' ] ],
 		on: {
 			pluginsLoaded: function( evt ) {
 				var ed = evt.editor,
@@ -28,6 +28,11 @@ bender.editor = {
 				ed.ui.addButton( 'clickable_btn', {
 					label: 'clickable button',
 					command: 'buttonCmd'
+				} );
+
+				ed.ui.addButton( 'disabled_btn', {
+					label: 'disabled button',
+					modes: {}
 				} );
 			}
 		}
@@ -69,5 +74,20 @@ bender.test( {
 		bender.tools.dispatchMouseEvent( btnEl, 'mouseup', CKEDITOR.MOUSE_BUTTON_RIGHT );
 
 		assert.areSame( 0, spy.callCount );
+	},
+
+	// (#4766)
+	'test click of a disabled button should not activate the focus': function() {
+		if ( !CKEDITOR.env.iOS ) {
+			assert.ignore();
+		}
+
+		var editor = this.editor,
+			btn = editor.ui.get( 'disabled_btn' ),
+			btnEl = CKEDITOR.document.getById( btn._.id ).$;
+
+		assert.isFalse( editor.editable().hasFocus );
+		btnEl.click();
+		assert.isFalse( editor.editable().hasFocus );
 	}
 } );

--- a/tests/plugins/dialog/manual/autofocus.html
+++ b/tests/plugins/dialog/manual/autofocus.html
@@ -1,0 +1,11 @@
+<div id="editor">
+	<p>Simple paragraph.</p>
+</div>
+
+<script>
+	if ( !CKEDITOR.env.iOS ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/dialog/manual/autofocus.md
+++ b/tests/plugins/dialog/manual/autofocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4766, bug, 4.16.2, dialog, focus
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table
+
+1. Click the table button.
+2. Click `OK` when the dialog box opens.
+
+ **Expected** Autofocus is fired, os keyboard is visible.
+
+3. Try to type something using the os keyboard.
+
+ **Expected** Typing is possible text is added correctly.
+
+ **Unexpected** Typing is possible but no text is added.
+
+4. Repeat the above steps by clicking the `Cancel` button in `step 2`.


### PR DESCRIPTION
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Skip

## What changes did you make?

I've removed the unnecessary part of code that added extra autofocus in the editor after close the dialog box or tap of the the toolbar button. This was an old fix ( iOS < 8 ) and now this is unnecessary. Also I was not able to add a unit test with a closing dialog due to the inability to test typing on the system keyboard so it's changed to manual test. 

Additionally, there is one test that fails on CI Safari. This is due to the old version of the browser `11.1.2`. As of version 13, the problem does not occur.

## Which issues does your PR resolve?

Closes [#4766](https://github.com/ckeditor/ckeditor4/issues/4766).
