### PR TITLE
Move replace checkbox to the top to be in the reading direction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Fixed Issues:
 * [#4790](https://github.com/ckeditor/ckeditor4/issues/4790): Fixed: Printing page is invoked before the printed page is fully loaded.
 * [#4874](https://github.com/ckeditor/ckeditor4/issues/4874): Fixed: Built-in support for pasting and dropping images in the [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin restricts third party plugins from handling image pasting. Thanks to [FlowIT-JIT](https://github.com/FlowIT-JIT)!
 * [#4888](https://github.com/ckeditor/ckeditor4/issues/4888): Fixed: [`CKEDITOR.dialog#setState()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#method-setState) method throws error when there is no "Ok" button in the dialog.
+* [#4901](https://github.com/ckeditor/ckeditor4/issues/4901): Fixed: Incorrect order of controls inside [Content templates](https://ckeditor.com/cke4/addon/templates) dialog. Thanks to [Fynn96](https://github.com/Fynn96)!
 
 API Changes:
 

--- a/plugins/templates/dialogs/templates.js
+++ b/plugins/templates/dialogs/templates.js
@@ -156,6 +156,12 @@
 					type: 'vbox',
 					padding: 5,
 					children: [ {
+						id: 'chkInsertOpt',
+						type: 'checkbox',
+						label: lang.insertOption,
+						'default': config.templates_replaceContent
+					},
+					{
 						id: 'selectTplText',
 						type: 'html',
 						html: '<span>' +
@@ -170,12 +176,6 @@
 								'<div class="cke_tpl_loading"><span></span></div>' +
 							'</div>' +
 							'<span class="cke_voice_label" id="' + templateListLabelId + '">' + lang.options + '</span>'
-					},
-					{
-						id: 'chkInsertOpt',
-						type: 'checkbox',
-						label: lang.insertOption,
-						'default': config.templates_replaceContent
 					} ]
 				} ]
 			} ],

--- a/tests/plugins/templates/manual/checkboxposition.html
+++ b/tests/plugins/templates/manual/checkboxposition.html
@@ -1,0 +1,10 @@
+<textarea id="editor">
+	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		templates_files: ['../_assets/test.js'],
+		templates: 'test'
+	} );
+</script>

--- a/tests/plugins/templates/manual/checkboxposition.md
+++ b/tests/plugins/templates/manual/checkboxposition.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.17.0, bug, 4901
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, templates,
+
+1. Press "Templates" button.
+2. Look at the checkbox inside the dialog
+
+**Expected** Checkbox is above the list of templates.
+
+**Unexpected** Checkbox is below the list of templates.

--- a/tests/plugins/templates/manual/inserttemplate.md
+++ b/tests/plugins/templates/manual/inserttemplate.md
@@ -7,7 +7,7 @@
 1. Find `I want my template here -><-` text.
 2. Place the cursor between `->` and `<-`.
 3. Click the `Templates` Button.
-4. Deselect the checkbox at the bottom.
+4. Deselect the checkbox at the top.
 5. Choose the template `Some text`.
 
 **Expected:** The paragraph with the text `I am a text` followed by a second paragprah with the text `Here is some more text` will be inserted between `->` and `<-`.
@@ -19,7 +19,7 @@
 1. Find `I want my secon template here -><-` text.
 2. Place the cursor between `->` and `<-`.
 3. Click the `Templates` Button.
-4. Deselect the checkbox at the bottom.
+4. Deselect the checkbox at the top.
 5. Choose the template `Title and Text`.
 
 **Expected:** The heading `I am a title` and the text `I am a text` will be inserted between `->` and `<-`.

--- a/tests/plugins/templates/manual/inserttemplatereplace.md
+++ b/tests/plugins/templates/manual/inserttemplatereplace.md
@@ -5,7 +5,7 @@
 ## Insert template and replace all contents
 
 1. Click the `Templates` Button.
-2. Select the checkbox at the bottom.
+2. Select the checkbox at the top.
 3. Choose the template `Some text`.
 
 **Expected:** The text inside of the editor will be replaced by a paragraph with the text `I am a text` followed by a second paragprah with the text `Here is some more text`.
@@ -13,7 +13,7 @@
 ## Insert template file and replace all contents
 
 1. Click the `Templates` Button.
-2. Select the checkbox at the bottom.
+2. Select the checkbox at the top.
 3. Choose the template `Title and Text`.
 
 **Expected:** The text inside of the editor will be replaced by the heading `I am a title` and the text `I am a text`.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?
New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4901](https://github.com/ckeditor/ckeditor4/issues/4901): Move replace checkbox to the top to be in the reading direction and improve usability.
```

## What changes did you make?

Moved the replace checkbox to the top of the dialog because the dialog immedeately cloeses after selecting a template. The checkbox was under the template list and therefore was ignored multiple times. It has to be in the reading direction.

## Which issues does your PR resolve?

Closes #4901 
