### PR TITLE
Use editor's title for new preview window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ New Features:
 * [#4807](https://github.com/ckeditor/ckeditor4/issues/4807): [Chrome] Improve the performance of pasting large images. Thanks to [FlowIT-JIT](https://github.com/FlowIT-JIT)!
 * [#4850](https://github.com/ckeditor/ckeditor4/issues/4850): Added support for loading [content templates](https://ckeditor.com/cke4/addon/templates) from HTML files. Thanks to [Fynn96](https://github.com/Fynn96)!
 * [#4874](https://github.com/ckeditor/ckeditor4/issues/4874): Added the [`config.clipboard_handleImages`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-clipboard_handleImages) configuration option for enabling and disabling built-in support for pasting and dropping images in the [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin. Thanks to [FlowIT-JIT](https://github.com/FlowIT-JIT)!
-* [#4858](https://github.com/ckeditor/ckeditor4/issues/4858): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin incorrectly escapes `&` characters when pasting links into the editor.
+* [#4026](https://github.com/ckeditor/ckeditor4/issues/4026): [Preview](https://ckeditor.com/cke4/addon/preview) plugin now uses [`editor#title`](http://localhost/ckeditor4-docs/build/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-title) property for the title of the preview window. Thanks to [Ely](https://github.com/Elyasin)!
 
 Fixed Issues:
 
@@ -35,6 +35,7 @@ Fixed Issues:
 * [#4790](https://github.com/ckeditor/ckeditor4/issues/4790): Fixed: Printing page is invoked before the printed page is fully loaded.
 * [#4874](https://github.com/ckeditor/ckeditor4/issues/4874): Fixed: Built-in support for pasting and dropping images in the [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin restricts third party plugins from handling image pasting. Thanks to [FlowIT-JIT](https://github.com/FlowIT-JIT)!
 * [#4888](https://github.com/ckeditor/ckeditor4/issues/4888): Fixed: [`CKEDITOR.dialog#setState()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html#method-setState) method throws error when there is no "Ok" button in the dialog.
+* [#4858](https://github.com/ckeditor/ckeditor4/issues/4858): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) plugin incorrectly escapes `&` characters when pasting links into the editor.
 
 API Changes:
 

--- a/plugins/preview/plugin.js
+++ b/plugins/preview/plugin.js
@@ -115,7 +115,7 @@
 	function createPreviewHtml( editor, callback ) {
 		var pluginPath = CKEDITOR.plugins.getPath( 'preview' ),
 			config = editor.config,
-			title = editor.lang.preview.preview,
+			title = editor.title,
 			baseTag = generateBaseTag();
 
 		if ( config.fullPage ) {

--- a/tests/plugins/preview/manual/previewtitle.html
+++ b/tests/plugins/preview/manual/previewtitle.html
@@ -1,0 +1,13 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.safari ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		title: 'Some fancy title'
+	} );
+</script>

--- a/tests/plugins/preview/manual/previewtitle.md
+++ b/tests/plugins/preview/manual/previewtitle.md
@@ -1,0 +1,8 @@
+@bender-tags: 4.17.0, feature, 4026
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, preview, font, colorbutton, format, clipboard, pagebreak, toolbar, floatingspace, link, image2
+
+1. Click "Preview" button.
+2. Check the title of the newly opened window.
+
+	**Expected** Title equals "Some fancy title".

--- a/tests/plugins/preview/preview.js
+++ b/tests/plugins/preview/preview.js
@@ -6,17 +6,19 @@ bender.editor = {
 };
 
 bender.test( {
+	// (#4026)
 	'test title of preview': function() {
 		var tc = this,
 			editor = tc.editor;
 
 		editor.title = 'Test title';
 		editor.once( 'contentPreview', function( event ) {
-			tc.resume( function() {
-				assert.isArray( event.data.dataValue.match( '<title>' + editor.title + '</title>' ), 'Preview title is editor\'s title.' );
-			} );
-
 			event.cancel();
+
+			tc.resume( function() {
+				assert.isMatching( '<title>' + editor.title + '</title>', event.data.dataValue,
+					'Preview title is editor\'s title.' );
+			} );
 		}, null, null, 1 );
 
 		editor.execCommand( 'preview' );

--- a/tests/plugins/preview/preview.js
+++ b/tests/plugins/preview/preview.js
@@ -6,6 +6,24 @@ bender.editor = {
 };
 
 bender.test( {
+    'test title of preview': function() {
+		var tc = this,
+			editor = tc.editor;
+
+        editor.title = 'Test title';
+        editor.once('contentPreview', function( event ) {
+            tc.resume( function() {
+                assert.isArray( event.data.dataValue.match( '<title>' + editor.title + '</title>'), 'Preview title is editor\'s title.');
+            } );
+
+            event.cancel();
+       }, null, null, 1);
+
+        editor.execCommand( 'preview' );
+
+        tc.wait();
+    },
+
 	'test processing of data on contentPreview': function() {
 		var tc = this,
 			editor = tc.editor;

--- a/tests/plugins/preview/preview.js
+++ b/tests/plugins/preview/preview.js
@@ -6,23 +6,23 @@ bender.editor = {
 };
 
 bender.test( {
-    'test title of preview': function() {
+	'test title of preview': function() {
 		var tc = this,
 			editor = tc.editor;
 
-        editor.title = 'Test title';
-        editor.once('contentPreview', function( event ) {
-            tc.resume( function() {
-                assert.isArray( event.data.dataValue.match( '<title>' + editor.title + '</title>'), 'Preview title is editor\'s title.');
-            } );
+		editor.title = 'Test title';
+		editor.once( 'contentPreview', function( event ) {
+			tc.resume( function() {
+				assert.isArray( event.data.dataValue.match( '<title>' + editor.title + '</title>' ), 'Preview title is editor\'s title.' );
+			} );
 
-            event.cancel();
-       }, null, null, 1);
+			event.cancel();
+		}, null, null, 1 );
 
-        editor.execCommand( 'preview' );
+		editor.execCommand( 'preview' );
 
-        tc.wait();
-    },
+		tc.wait();
+	},
 
 	'test processing of data on contentPreview': function() {
 		var tc = this,


### PR DESCRIPTION
## What is the purpose of this pull request?

Other: It is a PR for the [Issue 4026](https://github.com/ckeditor/ckeditor4/issues/4026)

## Does your PR contain necessary tests?

No, it does not.
1. I am not sure if this change requires a test.
2. bender exits with a failure. I tried to follow the steps described in the corresponding documentation (Setting up tests, run tests, etc.). Too time consuming for this simple test.

### This PR contains

- None, as explained above

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4026](https://github.com/ckeditor/ckeditor4/issues/4026): Preview addon should use editor's "title" property for the title of the new window
```

## What changes did you make?

Changed `title = editor.lang.preview.preview,` to `title = editor.title,`

## Which issues does your PR resolve?

Closes #4026
