### PR TITLE
Fix for lack of cache key for some resources

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -287,7 +287,7 @@ CKEDITOR.config = {
 	/**
 	 * The CSS file(s) to be used to apply style to editor content. It should
 	 * reflect the CSS used in the target pages where the content is to be
-	 * displayed. Every URL is passed through {@link CKEDITOR.getUrl} function.
+	 * displayed. Every URL is passed through {@link CKEDITOR#getUrl} function.
 	 *
 	 * **Note:** This configuration value is used only in {@glink guide/dev_framed `<iframe>`-based editor }
 	 * and ignored by {@glink guide/dev_inline inline editor}

--- a/core/config.js
+++ b/core/config.js
@@ -287,7 +287,7 @@ CKEDITOR.config = {
 	/**
 	 * The CSS file(s) to be used to apply style to editor content. It should
 	 * reflect the CSS used in the target pages where the content is to be
-	 * displayed.
+	 * displayed. Every URL is passed through {@link CKEDITOR.getUrl} function.
 	 *
 	 * **Note:** This configuration value is used only in {@glink guide/dev_framed `<iframe>`-based editor }
 	 * and ignored by {@glink guide/dev_inline inline editor}
@@ -301,9 +301,9 @@ CKEDITOR.config = {
 	 *		config.contentsCss = '/css/mysitestyles.css';
 	 *		config.contentsCss = [ '/css/mysitestyles.css', '/css/anotherfile.css' ];
 	 *
-	 * @cfg {String/Array} [contentsCss=CKEDITOR.getUrl( 'contents.css' )]
+	 * @cfg {String/Array} [contentsCss='contents.css']
 	 */
-	contentsCss: CKEDITOR.getUrl( 'contents.css' ),
+	contentsCss: 'contents.css',
 
 	/**
 	 * Comma-separated list of plugins to be used in an editor instance. Note that

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -40,7 +40,7 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 *
 	 *		CKEDITOR.document.appendStyleSheet( '/mystyles.css' );
 	 *
-	 * **Note:** URLs are passed through {@link CKEDITOR.getUrl} function.
+	 * **Note:** URLs are passed through {@link CKEDITOR#getUrl} function.
 	 *
 	 * @param {String} cssFileUrl The CSS file URL.
 	 */

--- a/core/dom/document.js
+++ b/core/dom/document.js
@@ -40,9 +40,13 @@ CKEDITOR.tools.extend( CKEDITOR.dom.document.prototype, {
 	 *
 	 *		CKEDITOR.document.appendStyleSheet( '/mystyles.css' );
 	 *
+	 * **Note:** URLs are passed through {@link CKEDITOR.getUrl} function.
+	 *
 	 * @param {String} cssFileUrl The CSS file URL.
 	 */
 	appendStyleSheet: function( cssFileUrl ) {
+		cssFileUrl = CKEDITOR.getUrl( cssFileUrl );
+
 		if ( this.$.createStyleSheet )
 			this.$.createStyleSheet( cssFileUrl );
 		else {

--- a/core/tools.js
+++ b/core/tools.js
@@ -414,7 +414,7 @@
 		 * Builds a HTML snippet from a set of `<style>/<link>`.
 		 *
 		 * @param {String/Array} css Each of which are URLs (absolute) of a CSS file or
-		 * a trunk of style text. URLs are passed through {@link CKEDITOR.getUrl} function.
+		 * a trunk of style text. URLs are passed through {@link CKEDITOR#getUrl} function.
 		 * @returns {String}
 		 */
 		buildStyleHtml: function( css ) {

--- a/core/tools.js
+++ b/core/tools.js
@@ -414,7 +414,7 @@
 		 * Builds a HTML snippet from a set of `<style>/<link>`.
 		 *
 		 * @param {String/Array} css Each of which are URLs (absolute) of a CSS file or
-		 * a trunk of style text.
+		 * a trunk of style text. URLs are passed through {@link CKEDITOR.getUrl} function.
 		 * @returns {String}
 		 */
 		buildStyleHtml: function( css ) {
@@ -426,8 +426,11 @@
 					// Is CSS style text ?
 					if ( /@import|[{}]/.test( item ) )
 						retval.push( '<style>' + item + '</style>' );
-					else
+					else {
+						item = CKEDITOR.getUrl( item );
+
 						retval.push( '<link type="text/css" rel=stylesheet href="' + item + '">' );
+					}
 				}
 			}
 			return retval.join( '' );

--- a/tests/core/ckeditor/geturl.js
+++ b/tests/core/ckeditor/geturl.js
@@ -1,0 +1,157 @@
+/* bender-tags: editor */
+
+( function() {
+	'use strict';
+
+	var FAKE_BASE_PATH = 'http://some.example:1030/subdir/ckeditor/',
+		testCases = [
+			{
+				url: 'just.js',
+				expected: FAKE_BASE_PATH + 'just.js',
+				timestamp: ''
+			},
+
+			{
+				url: 'just.js',
+				expected: FAKE_BASE_PATH + 'just.js?t=347',
+				timestamp: '347'
+			},
+
+			{
+				url: './test.css',
+				expected: FAKE_BASE_PATH + './test.css',
+				timestamp: ''
+			},
+
+			{
+				url: './test.css',
+				expected: FAKE_BASE_PATH + './test.css?t=tr4',
+				timestamp: 'tr4'
+			},
+
+			{
+				url: '../whatever.js',
+				expected: FAKE_BASE_PATH + '../whatever.js',
+				timestamp: ''
+			},
+
+			{
+				url: '../whatever.js',
+				expected: FAKE_BASE_PATH + '../whatever.js?t=qwerty',
+				timestamp: 'qwerty'
+			},
+
+			{
+				url: '/file',
+				expected: '/file',
+				timestamp: ''
+			},
+
+			{
+				url: '/file',
+				expected: '/file?t=cke4',
+				timestamp: 'cke4'
+			},
+
+			{
+				url: 'http://some.site:47/file.js',
+				expected: 'http://some.site:47/file.js',
+				timestamp: ''
+			},
+
+			{
+				url: 'http://some.site:47/file.js',
+				expected: 'http://some.site:47/file.js?t=cv3',
+				timestamp: 'cv3'
+			},
+
+			{
+				url: 'https://whatever/file',
+				expected: 'https://whatever/file',
+				timestamp: ''
+			},
+
+			{
+				url: 'https://whatever/file',
+				expected: 'https://whatever/file?t=1er',
+				timestamp: '1er'
+			},
+
+			{
+				url: '//cksource.com/file.css',
+				expected: '//cksource.com/file.css',
+				timestamp: ''
+			},
+
+			{
+				url: '//cksource.com/file.css',
+				expected: '//cksource.com/file.css?t=try6',
+				timestamp: 'try6'
+			},
+
+			{
+				url: 'file.t?something=here',
+				expected: FAKE_BASE_PATH + 'file.t?something=here&t=wer',
+				timestamp: 'wer'
+			},
+
+			{
+				url: '/file.t?something=here',
+				expected: '/file.t?something=here&t=wer',
+				timestamp: 'wer'
+			},
+
+			{
+				url: 'http://dot.example/file.t?something=here',
+				expected: 'http://dot.example/file.t?something=here&t=wer',
+				timestamp: 'wer'
+			},
+
+			{
+				url: 'https://dot.example/file.t?something=here',
+				expected: 'https://dot.example/file.t?something=here&t=wer',
+				timestamp: 'wer'
+			},
+
+			{
+				url: '//dot.example/file.t?something=here',
+				expected: '//dot.example/file.t?something=here&t=wer',
+				timestamp: 'wer'
+			}
+		],
+		tests = createGetUrlTests( testCases );
+
+	bender.test( tests );
+
+	function createGetUrlTests( testCases ) {
+		return CKEDITOR.tools.array.reduce( testCases, function( tests, testCase ) {
+			var test = {},
+				testName = 'test CKEDITOR.getUrl( \'' + testCase.url + '\' ) with timestamp \'' +
+					testCase.timestamp + '\'';
+
+			test[ testName ] = createTest( testCase );
+
+			return CKEDITOR.tools.object.merge( tests, test );
+		}, {} );
+
+		function createTest( options ) {
+			var url = options.url,
+				expected = options.expected,
+				timestamp = options.timestamp;
+
+			return function() {
+				var originalBasePath = CKEDITOR.basePath,
+					originalTimestamp = CKEDITOR.timestamp,
+					actualResult;
+
+				CKEDITOR.basePath = FAKE_BASE_PATH;
+				CKEDITOR.timestamp = timestamp;
+				actualResult = CKEDITOR.getUrl( url );
+				CKEDITOR.basePath = originalBasePath;
+				CKEDITOR.timestamp = originalTimestamp;
+
+				assert.areSame( expected, actualResult, 'For ' + url + ' input correct ' + expected + ' is returned' );
+			};
+		}
+	}
+} )();

--- a/tests/core/ckeditor/manual/geturl.html
+++ b/tests/core/ckeditor/manual/geturl.html
@@ -1,0 +1,13 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	( function() {
+		if ( !CKEDITOR.timestamp ) {
+			return bender.ignore();
+		}
+
+		CKEDITOR.replace( 'editor' );
+	} )();
+</script>

--- a/tests/core/ckeditor/manual/geturl.md
+++ b/tests/core/ckeditor/manual/geturl.md
@@ -1,0 +1,10 @@
+@bender-tags: bug, 4.17.0, 4761
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, emoji, copyformatting, easyimage, tableselection
+
+**Note**: This test requires CKEDITOR with set `CKEDITOR.timestamp` (e.g. built one).
+
+1. Open developer tools and switch to "Network" tab.
+2. Refresh the page.
+
+	**Expected** CKEditor 4's resources are loaded with the cache key (`?t=<some alphanum characters>` at the end of URL).

--- a/tests/core/dom/document.js
+++ b/tests/core/dom/document.js
@@ -15,8 +15,12 @@ bender.test( appendDomObjectTests(
 			assert.areSame( document, doc.$ );
 		},
 
-		test_appendStyleSheet: function() {
-			var cssUrl = CKEDITOR.basePath + 'tests/_assets/sample.css';
+		// (#4761)
+		test_appendStyleSheet_notimestamp: function() {
+			var originalTimestamp = CKEDITOR.timestamp,
+				cssUrl = CKEDITOR.basePath + 'tests/_assets/sample.css';
+
+			CKEDITOR.timestamp = '';
 
 			var doc = new CKEDITOR.dom.document( document );
 			doc.appendStyleSheet( cssUrl );
@@ -30,6 +34,31 @@ bender.test( appendDomObjectTests(
 				}
 			}
 
+			CKEDITOR.timestamp = originalTimestamp;
+			assert.isTrue( succeed, 'The link element was not found' );
+		},
+
+		// (#4761)
+		test_appendStyleSheet_timestamp: function() {
+			var originalTimestamp = CKEDITOR.timestamp,
+				cssUrl = CKEDITOR.basePath + 'tests/_assets/sample.css',
+				expectedUrl = cssUrl + '?t=wer56';
+
+			CKEDITOR.timestamp = 'wer56';
+
+			var doc = new CKEDITOR.dom.document( document );
+			doc.appendStyleSheet( cssUrl );
+
+			var links = document.getElementsByTagName( 'link' );
+			var succeed = false;
+			for ( var i = 0 ; i < links.length ; i++ ) {
+				if ( links[ i ].href == expectedUrl ) {
+					succeed = true;
+					break;
+				}
+			}
+
+			CKEDITOR.timestamp = originalTimestamp;
 			assert.isTrue( succeed, 'The link element was not found' );
 		},
 

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -1177,6 +1177,80 @@
 			assert.areSame( 2, testSpy.callCount );
 			assert.areSame( testObj, testSpy.getCall( 0 ).thisValue );
 			assert.isTrue( testSpy.calledWithExactly( 'baz', 100, 'bar' ) );
+		},
+
+		// (#4761)
+		'test buildStyleHtml with no timestamp returns stylesheet URL without cache key for passed string': function() {
+			var originalTimestamp = CKEDITOR.timestamp,
+				url = '/file.css',
+				expectedHref = 'href="' + url + '"',
+				html;
+
+			CKEDITOR.timestamp = '';
+			html = CKEDITOR.tools.buildStyleHtml( url ),
+			CKEDITOR.timestamp = originalTimestamp;
+
+			assert.areNotSame( -1, html.indexOf( expectedHref ), 'Built HTML includes correct stylesheet link' );
+		},
+
+		// (#4761)
+		'test buildStyleHtml with set timestamp returns stylesheet URL with cache key for passed string': function() {
+			var originalTimestamp = CKEDITOR.timestamp,
+				newTimestamp = 'wer55',
+				url = '/file.css',
+				expectedHref = 'href="' + url + '?t=' + newTimestamp + '"',
+				html;
+
+			CKEDITOR.timestamp = newTimestamp;
+			html = CKEDITOR.tools.buildStyleHtml( url ),
+			CKEDITOR.timestamp = originalTimestamp;
+
+			assert.areNotSame( -1, html.indexOf( expectedHref ), 'Built HTML includes correct stylesheet link' );
+		},
+
+		// (#4761)
+		'test buildStyleHtml with no timestamp returns stylesheet URLs without cache key for passed array': function() {
+			var originalTimestamp = CKEDITOR.timestamp,
+				urls = [
+					'/file.css',
+					'/some-other-file'
+				],
+				expectedHrefs = [
+					'href="' + urls[ 0 ] + '"',
+					'href="' + urls[ 1 ] + '"'
+				],
+				html;
+
+			CKEDITOR.timestamp = '';
+			html = CKEDITOR.tools.buildStyleHtml( urls ),
+			CKEDITOR.timestamp = originalTimestamp;
+
+			CKEDITOR.tools.array.forEach( expectedHrefs, function( expectedHref ) {
+				assert.areNotSame( -1, html.indexOf( expectedHref ), 'Built HTML includes correct stylesheet link' );
+			} );
+		},
+
+		// (#4761)
+		'test buildStyleHtml with set timestamp returns stylesheet URLs with cache key for passed array': function() {
+			var originalTimestamp = CKEDITOR.timestamp,
+				newTimestamp = 'wer55',
+				urls = [
+					'/file.css',
+					'/some-other-file'
+				],
+				expectedHrefs = [
+					'href="' + urls[ 0 ] + '?t=' + newTimestamp + '"',
+					'href="' + urls[ 1 ] + '?t=' + newTimestamp + '"'
+				],
+				html;
+
+			CKEDITOR.timestamp = newTimestamp;
+			html = CKEDITOR.tools.buildStyleHtml( urls ),
+			CKEDITOR.timestamp = originalTimestamp;
+
+			CKEDITOR.tools.array.forEach( expectedHrefs, function( expectedHref ) {
+				assert.areNotSame( -1, html.indexOf( expectedHref ), 'Built HTML includes correct stylesheet link' );
+			} );
 		}
 	} );
 } )();


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Fixed Issues:

* [#4761](https://github.com/ckeditor/ckeditor4/issues/4761): Fixed: not all resources loaded by the editor respect the cache key.

API Changes:

* [#4761](https://github.com/ckeditor/ckeditor4/issues/4761): [`CKEDITOR.dom.document#appendStyleSheet()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_document.html#method-appendStyleSheet) and [`CKEDITOR.tools.buildStyleHtml()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-buildStyleHtml) now use [`CKEDITOR.getUrl()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-getUrl) to correctly handle caching of CSS files.
```

## What changes did you make?

I've used `CKEDITOR.getUrl()` inside `CKEDITOR.tools.buildStyleHtml()` (used to load `config.contentsCss` files) and `CKEDITOR.dom.document#appendStyleSheet()` (used to add stylesheets in plugin) to add the cache key to every CSS file.

I've also changed the default value of `config.contentsCss` as wrapping it in `CKEDITOR.getUrl()` is no longer needed (not sure if we should add info about it to changelog or some notification in API docs?). I've added some basic tests for `CKEDITOR.getUrl()` as well – apparently it wasn't tested until now.

As it's a potentially breaking change I'll target it to `major` instead of `master`.

## Which issues does your PR resolve?

Closes #4761.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
