### PR TITLE
Prevent br normalization in ENTER_BR mode

### DIFF
--- a/core/editable.js
+++ b/core/editable.js
@@ -1897,7 +1897,10 @@
 
 			nodesData = extractNodesData( that.dataWrapper, that );
 
-			removeBrsAdjacentToPastedBlocks( nodesData, range );
+			// Keep br's when CKEDITOR.ENTER_BR is active for proper spacing. (#3858)
+			if ( that.editor.enterMode !== 2 ) {
+				removeBrsAdjacentToPastedBlocks( nodesData, range );
+			}
 
 			for ( ; nodeIndex < nodesData.length; nodeIndex++ ) {
 				nodeData = nodesData[ nodeIndex ];

--- a/core/editable.js
+++ b/core/editable.js
@@ -1898,7 +1898,7 @@
 			nodesData = extractNodesData( that.dataWrapper, that );
 
 			// Keep br's when CKEDITOR.ENTER_BR is active for proper spacing. (#3858)
-			if ( that.editor.enterMode !== 2 ) {
+			if ( that.editor.enterMode !== CKEDITOR.ENTER_BR ) {
 				removeBrsAdjacentToPastedBlocks( nodesData, range );
 			}
 

--- a/tests/core/editable/manual/enterbr.html
+++ b/tests/core/editable/manual/enterbr.html
@@ -1,0 +1,12 @@
+<h3>Copy this:</h3>
+<p>a</p>
+<p>b</p>
+
+<p id="editor"></p>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		enterMode: CKEDITOR.ENTER_BR,
+		shiftEnterMode: CKEDITOR.ENTER_BR
+	} );
+</script>

--- a/tests/core/editable/manual/enterbr.html
+++ b/tests/core/editable/manual/enterbr.html
@@ -1,10 +1,14 @@
-<h3>Copy this:</h3>
+<h3>Copy below content:</h3>
 <p>a</p>
 <p>b</p>
-
+<br>
 <p id="editor"></p>
 
 <script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'editor', {
 		enterMode: CKEDITOR.ENTER_BR,
 		shiftEnterMode: CKEDITOR.ENTER_BR

--- a/tests/core/editable/manual/enterbr.html
+++ b/tests/core/editable/manual/enterbr.html
@@ -5,12 +5,14 @@
 <p id="editor"></p>
 
 <script>
-	if ( bender.tools.env.mobile ) {
-		bender.ignore();
-	}
+	( function() {
+		if ( bender.tools.env.mobile ) {
+			return bender.ignore();
+		}
 
-	CKEDITOR.replace( 'editor', {
-		enterMode: CKEDITOR.ENTER_BR,
-		shiftEnterMode: CKEDITOR.ENTER_BR
-	} );
+		CKEDITOR.replace( 'editor', {
+			enterMode: CKEDITOR.ENTER_BR,
+			shiftEnterMode: CKEDITOR.ENTER_BR
+		} );
+	} )();
 </script>

--- a/tests/core/editable/manual/enterbr.md
+++ b/tests/core/editable/manual/enterbr.md
@@ -1,0 +1,20 @@
+@bender-tags: 4.16.3, bug, 3858
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, clipboard, enterkey, format,
+
+
+1. Open browser's console.
+2. Copy two paragraphs placed above the editor. `<p>a</p><p>b</p>` and paste into editable.
+3. Hit enter twice.
+4. Type any ( only one ) letter and remove it using `backspace`.
+5. Paste the the same two paragraphs from `step 1` ( don't change cursor position ).
+
+**Expected**
+ * The paragraphs from `step 5` are pasted correctly.
+ * The indentation is correct.
+ * There is no error in the browser's console.
+
+**Unexpected**
+ * The paragraphs are not pasted.
+ * The cursor position has moved after the `b` letter from `step 1`.
+ * An error occurred in the browser's console: ```Cannot read properties of null (reading 'getParents')```

--- a/tests/core/editable/manual/enterbr.md
+++ b/tests/core/editable/manual/enterbr.md
@@ -1,20 +1,27 @@
 @bender-tags: 4.16.3, bug, 3858
 @bender-ui: collapsed
-@bender-ckeditor-plugins: toolbar, wysiwygarea, clipboard, enterkey, format,
+@bender-ckeditor-plugins: toolbar, wysiwygarea, clipboard, enterkey, format, sourcearea
 
+
+**Note**: Do not change the cursor position during the following steps.
 
 1. Open browser's console.
-2. Copy two paragraphs placed above the editor. `<p>a</p><p>b</p>` and paste into editable.
+2. Copy two paragraphs placed above the editor and paste then.
+
+**Note**: This will also copy `<p>` elements that are around `a` and `b` letters.
+
 3. Hit enter twice.
-4. Type any ( only one ) letter and remove it using `backspace`.
-5. Paste the the same two paragraphs from `step 1` ( don't change cursor position ).
+4. Type any (only one) letter and remove it using `backspace`.
+5. Don't change the cursor position. Paste again the same two paragraphs.
 
 **Expected**
- * The paragraphs from `step 5` are pasted correctly.
- * The indentation is correct.
+
+ * The paragraphs from `step 5` look the same as in `step2`.
+ * The place where the paragraphs were pasted has not changed.
  * There is no error in the browser's console.
 
 **Unexpected**
+
  * The paragraphs are not pasted.
  * The cursor position has moved after the `b` letter from `step 1`.
  * An error occurred in the browser's console: ```Cannot read properties of null (reading 'getParents')```

--- a/tests/core/editable/manual/enterbr.md
+++ b/tests/core/editable/manual/enterbr.md
@@ -6,13 +6,13 @@
 **Note**: Do not change the cursor position during the following steps.
 
 1. Open browser's console.
-2. Copy two paragraphs placed above the editor and paste then.
+2. Copy two paragraphs placed above the editor and paste them.
 
 **Note**: This will also copy `<p>` elements that are around `a` and `b` letters.
 
 3. Hit enter twice.
 4. Type any (only one) letter and remove it using `backspace`.
-5. Don't change the cursor position. Paste again the same two paragraphs.
+5. Remember: don't change the cursor position. Paste again the same two paragraphs.
 
 **Expected**
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3858](https://github.com/ckeditor/ckeditor4/issues/3858): Fixed pasting content in ENTER_BR mode.
```

## What changes did you make?

The problem was with the [removeBrsAdjacentToPastedBlocks()](https://github.com/ckeditor/ckeditor4/blob/t/3858/core/editable.js#L2293-L2313) function which removes the `<br>` tags when pasting content in `ENTER_BR` mode.
This resulted in a problem with the incorrect updating of `range.startOffset` causing another problem in the [getParents()](https://github.com/ckeditor/ckeditor4/blob/t%2F3858/core/dom/range.js#L277) function with trying to get a child that no longer exists.

Bugfix looks simple because I only prevented invoke `removeBrsAdjacentToPastedBlocks()` function in ENTER_BR mode.

## Which issues does your PR resolve?

Closes #3858.
