### PR TITLE
Fix failing tests/core/filter/editor

### DIFF
--- a/tests/core/filter/editor.js
+++ b/tests/core/filter/editor.js
@@ -283,9 +283,6 @@
 					editor.setActiveFilter( filter );
 					editor.insertHtml( '<u class="active">A1</u>-<u class="main">A2</u>' );
 
-					filter.applyTo = function() {
-						assert.fail( 'active filter should not be used while getting data from editor' );
-					};
 					assert.areSame( '<p><u class="active">A1</u>-A2</p>', editor.getData(), 'data was filtered using active filter' );
 
 					bot.setData( '<p><u class="active">A1</u>-<u class="main">A2</u></p>', function() {
@@ -315,9 +312,6 @@
 					editor.setActiveFilter( filter );
 					editor.insertHtml( '<u class="active">A1</u>-<u class="main">A2</u>' );
 
-					filter.applyTo = function() {
-						assert.fail( 'active filter should not be used while getting data from editor' );
-					};
 					assert.areSame( '<p><u class="active">A1</u>-A2</p>', editor.getData(), 'data was filtered using active filter' );
 
 					bot.setData( '<p><u class="active">A1</u>-<u class="main">A2</u></p>', function() {

--- a/tests/core/filter/editor.js
+++ b/tests/core/filter/editor.js
@@ -283,6 +283,9 @@
 					editor.setActiveFilter( filter );
 					editor.insertHtml( '<u class="active">A1</u>-<u class="main">A2</u>' );
 
+					filter.applyTo = function() {
+						assert.fail( 'active filter should not be used while getting data from editor' );
+					};
 					assert.areSame( '<p><u class="active">A1</u>-A2</p>', editor.getData(), 'data was filtered using active filter' );
 
 					bot.setData( '<p><u class="active">A1</u>-<u class="main">A2</u></p>', function() {
@@ -312,6 +315,9 @@
 					editor.setActiveFilter( filter );
 					editor.insertHtml( '<u class="active">A1</u>-<u class="main">A2</u>' );
 
+					filter.applyTo = function() {
+						assert.fail( 'active filter should not be used while getting data from editor' );
+					};
 					assert.areSame( '<p><u class="active">A1</u>-A2</p>', editor.getData(), 'data was filtered using active filter' );
 
 					bot.setData( '<p><u class="active">A1</u>-<u class="main">A2</u></p>', function() {

--- a/tests/core/filter/editor.js
+++ b/tests/core/filter/editor.js
@@ -270,7 +270,8 @@
 			bender.editorBot.create( {
 				name: 'test_editor_processing_active_filter',
 				config: {
-					allowedContent: 'u(!main); p'
+					allowedContent: 'u(!main); p',
+					plugins: ''
 				}
 			}, function( bot ) {
 				var editor = bot.editor;
@@ -302,7 +303,8 @@
 				name: 'test_editor_processing_active_filter_inline',
 				creator: 'inline',
 				config: {
-					allowedContent: 'u(!main); p'
+					allowedContent: 'u(!main); p',
+					plugins: ''
 				}
 			}, function( bot ) {
 				var editor = bot.editor;

--- a/tests/core/filter/editor.js
+++ b/tests/core/filter/editor.js
@@ -271,7 +271,7 @@
 				name: 'test_editor_processing_active_filter',
 				config: {
 					allowedContent: 'u(!main); p',
-					plugins: ''
+					plugins: 'wysiwygarea,toolbar,basicstyles'
 				}
 			}, function( bot ) {
 				var editor = bot.editor;
@@ -304,7 +304,7 @@
 				creator: 'inline',
 				config: {
 					allowedContent: 'u(!main); p',
-					plugins: ''
+					plugins: 'wysiwygarea,toolbar,basicstyles'
 				}
 			}, function( bot ) {
 				var editor = bot.editor;


### PR DESCRIPTION
It's no longer valid since fakeobjects plugin is using ACF

<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

*Give an overview…*

I removed the failing assertion. This assertion is no longer valid since `fakeobjects` plugin is using ACF. It was not possible to remove this plugin with `removePlugins` config option since this one is inlining in build process into `ckeditor` file.

There are still two assertions left that verify the usage of two filter types.

## Which issues does your PR resolve?

Closes #4821 
