### PR TITLE
Fix issue with double escaped autolink special characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ New Features:
 * [#4807](https://github.com/ckeditor/ckeditor4/issues/4807): [Chrome] Improve the performance of pasting large images. Thanks to [FlowIT-JIT](https://github.com/FlowIT-JIT)!
 * [#4850](https://github.com/ckeditor/ckeditor4/issues/4850): Added support for loading [content templates](https://ckeditor.com/cke4/addon/templates) from HTML files. Thanks to [Fynn96](https://github.com/Fynn96)!
 * [#4874](https://github.com/ckeditor/ckeditor4/issues/4874): Added the [`config.clipboard_handleImages`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-clipboard_handleImages) configuration option for enabling and disabling built-in support for pasting and dropping images in the [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin. Thanks to [FlowIT-JIT](https://github.com/FlowIT-JIT)!
+* [#4858](https://github.com/ckeditor/ckeditor4/issues/4858): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin incorrectly escapes `&` characters when pasting links into the editor.
 
 Fixed Issues:
 

--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -74,6 +74,10 @@
 			}
 
 			function getHtmlToInsert( text ) {
+				// URL will be encoded later on with link.setAttribute method. Avoid
+				// double encoding of special characters (#4858).
+				text = CKEDITOR.tools.htmlDecodeAttr( text );
+
 				var link = new CKEDITOR.dom.element( 'a' ),
 					value = text.replace( /"/g, '%22' );
 

--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -99,6 +99,14 @@
 			assertPasteEvent( this.editors.classic, { dataValue: pastedText }, { dataValue: pastedText, type: 'html' } );
 		},
 
+		// (#4858)
+		'test URL link with encoded characters': function() {
+			var pastedText = 'https://www.google.com/test/?one=one&amp;two=two&amp;three',
+				expected = '<a href="https://www.google.com/test/?one=one&amp;two=two&amp;three">https://www.google.com/test/?one=one&amp;two=two&amp;three</a>';
+
+			assertPasteEvent( this.editors.classic, { dataValue: pastedText }, { dataValue: expected, type: 'html' } );
+		},
+
 		'test mail link with text after': function() {
 			var pastedText = 'mail@example.com nope';
 

--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -102,9 +102,15 @@
 		// (#4858)
 		'test URL link with encoded characters': function() {
 			var pastedText = 'https://www.google.com/test/?one=one&amp;two=two&amp;three',
-				expected = '<a href="https://www.google.com/test/?one=one&amp;two=two&amp;three">https://www.google.com/test/?one=one&amp;two=two&amp;three</a>';
+				expected = '<a href="https://www.google.com/test/?one=one&amp;two=two&amp;three">https://www.google.com/test/?one=one&amp;two=two&amp;three</a>',
+				spy = sinon.spy( CKEDITOR.tools, 'htmlDecodeAttr' );
 
 			assertPasteEvent( this.editors.classic, { dataValue: pastedText }, { dataValue: expected, type: 'html' } );
+
+			spy.restore();
+
+			// Ensure that the test is correct.
+			assert.isTrue( spy.calledWithExactly( pastedText ), 'htmlDecodeAttr was called with incorrect input' );
 		},
 
 		'test mail link with text after': function() {

--- a/tests/plugins/autolink/manual/encoding.html
+++ b/tests/plugins/autolink/manual/encoding.html
@@ -1,0 +1,17 @@
+<h3>URLs that should be turned into links</h3>
+
+<style>
+input[type=text] { width: 450px }
+</style>
+
+<input type="text" readonly="readonly" value="https://www.google.com/test/?one=one&two=two&three">
+
+<textarea id="editor" cols="10" rows="10">
+	<p>Foo bar.</p>
+</textarea>
+
+<script>
+	bender.tools.ignoreUnsupportedEnvironment( 'autolink' );
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/autolink/manual/encoding.md
+++ b/tests/plugins/autolink/manual/encoding.md
@@ -1,13 +1,15 @@
 @bender-ui: collapsed
 @bender-tags: 4.17.0, bug, 4858
-@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, elementspath, autolink
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, elementspath, autolink, sourcearea, htmlwriter
 
-Paste the given URL to the editor and check whether it's turned into a link.
+Paste the given URL to the editor and check whether it's turned into a link. Make sure to also confirm links in source area.
 
 ## Expected
 
-Link is pasted as it is, without additional encoding.
+**Editor:** Link is pasted as it is, without additional encoding.
+**Source area:** `&` characters are single encoded with `&amp;`.
 
 ## Unexpected
 
-Special `&` characters are additionaly encoded to `&amp;`.
+**Editor:** Special `&` characters are additionaly encoded to `&amp;`.
+**Source area:** `&` characters are double encoded to `&amp;amp;`.

--- a/tests/plugins/autolink/manual/encoding.md
+++ b/tests/plugins/autolink/manual/encoding.md
@@ -7,9 +7,11 @@ Paste the given URL to the editor and check whether it's turned into a link. Mak
 ## Expected
 
 **Editor:** Link is pasted as it is, without additional encoding.
+
 **Source area:** `&` characters are single encoded with `&amp;`.
 
 ## Unexpected
 
 **Editor:** Special `&` characters are additionaly encoded to `&amp;`.
+
 **Source area:** `&` characters are double encoded to `&amp;amp;`.

--- a/tests/plugins/autolink/manual/encoding.md
+++ b/tests/plugins/autolink/manual/encoding.md
@@ -1,0 +1,13 @@
+@bender-ui: collapsed
+@bender-tags: 4.17.0, bug, 4858
+@bender-ckeditor-plugins: clipboard, toolbar, wysiwygarea, elementspath, autolink
+
+Paste the given URL to the editor and check whether it's turned into a link.
+
+## Expected
+
+Link is pasted as it is, without additional encoding.
+
+## Unexpected
+
+Special `&` characters are additionaly encoded to `&amp;`.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4858](https://github.com/ckeditor/ckeditor4/issues/4858): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin incorrectly escapes `&` characters when pasting links into the editor.
```

## What changes did you make?

Links were double escaped by executing 2x `setAttribute` method with already escaped `&` character to `&amp;`.

## Which issues does your PR resolve?

Closes #4858
