### PR TITLE
Fix for `CKEDITOR.dialog#setState()` throwing error when there is no "Ok" button in the dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#4790](https://github.com/ckeditor/ckeditor4/issues/4790): Fixed: Printing page is invoked before the printed page is fully loaded.
 * [#3876](https://github.com/ckeditor/ckeditor4/issues/3876): Fixed: [Print](https://ckeditor.com/cke4/addon/print) plugin incorrectly prints links and images.
 * [#4444](https://github.com/ckeditor/ckeditor4/issues/4444): [Firefox] Fixed: Print preview is incorrectly loaded from CDN.
+* [#4888](https://github.com/ckeditor/ckeditor4/issues/4888): Fixed: [`CKEDITOR.dialog#setState()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#method-setState) method throws error when there is no "Ok" button in the dialog.
 
 API Changes:
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -1535,12 +1535,16 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				// Finally, show the spinner.
 				this.parts.spinner.show();
 
-				this.getButton( 'ok' ).disable();
+				if ( this.getButton( 'ok' ) ) {
+					this.getButton( 'ok' ).disable();
+				}
 			} else if ( state == CKEDITOR.DIALOG_STATE_IDLE ) {
 				// Hide the spinner. But don't do anything if there is no spinner yet.
 				this.parts.spinner && this.parts.spinner.hide();
 
-				this.getButton( 'ok' ).enable();
+				if ( this.getButton( 'ok' ) ) {
+					this.getButton( 'ok' ).enable();
+				}
 			}
 
 			this.fire( 'state', state );

--- a/tests/plugins/dialog/manual/setstatenook.html
+++ b/tests/plugins/dialog/manual/setstatenook.html
@@ -1,0 +1,45 @@
+<div id="editor">
+	<p>Somebody once told me the world is gonna roll me…</p>
+</div>
+
+<button id="press">Open Dialog</button>
+<script>
+( function() {
+	if ( bender.tools.env.mobile ) {
+		return bender.ignore();
+	}
+
+	var editor = CKEDITOR.replace( 'editor' );
+
+	CKEDITOR.once( 'instanceLoaded', function() {
+		CKEDITOR.dialog.add( 'testDialog', function() {
+			return {
+				title: 'Test dialog',
+				contents: [
+					{
+						id: 'tab1',
+						label: 'Tab one',
+						elements: [
+							{
+								type: 'html',
+								id: 'field11',
+								html: 'foo'
+							}
+						]
+					}
+				],
+				buttons: [],
+				onShow: function() {
+					this.setState( CKEDITOR.DIALOG_STATE_BUSY );
+				}
+			}
+		} );
+
+		editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog' ) );
+	} );
+
+	CKEDITOR.document.getById( 'press' ).on( 'click', function() {
+		editor.execCommand( 'testDialog' );
+	} );
+} )();
+</script>

--- a/tests/plugins/dialog/manual/setstatenook.md
+++ b/tests/plugins/dialog/manual/setstatenook.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.16.3, bug, 4888
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link, image
+
+1. Open the console.
+2. Press "Open dialog" button.
+
+	**Expected** There is a spinner in the dialog's title bar and no errors in the console.
+
+	**Unexpected** There is no spinner in the dialog's title bar or some errors in the console.
+3. Close the dialog
+
+	**Expected** No new errors appear in the console.

--- a/tests/plugins/dialog/plugin.js
+++ b/tests/plugins/dialog/plugin.js
@@ -415,6 +415,63 @@
 			wait();
 		},
 
+		// (#4888)
+		'test dialog setState does not throw when dialog has no Ok button': function() {
+			var editor = this.editor,
+				errorOccured = false;
+
+			CKEDITOR.dialog.add( 'testDialogSetStateNoOk', function() {
+				return {
+					title: 'Test Dialog setState No Ok',
+					contents: [
+						{
+							id: 'tab1',
+							label: 'Test 1',
+							elements: [
+								{
+									type: 'text',
+									id: 'foo',
+									label: 'foo',
+									requiredContent: 'p'
+								}
+							]
+						}
+					],
+					buttons: []
+				};
+			} );
+
+			editor.addCommand( 'testDialogSetStateNoOk', new CKEDITOR.dialogCommand( 'testDialogSetStateNoOk' ) );
+
+			editor.once( 'dialogShow', function( evt ) {
+				var dialog = evt.data;
+
+				resume( function() {
+					try {
+						dialog.setState( CKEDITOR.DIALOG_STATE_BUSY );
+					} catch ( err ) {
+						errorOccured = true;
+					}
+
+					assert.areSame( CKEDITOR.DIALOG_STATE_BUSY, dialog.state, 'Correct dialog state – BUSY' );
+
+					// These tries are separate to catch issues with setting and unsetting busy state.
+					try {
+						dialog.setState( CKEDITOR.DIALOG_STATE_IDLE );
+					} catch ( err ) {
+						errorOccured = true;
+					}
+
+					assert.areSame( CKEDITOR.DIALOG_STATE_IDLE, dialog.state, 'Correct dialog state – IDLE' );
+					assert.isFalse( errorOccured, 'No error occured' );
+				} );
+			} );
+
+			editor.execCommand( 'testDialogSetStateNoOk' );
+
+			wait();
+		},
+
 		// #830
 		'test dialog opens tab defined in tabId as default': function() {
 			var editor = this.editor;


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<ISSUE_NUMBER>](https://github.com/ckeditor/ckeditor4/issues/4888): Fixed: [ `CKEDITOR.dialog#setState()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#method-setState) method throws error when there is no "Ok" button in the dialog.
```

## What changes did you make?

I've added a simple checks for "Ok" button presence.

## Which issues does your PR resolve?

Closes #4888.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
