### PR TITLE
Preventing comparisons between thousandths of a decimal place in unit tests

### DIFF
--- a/tests/core/dom/range/getclientrectsabsolute.js
+++ b/tests/core/dom/range/getclientrectsabsolute.js
@@ -79,7 +79,7 @@
 						} else if ( bender.tools.env.mobile ) {
 							actual = Math.round( actual );
 						}
-						// Adding toFixed method in the expected values due to difference level of thousands of a decimal place on mobile devices. (#2832)
+						// Adding toFixed method to expected values due to decimal differences in the mobile screens. (#2832)
 						assert.areEqual( expected[ index ][ rectKey ].toFixed( 2 ), actual, 'rect[' + index + '].' + rectKey );
 					}
 				}

--- a/tests/core/dom/range/getclientrectsabsolute.js
+++ b/tests/core/dom/range/getclientrectsabsolute.js
@@ -79,7 +79,8 @@
 						} else if ( bender.tools.env.mobile ) {
 							actual = Math.round( actual );
 						}
-						assert.areEqual( expected[ index ][ rectKey ], actual, 'rect[' + index + '].' + rectKey );
+						// Adding toFixed method in the expected values due to difference level of thousands of a decimal place on mobile devices. (#2832)
+						assert.areEqual( expected[ index ][ rectKey ].toFixed( 2 ), actual, 'rect[' + index + '].' + rectKey );
 					}
 				}
 			} );

--- a/tests/plugins/magicline/magicline.js
+++ b/tests/plugins/magicline/magicline.js
@@ -68,7 +68,7 @@
 			if ( typeof object[ p ] == 'object' ) {
 				compareObjects( object[ p ], reference[ p ] );
 			} else {
-				// Adding toFixed method in the actual values due to difference level of thousands of a decimal place on mobile devices. (#2832)
+				// Adding toFixed method to actual values due to decimal differences in the mobile screens. (#2832)
 				assert.areEqual( reference[ p ], Math.round( object[ p ] ).toFixed( 2 ) );
 			}
 		}

--- a/tests/plugins/magicline/magicline.js
+++ b/tests/plugins/magicline/magicline.js
@@ -68,7 +68,8 @@
 			if ( typeof object[ p ] == 'object' ) {
 				compareObjects( object[ p ], reference[ p ] );
 			} else {
-				assert.areEqual( reference[ p ], Math.round( object[ p ] ) );
+				// Adding toFixed method in the actual values due to difference level of thousands of a decimal place on mobile devices. (#2832)
+				assert.areEqual( reference[ p ], Math.round( object[ p ] ).toFixed( 2 ) );
 			}
 		}
 	}


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Failing test fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

I added the `toFixed` method in assertions, which compares the values taken from mobile screens due to cases where there is a difference of e.g. 40.00 vs 40.0001221.

I also found only one device model on `BrowserStack` where only test `tests/core/dom/range/getclientrectsabsolute` fails, but in test `testing/plugins/magicline/magicline` there are values that also have the minimal differences mentioned above however the tests pass. To make sure that doesn't happen in the future, I've also added a `foFixed` method there.

## Which issues does your PR resolve?

Closes #2832.
