### PR TITLE
Integrate maximize plugin with History API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@ New Features:
 * [#4612](https://github.com/ckeditor/ckeditor4/issues/4612): Allow pasting images as Base64 from [clipboard](https://ckeditor.com/cke4/addon/clipboard) in all browsers except IE.
 * [#4681](https://github.com/ckeditor/ckeditor4/issues/4681): Allow drag and drop images as Base64.
 * [#4750](https://github.com/ckeditor/ckeditor4/issues/4750): Added notification for pasting and dropping unsupported file types into the editor.
-* [#3433](https://github.com/ckeditor/ckeditor4/issues/3433): Marked required fields in dialogs with asterisk (*) symbol.
+* [#3433](https://github.com/ckeditor/ckeditor4/issues/3433): Marked required fields in dialogs with asterisk (`*`) symbol.
+* [#4374](https://github.com/ckeditor/ckeditor4/issues/4374): Integrated [Maximize](https://ckeditor.com/cke4/addon/maximize) plugin with browser's History API.
 
 Fixed Issues:
 

--- a/core/dom/event.js
+++ b/core/dom/event.js
@@ -226,3 +226,13 @@ CKEDITOR.HISTORY_NATIVE = 1;
  * @member CKEDITOR
  */
 CKEDITOR.HISTORY_HASH = 2;
+
+/**
+ * Switch off integration with browser's "Go back" and "Go forward" buttons.
+ *
+ * @since 4.17.0
+ * @readonly
+ * @property {Number} [=0]
+ * @member CKEDITOR
+ */
+CKEDITOR.HISTORY_OFF = 0;

--- a/core/dom/event.js
+++ b/core/dom/event.js
@@ -206,3 +206,23 @@ CKEDITOR.EVENT_PHASE_AT_TARGET = 2;
  * @member CKEDITOR
  */
 CKEDITOR.EVENT_PHASE_BUBBLING = 3;
+
+/**
+ * Integration with browser's "Go back" and "Go forward" buttons using Native History API.
+ *
+ * @since 4.17.0
+ * @readonly
+ * @property {Number} [=1]
+ * @member CKEDITOR
+ */
+CKEDITOR.HISTORY_NATIVE = 1;
+
+/**
+ * Integration with browser's "Go back" and "Go forward" buttons using hash-based navigation.
+ *
+ * @since 4.17.0
+ * @readonly
+ * @property {Number} [=2]
+ * @member CKEDITOR
+ */
+CKEDITOR.HISTORY_HASH = 2;

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -299,6 +299,15 @@
 				var command = editor.getCommand( 'maximize' );
 				command.setState( command.state == CKEDITOR.TRISTATE_DISABLED ? CKEDITOR.TRISTATE_DISABLED : savedState );
 			}, null, null, 100 );
+
+			// Add support for History API (#4374).
+			mainWindow.on( 'popstate', function() {
+				var command = editor.getCommand( 'maximize' );
+
+				if ( command.state === CKEDITOR.TRISTATE_ON ) {
+					command.exec();
+				}
+			} );
 		}
 	} );
 } )();

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -318,13 +318,17 @@
 
 	/**
 	 * Informs plugin how it should integrate with browser's "Go back" and "Go forward" buttons.
-	 * If it's set to {@link CKEDITOR.plugins.maximize#HISTORY_NATIVE}, the plugin will use native History API and
-	 * [`popstate`](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event) event.
-	 * If it's set to {@link CKEDITOR.plugins.maximize#HISTORY_HASH}, the plugin will use
-	 * [`hashchange`](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event) event.
-	 * If it's set to `false`, the plugin will not integrate with browser's "Go back" and "Go forward" buttons.
 	 *
-	 * @cfg {Boolean} [maximize_historyIntegration=CKEDITOR.HISTORY_NATIVE]
+	 * If it's set to {@link CKEDITOR#HISTORY_NATIVE}, the plugin will use native History API and
+	 * [`popstate`](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event) event.
+	 *
+	 * If it's set to {@link CKEDITOR#HISTORY_HASH}, the plugin will use
+	 * [`hashchange`](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event) event.
+	 *
+	 * If it's set to {@link CKEDITOR#HISTORY_OFF}, the plugin will not integrate
+	 * with browser's "Go back" and "Go forward" buttons.
+	 *
+	 * @cfg {Number} [maximize_historyIntegration=CKEDITOR.HISTORY_NATIVE]
 	 * @member CKEDITOR.config
 	 */
 	CKEDITOR.config.maximize_historyIntegration = CKEDITOR.HISTORY_NATIVE;

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -301,7 +301,9 @@
 			}, null, null, 100 );
 
 			// Add support for History API (#4374).
-			mainWindow.on( 'popstate', function() {
+			var historyEvent = editor.config.maximize_useHistoryApi ? 'popstate': 'hashchange';
+
+			mainWindow.on( historyEvent, function() {
 				var command = editor.getCommand( 'maximize' );
 
 				if ( command.state === CKEDITOR.TRISTATE_ON ) {
@@ -310,6 +312,42 @@
 			} );
 		}
 	} );
+
+	/**
+	 * @since 4.17.0
+	 * @singleton
+	 * @class CKEDITOR.plugins.maximize
+	 */
+	CKEDITOR.plugins.maximize = {
+		/**
+		 * Integration with browser's "Go back" and "Go forward" buttons using Native History API.
+		 *
+		 * @readonly
+		 * @property {Number} [=1]
+		 */
+		HISTORY_NATIVE: 1,
+
+		/**
+		 * Integration with browser's "Go back" and "Go forward" buttons using Native History API.
+		 *
+		 * @readonly
+		 * @property {Number} [=2]
+		 */
+		HISTORY_HASH: 2
+	};
+
+	/**
+	 * Informs plugin how it should integrate with browser's "Go back" and "Go forward" buttons.
+	 * If it's set to {@link CKEDITOR.plugins.maximize#HISTORY_NATIVE}, the plugin will use native History API and
+	 * [`popstate`](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event) event.
+	 * If it's set to {@link CKEDITOR.plugins.maximize#HISTORY_HASH}, the plugin will use
+	 * [`hashchange`](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event) event.
+	 * If it's set to `false`, the plugin will not integrate with browser's "Go back" and "Go forward" buttons.
+	 *
+	 * @cfg {Boolean} [maximize_historyIntegration=CKEDITOR.plugins.maximize.HISTORY_NATIVE]
+	 * @member CKEDITOR.config
+	 */
+	CKEDITOR.config.maximize_historyIntegration = CKEDITOR.plugins.maximize.HISTORY_NATIVE;
 } )();
 
 /**

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -301,40 +301,20 @@
 			}, null, null, 100 );
 
 			// Add support for History API (#4374).
-			var historyEvent = editor.config.maximize_useHistoryApi ? 'popstate': 'hashchange';
+			if ( editor.config.maximize_historyIntegration ) {
+				var historyEvent = editor.config.maximize_historyIntegration === CKEDITOR.HISTORY_NATIVE ?
+					'popstate' : 'hashchange';
 
-			mainWindow.on( historyEvent, function() {
-				var command = editor.getCommand( 'maximize' );
+				mainWindow.on( historyEvent, function() {
+					var command = editor.getCommand( 'maximize' );
 
-				if ( command.state === CKEDITOR.TRISTATE_ON ) {
-					command.exec();
-				}
-			} );
+					if ( command.state === CKEDITOR.TRISTATE_ON ) {
+						command.exec();
+					}
+				} );
+			}
 		}
 	} );
-
-	/**
-	 * @since 4.17.0
-	 * @singleton
-	 * @class CKEDITOR.plugins.maximize
-	 */
-	CKEDITOR.plugins.maximize = {
-		/**
-		 * Integration with browser's "Go back" and "Go forward" buttons using Native History API.
-		 *
-		 * @readonly
-		 * @property {Number} [=1]
-		 */
-		HISTORY_NATIVE: 1,
-
-		/**
-		 * Integration with browser's "Go back" and "Go forward" buttons using Native History API.
-		 *
-		 * @readonly
-		 * @property {Number} [=2]
-		 */
-		HISTORY_HASH: 2
-	};
 
 	/**
 	 * Informs plugin how it should integrate with browser's "Go back" and "Go forward" buttons.
@@ -344,10 +324,10 @@
 	 * [`hashchange`](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event) event.
 	 * If it's set to `false`, the plugin will not integrate with browser's "Go back" and "Go forward" buttons.
 	 *
-	 * @cfg {Boolean} [maximize_historyIntegration=CKEDITOR.plugins.maximize.HISTORY_NATIVE]
+	 * @cfg {Boolean} [maximize_historyIntegration=CKEDITOR.HISTORY_NATIVE]
 	 * @member CKEDITOR.config
 	 */
-	CKEDITOR.config.maximize_historyIntegration = CKEDITOR.plugins.maximize.HISTORY_NATIVE;
+	CKEDITOR.config.maximize_historyIntegration = CKEDITOR.HISTORY_NATIVE;
 } )();
 
 /**

--- a/tests/plugins/maximize/manual/historyapi.html
+++ b/tests/plugins/maximize/manual/historyapi.html
@@ -1,0 +1,17 @@
+<div id="editor">
+	<p>Hi, I am just a test editor!</p>
+</div>
+<button id="history-pusher">Push history</button>
+
+<script>
+	( function() {
+		if ( !history.pushState ) {
+			return bender.ignore();
+		}
+
+		CKEDITOR.document.getById( 'history-pusher' ).on( 'click', function() {
+			history.pushState( {}, '', './test' );
+		} );
+		CKEDITOR.replace( 'editor' );
+	} )();
+</script>

--- a/tests/plugins/maximize/manual/historyapi.md
+++ b/tests/plugins/maximize/manual/historyapi.md
@@ -1,0 +1,19 @@
+@bender-tags: feature, 4.17.0, 4374
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, maximize
+
+**Note** The test is best run on a browser tab with clear history.
+
+1. Click "Push history" button.
+1. Click "Maximize" toolbar button.
+1. Press browser's "Go back" button.
+
+	**Expected** Editor is no longer maximized.
+
+	**Unexpected** Editor is still maximized.
+1. Press "Maximize" toolbar button.
+1. Press borwser's "Go forward" button.
+
+	**Expected** Editor is no longer maximized.
+
+	**Unexpected** Editor is still maximized.

--- a/tests/plugins/maximize/manual/historyapihash.html
+++ b/tests/plugins/maximize/manual/historyapihash.html
@@ -5,14 +5,16 @@
 
 <script>
 	( function() {
-		if ( !( 'pushState' in history ) ) {
+		if ( !( 'onhashchange' in window ) ) {
 			return bender.ignore();
 		}
 
 		CKEDITOR.document.getById( 'history-pusher' ).on( 'click', function() {
-			history.pushState( {}, '', './test' );
+			location.hash = '#/test';
 		} );
 
-		CKEDITOR.replace( 'editor' );
+		CKEDITOR.replace( 'editor', {
+			maximize_historyIntegration: 2
+		} );
 	} )();
 </script>

--- a/tests/plugins/maximize/manual/historyapihash.md
+++ b/tests/plugins/maximize/manual/historyapihash.md
@@ -1,0 +1,19 @@
+@bender-tags: feature, 4.17.0, 4374
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, maximize
+
+**Note** The test is best run on a browser tab with clear history.
+
+1. Click "Push history" button.
+1. Click "Maximize" toolbar button.
+1. Press browser's "Go back" button.
+
+	**Expected** Editor is no longer maximized.
+
+	**Unexpected** Editor is still maximized.
+1. Press "Maximize" toolbar button.
+1. Press borwser's "Go forward" button.
+
+	**Expected** Editor is no longer maximized.
+
+	**Unexpected** Editor is still maximized.

--- a/tests/plugins/maximize/manual/historyapioff.html
+++ b/tests/plugins/maximize/manual/historyapioff.html
@@ -5,7 +5,7 @@
 
 <script>
 	( function() {
-		if ( !( 'pushState' in history ) ) {
+		if ( !history.pushState ) {
 			return bender.ignore();
 		}
 
@@ -13,6 +13,8 @@
 			history.pushState( {}, '', './test' );
 		} );
 
-		CKEDITOR.replace( 'editor' );
+		CKEDITOR.replace( 'editor', {
+			maximize_historyIntegration: false
+		} );
 	} )();
 </script>

--- a/tests/plugins/maximize/manual/historyapioff.html
+++ b/tests/plugins/maximize/manual/historyapioff.html
@@ -14,7 +14,7 @@
 		} );
 
 		CKEDITOR.replace( 'editor', {
-			maximize_historyIntegration: false
+			maximize_historyIntegration: CKEDITOR.HISTORY_OFF
 		} );
 	} )();
 </script>

--- a/tests/plugins/maximize/manual/historyapioff.md
+++ b/tests/plugins/maximize/manual/historyapioff.md
@@ -1,0 +1,20 @@
+@bender-tags: feature, 4.17.0, 4374
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, maximize
+
+**Note** The test is best run on a browser tab with clear history.
+
+**Note** Maximized editor will be covering test steps after starting, so better read them all first!
+
+1. Click "Push history" button.
+1. Click "Maximize" toolbar button.
+1. Press browser's "Go back" button.
+
+	**Expected** Editor is still maximized.
+
+	**Unexpected** Editor is no longer maximized.
+1. Press borwser's "Go forward" button.
+
+	**Expected** Editor is still maximized.
+
+	**Unexpected** Editor is no longer maximized.

--- a/tests/plugins/maximize/maximize.js
+++ b/tests/plugins/maximize/maximize.js
@@ -11,6 +11,16 @@ bender.test( {
 		}
 	},
 
+	tearDown: function() {
+		var editors = CKEDITOR.tools.object.values( CKEDITOR.instances );
+
+		CKEDITOR.tools.array.forEach( editors, function( editor ) {
+			if ( editor.getCommand( 'maximize' ).state === CKEDITOR.TRISTATE_ON ) {
+				editor.execCommand( 'maximize' );
+			}
+		} );
+	},
+
 	// https://dev.ckeditor.com/ticket/4355
 	'test command exec not require editor focus': function() {
 		if ( this.editor.elementMode == CKEDITOR.ELEMENT_MODE_INLINE )

--- a/tests/plugins/maximize/maximize.js
+++ b/tests/plugins/maximize/maximize.js
@@ -102,5 +102,94 @@ bender.test( {
 			bot.editor.execCommand( 'maximize' );
 			assert.isFalse( inner.hasClass( 'cke_maximized' ) );
 		} );
+	},
+
+	// (#4374)
+	'test maximize integrates with native History API by default': function() {
+		bender.editorBot.create( {
+			name: 'editor_historyDefault'
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				maximizeCommand = editor.getCommand( 'maximize' );
+
+			ckeWindow.on( 'popstate', function() {
+				assert.areSame( CKEDITOR.TRISTATE_OFF, maximizeCommand.state, 'Maximize has correct state – OFF' );
+			}, null, null, 999 );
+
+			editor.execCommand( 'maximize' );
+
+			ckeWindow.fire( 'popstate' );
+		} );
+	},
+
+	// (#4374)
+	'test maximize integrates with native History API if config.maximize_historyIntegration is set to native value': function() {
+		bender.editorBot.create( {
+			name: 'editor_historyNative',
+			config: {
+				maximize_historyIntegration: CKEDITOR.HISTORY_NATIVE
+			}
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				maximizeCommand = editor.getCommand( 'maximize' );
+
+			ckeWindow.on( 'popstate', function() {
+				assert.areSame( CKEDITOR.TRISTATE_OFF, maximizeCommand.state, 'Maximize has correct state – OFF' );
+			}, null, null, 999 );
+
+			editor.execCommand( 'maximize' );
+
+			ckeWindow.fire( 'popstate' );
+		} );
+	},
+
+	// (#4374)
+	'test maximize integrates with hash-based navigation if config.maximize_historyIntegration is set to hash value': function() {
+		bender.editorBot.create( {
+			name: 'editor_historyHash',
+			config: {
+				maximize_historyIntegration: CKEDITOR.HISTORY_HASH
+			}
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				maximizeCommand = editor.getCommand( 'maximize' );
+
+			ckeWindow.on( 'hashchange', function() {
+				assert.areSame( CKEDITOR.TRISTATE_OFF, maximizeCommand.state, 'Maximize has correct state – OFF' );
+			}, null, null, 999 );
+
+			editor.execCommand( 'maximize' );
+			ckeWindow.fire( 'hashchange' );
+		} );
+	},
+
+	// (#4374)
+	'test maximize does not integrates with history if config.maximize_historyIntegration is set to off value': function() {
+		bender.editorBot.create( {
+			name: 'editor_historyOff',
+			config: {
+				maximize_historyIntegration: CKEDITOR.HISTORY_OFF
+			}
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				maximizeCommand = editor.getCommand( 'maximize' );
+
+			ckeWindow.on( 'popstate', function() {
+				assert.areSame( CKEDITOR.TRISTATE_ON, maximizeCommand.state, 'Maximize has correct state – ON' );
+
+				ckeWindow.fire( 'hashchange' );
+			}, null, null, 999 );
+
+			ckeWindow.on( 'hashchange', function() {
+				assert.areSame( CKEDITOR.TRISTATE_ON, maximizeCommand.state, 'Maximize has correct state – ON' );
+			}, null, null, 999 );
+
+			editor.execCommand( 'maximize' );
+			ckeWindow.fire( 'popstate' );
+		} );
 	}
 } );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4374](https://github.com/ckeditor/ckeditor4/issues/4374): Integrated [Maximize](https://ckeditor.com/cke4/addon/maximize) plugin with browser's History API.
```

## What changes did you make?

I've added a simple `popstate` event listener, which minimize editor if it's maximized. This way the editor returns to normal dimensions when user clicks back or forward button in the browser.

There are no unit tests, unfortunately, because some of browsers (Blink-based ones) require user gesture to allow pushing to history with enabling back/forward buttons at the same time.

## Which issues does your PR resolve?

Closes #4374.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
