### PR TITLE
Fix lack of info about moving focus upon activating a toolbar button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.16.3
 
+* [#4783](https://github.com/ckeditor/ckeditor4/issues/4783): Fixed: [Accessibility Help](https://ckeditor.com/cke4/addon/a11yhelp) dialog does not contain info about focus being moved back to the editing area upon activating a toolbar button.
+
 ## CKEditor 4.16.2
 
 **Security Updates:**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.16.3
 
+Fixed Issues:
 * [#4783](https://github.com/ckeditor/ckeditor4/issues/4783): Fixed: [Accessibility Help](https://ckeditor.com/cke4/addon/a11yhelp) dialog does not contain info about focus being moved back to the editing area upon activating a toolbar button.
 
 ## CKEditor 4.16.2

--- a/plugins/a11yhelp/dialogs/lang/ar.js
+++ b/plugins/a11yhelp/dialogs/lang/ar.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'ar', {
 		items: [
 			{
 			name: 'Editor Toolbar', // MISSING
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/bg.js
+++ b/plugins/a11yhelp/dialogs/lang/bg.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'bg', {
 		items: [
 			{
 			name: 'Лента с инструменти за редактора',
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/en-gb.js
+++ b/plugins/a11yhelp/dialogs/lang/en-gb.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'en-gb', {
 		items: [
 			{
 			name: 'Editor Toolbar',
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/en.js
+++ b/plugins/a11yhelp/dialogs/lang/en.js
@@ -15,7 +15,8 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'en', {
 			legend: 'Press ${toolbarFocus} to navigate to the toolbar. ' +
 				'Move to the next and previous toolbar group with TAB and SHIFT+TAB. ' +
 				'Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. ' +
-				'Press SPACE or ENTER to activate the toolbar button.'
+				'Press SPACE or ENTER to activate the toolbar button.' +
+				'The focus will be moved back to the editing area upon activating the toolbar button.'
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/fo.js
+++ b/plugins/a11yhelp/dialogs/lang/fo.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'fo', {
 		items: [
 			{
 			name: 'Editor Toolbar', // MISSING
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/gu.js
+++ b/plugins/a11yhelp/dialogs/lang/gu.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'gu', {
 		items: [
 			{
 			name: 'એડિટર ટૂલબાર',
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/hi.js
+++ b/plugins/a11yhelp/dialogs/lang/hi.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'hi', {
 		items: [
 			{
 			name: 'Editor Toolbar', // MISSING
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/km.js
+++ b/plugins/a11yhelp/dialogs/lang/km.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'km', {
 		items: [
 			{
 			name: 'របារ​ឧបករណ៍​កម្មវិធី​និពន្ធ',
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/lt.js
+++ b/plugins/a11yhelp/dialogs/lang/lt.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'lt', {
 		items: [
 			{
 			name: 'Editor Toolbar', // MISSING
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/mk.js
+++ b/plugins/a11yhelp/dialogs/lang/mk.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'mk', {
 		items: [
 			{
 			name: 'Мени за уредувачот',
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/mn.js
+++ b/plugins/a11yhelp/dialogs/lang/mn.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'mn', {
 		items: [
 			{
 			name: 'Editor Toolbar', // MISSING
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/th.js
+++ b/plugins/a11yhelp/dialogs/lang/th.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'th', {
 		items: [
 			{
 			name: 'แถบเครื่องมือสำหรับเครื่องมือช่วยพิมพ์',
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/plugins/a11yhelp/dialogs/lang/tt.js
+++ b/plugins/a11yhelp/dialogs/lang/tt.js
@@ -12,7 +12,7 @@ CKEDITOR.plugins.setLang( 'a11yhelp', 'tt', {
 		items: [
 			{
 			name: 'Editor Toolbar', // MISSING
-			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.' // MISSING
+			legend: 'Press ${toolbarFocus} to navigate to the toolbar. Move to the next and previous toolbar group with TAB and SHIFT+TAB. Move to the next and previous toolbar button with RIGHT ARROW or LEFT ARROW. Press SPACE or ENTER to activate the toolbar button.The focus will be moved back to the editing area upon activating the toolbar button.' // MISSING
 		},
 
 			{

--- a/tests/plugins/a11yhelp/manual/focusinfo.html
+++ b/tests/plugins/a11yhelp/manual/focusinfo.html
@@ -1,0 +1,7 @@
+<div id="editor"></div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/a11yhelp/manual/focusinfo.md
+++ b/tests/plugins/a11yhelp/manual/focusinfo.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.16.3, 4783, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar,basicstyles,a11yhelp
+
+### Scenario:
+
+1. Focus the edtior.
+1. Open Accessibility Help using `ALT+0` hotkey.
+1. Check `Editor Toolbar` section.
+
+	**Expected** The section contains info about focus moving to the editing area after activating a toolbar button.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4783](https://github.com/ckeditor/ckeditor4/issues/4783): Fixed: [Accessibility Help](https://ckeditor.com/cke4/addon/a11yhelp) dialog does not contain info about focus being moved back to the editing area upon activating a toolbar button.
```

## What changes did you make?

I've added info about focu… Oh, come on, it's probably clear what I did at this point!

## Which issues does your PR resolve?

Closes #4783.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
