### PR TITLE
make javascript: protocol validation case insensitive

### DIFF
--- a/plugins/link/dialogs/link.js
+++ b/plugins/link/dialogs/link.js
@@ -342,7 +342,7 @@
 									return true;
 								}
 
-								if ( !editor.config.linkJavaScriptLinksAllowed && ( /javascript\:/ ).test( this.getValue() ) ) {
+								if ( !editor.config.linkJavaScriptLinksAllowed && ( /javascript\:/i ).test( this.getValue() ) ) {
 									alert( commonLang.invalidValue ); // jshint ignore:line
 									return false;
 								}


### PR DESCRIPTION
Protocol names are not case sensitive, reflect this fact in the validation function.