### PR TITLE
Fix fire print on Firefox

### DIFF
--- a/plugins/preview/plugin.js
+++ b/plugins/preview/plugin.js
@@ -24,7 +24,9 @@
 				modes: { wysiwyg: 1 },
 				canUndo: false,
 				readOnly: 1,
-				exec: CKEDITOR.plugins.preview.createPreview
+				exec: function() {
+					CKEDITOR.plugins.preview.createPreview( editor );
+				}
 			} );
 			editor.ui.addButton && editor.ui.addButton( 'Preview', {
 				label: editor.lang.preview.preview,
@@ -51,8 +53,8 @@
 		 * @param {CKEDITOR.editor} editor The editor instance.
 		 * @returns {CKEDITOR.dom.window} A newly created window that contains the preview HTML.
 		 */
-		createPreview: function( editor ) {
-			var previewHtml = createPreviewHtml( editor ),
+		createPreview: function( editor, callback ) {
+			var previewHtml = createPreviewHtml( editor, callback ),
 				eventData = { dataValue: previewHtml },
 				windowDimensions = getWindowDimensions(),
 				// For IE we should use window.location rather than setting url in window.open (https://dev.ckeditor.com/ticket/11146).
@@ -94,7 +96,7 @@
 		}
 	};
 
-	function createPreviewHtml( editor ) {
+	function createPreviewHtml( editor, callback ) {
 		var pluginPath = CKEDITOR.plugins.getPath( 'preview' ),
 			config = editor.config,
 			title = editor.lang.preview.preview,
@@ -113,6 +115,7 @@
 				'<link rel="stylesheet" media="screen" href="' + pluginPath + 'styles/screen.css">' +
 			'</head>' + createBodyHtml() +
 				editor.getData() +
+				setPrintCallback( callback ) +
 			'</body></html>';
 
 		function generateBaseTag() {
@@ -154,6 +157,14 @@
 			}
 
 			return html;
+		}
+
+		function setPrintCallback( callback ) {
+			if ( !callback ) {
+				return '';
+			}
+
+			return '<script> window.onreadystatechange = firePrint </script>';
 		}
 	}
 

--- a/plugins/print/plugin.js
+++ b/plugins/print/plugin.js
@@ -52,33 +52,25 @@
 	 */
 	CKEDITOR.plugins.print = {
 		exec: function( editor ) {
-			var previewWindow = CKEDITOR.plugins.preview.createPreview( editor ),
-				nativePreviewWindow;
+			var previewWindow = CKEDITOR.plugins.preview.createPreview( editor, true ),
+				nativePreviewWindow = previewWindow.$;
 
-			if ( !previewWindow ) {
-				return;
-			}
+			nativePreviewWindow.firePrint = function() {
+				// In several browsers (e.g. Safari or Chrome on Linux) print command
+				// seems to be blocking loading of the preview page. Because of that
+				// print must be performed after the document is complete.
+				if ( document.readyState === 'complete' ) {
+					if ( CKEDITOR.env.gecko ) {
+						nativePreviewWindow.print();
+					} else {
+						nativePreviewWindow.document.execCommand( 'Print' );
+					}
 
-			nativePreviewWindow = previewWindow.$;
-
-			// In several browsers (e.g. Safari or Chrome on Linux) print command
-			// seems to be blocking loading of the preview page. Because of that
-			// print must be performed after the document is complete.
-			if ( nativePreviewWindow.document.readyState === 'complete' ) {
-				return print();
-			}
-
-			previewWindow.once( 'load', print );
-
-			function print() {
-				if ( CKEDITOR.env.gecko ) {
-					nativePreviewWindow.print();
-				} else {
-					nativePreviewWindow.document.execCommand( 'Print' );
+					nativePreviewWindow.close();
 				}
+			};
 
-				nativePreviewWindow.close();
-			}
+			nativePreviewWindow.firePrint();
 		},
 		canUndo: false,
 		readOnly: 1,

--- a/tests/plugins/print/print.js
+++ b/tests/plugins/print/print.js
@@ -42,15 +42,27 @@ bender.test( {
 	// (#3661)
 	'test returning false from CKEDITOR.plugins.preview#createPreview cancels printing': function() {
 		var editor = this.editor,
+			isCanceled = null,
 			createPreviewStub = sinon.stub( CKEDITOR.plugins.preview, 'createPreview', function() {
-				return false;
+				return {
+					$: {
+						print: function() {},
+						close: function() {
+							return isCanceled = true;
+						},
+						document: {
+							readyState: 'interactive',
+							execCommand: function() {}
+						}
+					}
+				};
 			} );
 
 		editor.once( 'afterCommandExec', function() {
 			resume( function() {
 				createPreviewStub.restore();
 
-				assert.pass();
+				assert.isTrue( isCanceled );
 			} );
 		} );
 


### PR DESCRIPTION

## What is the purpose of this pull request?

Bug fix 

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<4790>](https://github.com/ckeditor/ckeditor4/issues/4790): Fixed: Incorrect fire Print on FF
```

## What changes did you make?

The problem was with the page load status in FF mode, because an attempt to print was triggered when the preview page was not ready. So I added a `onreadystatechange` callback to wait for the `complete` status.

## Which issues does your PR resolve?

Closes [#4790](https://github.com/ckeditor/ckeditor4/issues/4790).
