### PR TITLE
Ignore unstable test on IE11

### DIFF
--- a/tests/core/editor/detaching.js
+++ b/tests/core/editor/detaching.js
@@ -32,7 +32,7 @@
 				'test should not throw any error after detach and destroy after iframe "load" event - classic editor in div': CKEDITOR.env.edge || CKEDITOR.env.safari, // (#3426)
 				'test should not throw any error after detach and destroy after iframe "load" event - classic editor in textarea': CKEDITOR.env.safari, // (#3426)
 				'test should not throw any error after detach and destroy asynchronously - classic editor in textarea': CKEDITOR.env.ie && CKEDITOR.env.version < 11,
-				'test should not throw any error after detach and destroy asynchronously - classic editor in div': CKEDITOR.env.ie && CKEDITOR.env.version < 11,
+				'test should not throw any error after detach and destroy asynchronously - classic editor in div': CKEDITOR.env.ie && CKEDITOR.env.version <= 11,
 				'test should not throw any error after detach and destroy asynchronously - divarea editor in textarea': CKEDITOR.env.ie && CKEDITOR.env.version < 11
 			}
 		},


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Ignore failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

Added unstable test (fails 1/3 runs) to ignored for IE11. It also causes failure of the next test case. During tests when I moved this particular tests case to the end - only this one failed. Permission denied is rather [old and long topic](https://github.com/ckeditor/ckeditor4/issues/3419) so it is not fixable in a small amount of time.

## Which issues does your PR resolve?

Closes #3714 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
