### PR TITLE
Failing test fix: Set fake observableParent element  

### DIFF
--- a/tests/plugins/preview/manual/previewcdn.html
+++ b/tests/plugins/preview/manual/previewcdn.html
@@ -8,6 +8,7 @@
 	</div>
 	<p>dolor sit amet.</p>
 </div>
+<div id="fake_observable_item"></div>
 
 <script>
 	if ( bender.tools.env.mobile ) {
@@ -21,7 +22,10 @@
 	var editorVersion = '',
 		path = getCKEditorCORSLink( window.location );
 
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor', {
+		// Set fake element as observableParent due to removing existing instance of the editor.
+		observableParent: document.getElementById( 'fake_observable_item' )
+	} );
 
 	CKEDITOR.once( 'instanceReady', function() {
 		var scripts = document.querySelectorAll( 'script' ),


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip.
```

## What changes did you make?

Due to addition of `MutationObserver` feature on the `major` branch, there was a problem trying to use `CKEDITOR` namespace. It resulted from the removal of the entire instance due to `cors` simulation. 
Observer tried to do something after removing the instance, but inside it uses tools from the `CKEDITOR` namespace, which did not exist at the moment. So I added a fake element outside of the editor container and set it up for observe.

This is also the reason why this failing test points to the `major` branch.   

## Which issues does your PR resolve?

Closes #4878.
