### PR TITLE
Change the manual test description

### DIFF
--- a/tests/plugins/toolbar/manual/hover/androidrichcombo.md
+++ b/tests/plugins/toolbar/manual/hover/androidrichcombo.md
@@ -4,17 +4,17 @@
 
 ## Procedure (Moono-Lisa on Android device)
 
-1. Check if rich combos have hover styles (darker background) by long tapping on them and releasing the finger.
+1. Check if rich combos have hover styles by long tapping on them and releasing the finger.
 
   ### Expected result
 
-  * There are hover styles **during** the tap.
-  * There aren't any hover styles **after** releasing the finger.
+  * There are hover styles (lighter background) **during** the tap.
+  * **after** releasing the finger the background becomes darker.
 
   ### Unexpected result
 
   * There aren't any hover styles **during** the tap.
-  * There are hover style **after** releasing the finger.
+  * There aren't hover style **after** releasing the finger.
 
 2. Check if taping on rich combos activate their toggled on state (lighter background).
 

--- a/tests/plugins/toolbar/manual/hover/androidrichcombo.md
+++ b/tests/plugins/toolbar/manual/hover/androidrichcombo.md
@@ -13,8 +13,7 @@
 
   ### Unexpected result
 
-  * There aren't any hover styles **during** the tap.
-  * There aren't hover style **after** releasing the finger.
+  * There aren't any hover styles **during** the tap and **after** it.
 
 2. Check if taping on rich combos activate their toggled on state (lighter background).
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

I've changed the description of test because now we have a situation that during the long-tapping on rich combo buttons we have a lighter background - `:active` state and after relating the finger the background becomes darker -`:hover` state.

## Which issues does your PR resolve?

Closes [#4701](https://github.com/ckeditor/ckeditor4/issues/4701).