### PR TITLE
Handling JDK version error in builder

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -88,7 +88,7 @@ fi
 	java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release $JAVA_ARGS --version="$VERSION" --revision="$REVISION" --overwrite
 } || {
 	if ! [[ $jdk_version =~ $regex ]] || [ $jdk_version -gt 15 ]; then
-		echo "${RED}Verify errors before java stack trace${RESET_STYLE}"
+		echo "\n${RED}The build has been stopped. Please verify the eventual error messages above.${RESET_STYLE}"
 	fi
 }
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

skip

## What changes did you make?

Since version 16 of JDK, our builder crashing. 
I created a simple detection of the currently installed JDK version, and when it is higher than 15, the script will be terminated with information about using the correct version

## Which issues does your PR resolve?

Closes #4883.
