### PR TITLE
Prevent inline hardcoding width property using autogrow plugin

### DIFF
--- a/plugins/autogrow/plugin.js
+++ b/plugins/autogrow/plugin.js
@@ -148,11 +148,8 @@
 			if ( newHeight != currentHeight && lastHeight != newHeight ) {
 				newHeight = editor.fire( 'autoGrow', { currentHeight: currentHeight, newHeight: newHeight } ).newHeight;
 
-				var boxSizingType = editor.container.getComputedStyle( 'box-sizing' ),
-					isBorderBox = boxSizingType === 'border-box',
-					width = editor.container.getSize( 'width', isBorderBox );
-
-				editor.resize( width, newHeight, true );
+				// width parameter is null because we only need to update the height of the editor. (#4891)
+				editor.resize( null, newHeight, true );
 				lastHeight = newHeight;
 			}
 

--- a/tests/plugins/autogrow/autogrow.js
+++ b/tests/plugins/autogrow/autogrow.js
@@ -58,6 +58,25 @@
 
 				wait();
 			} );
+		},
+
+		// (#4891)
+		'test autogrow shouldn\'t add inline width property to editor container': function() {
+			var editor = this.editor,
+				bot = this.editorBot;
+
+			bot.setData( autogrowTools.getTestContent( 10 ), function() {
+				editor.once( 'afterCommandExec', function() {
+					resume( function() {
+						var editorContainerInlineWidth = editor.container.$.style.width;
+
+						assert.areSame( editorContainerInlineWidth, '', 'editor shouldn\'t have width property' );
+					} );
+				} );
+
+				editor.execCommand( 'autogrow' );
+				wait();
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/autogrow/autogrow.js
+++ b/tests/plugins/autogrow/autogrow.js
@@ -70,7 +70,7 @@
 					resume( function() {
 						var editorContainerInlineWidth = editor.container.$.style.width;
 
-						assert.areSame( editorContainerInlineWidth, '', 'editor shouldn\'t have width property' );
+						assert.areSame( editorContainerInlineWidth, '', 'editor shouldn\'t have any inline width property' );
 					} );
 				} );
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4891](https://github.com/ckeditor/ckeditor4/issues/4891): Fixed: [Autogrow](https://ckeditor.com/cke4/addon/autogrow) prevent impose fixed width size with single direction resize. 
```

## What changes did you make?

Editor container shouldn't impose fixed size with single direction resize, so I've pass `null` as `width` parameter in `editor.resize()` method to prevent this.

## Which issues does your PR resolve?

Closes #4891.
