### PR TITLE
Ignore `tests/plugins/uploadwidget/manual/escapecssuploadimage` test in unsupported browsers

### DIFF
--- a/tests/plugins/uploadwidget/manual/escapecssuploadimage.html
+++ b/tests/plugins/uploadwidget/manual/escapecssuploadimage.html
@@ -9,7 +9,12 @@
 
 	( function() {
 		CKEDITOR.inline( 'edito,r', {
-			uploadUrl: '%BASE_PATH%'
+			uploadUrl: '%BASE_PATH%',
+			on: {
+				instanceReady: function( evt ) {
+					bender.tools.ignoreUnsupportedEnvironment( 'uploadwidget', evt.editor );
+				}
+			}
 		} );
 	} )();
 </script>


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix for failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

Not needed

## What changes did you make?

I've used `bender.tools.ignoreUnsupportedEnvironment` to skip the test in browsers that do not support File API.

## Which issues does your PR resolve?

Closes #4831 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
