### PR TITLE
Fix for incorrect button name in `tests/core/editable/keystrokes/delbackspacequirks/manual/nbspdeleting`

### DIFF
--- a/tests/core/editable/keystrokes/delbackspacequirks/manual/nbspdeleting.md
+++ b/tests/core/editable/keystrokes/delbackspacequirks/manual/nbspdeleting.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo
 
-**Note**: On mac devices, press `fn`+`delete` whenever `delete` key is required.
+**Note**: On mac devices, press `fn`+`backspace` whenever `delete` key is required.
 
 1. Put caret right after the word `One`.
 1. Type a space. The caret is now between two visual spaces.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix for failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Not needed

## What changes did you make?

I've updated incorrect key info in `tests/core/editable/keystrokes/delbackspacequirks/manual/nbspdeleting`.

## Which issues does your PR resolve?

Closes #4830.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
