### PR TITLE
Allow basic d&d element/image in tables when tableselection is on

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.17.2 [IN DEVELOPMENT]
 
+Fixed issues:
+
+* [#547](https://github.com/ckeditor/ckeditor4/issues/547): Fixed: Element/Image drag to move within the table is no longer available.
+
+
 ## CKEditor 4.17.1
 
 **Highlights:**

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -381,6 +381,9 @@
 	function fakeSelectionDragHandler( evt ) {
 		var table = evt.data.getTarget().getAscendant( 'table', true );
 
+		// Prevent table selection during dragging. (#547)
+		fakeSelection.active = false;
+
 		// (#2945)
 		if ( table && table.hasAttribute( ignoredTableAttribute ) ) {
 			return;
@@ -391,10 +394,6 @@
 		if ( !cell || cell.hasClass( fakeSelectedClass ) ) {
 			return;
 		}
-
-		// We're not supporting dragging in our table selection for the time being.
-		evt.cancel();
-		evt.data.preventDefault();
 	}
 
 	function copyTable( editor, isCut ) {
@@ -786,6 +785,11 @@
 			pastedTableMap;
 
 		if ( !isCustomPaste( selection, selectedCells, pastedTable, boundarySelection ) ) {
+			return;
+		}
+
+		// #(547)
+		if ( evt.data.method === 'drop' ) {
 			return;
 		}
 

--- a/tests/plugins/tableselection/manual/draganddropimage.html
+++ b/tests/plugins/tableselection/manual/draganddropimage.html
@@ -1,0 +1,42 @@
+<textarea id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td><img alt="" src="https://via.placeholder.com/100" />&nbsp;</td>
+				<td>test</td>
+			</tr>
+			<tr>
+				<td>
+				<p>&nbsp;</p>
+				<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+					<tbody>
+						<tr>
+							<td>&nbsp;</td>
+							<td>&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p>&nbsp;</p>
+				</td>
+				<td>&nbsp;</td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+
+	CKEDITOR.replace('editor', {
+		height: 350
+	} );
+</script>

--- a/tests/plugins/tableselection/manual/draganddropimage.html
+++ b/tests/plugins/tableselection/manual/draganddropimage.html
@@ -2,7 +2,7 @@
 	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 		<tbody>
 			<tr>
-				<td><img alt="" src="https://via.placeholder.com/100" />&nbsp;</td>
+				<td><img alt="" src="http://via.placeholder.com/100" />&nbsp;</td>
 				<td>test</td>
 			</tr>
 			<tr>
@@ -30,13 +30,15 @@
 </textarea>
 
 <script>
-	if ( bender.tools.env.mobile ) {
-		bender.ignore();
-	}
+	( function() {
+		if ( bender.tools.env.mobile ) {
+			return bender.ignore();
+		}
 
-	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+		bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
 
-	CKEDITOR.replace('editor', {
-		height: 350
-	} );
+		CKEDITOR.replace( 'editor', {
+			height: 350
+		} );
+	} )();
 </script>

--- a/tests/plugins/tableselection/manual/draganddropimage.md
+++ b/tests/plugins/tableselection/manual/draganddropimage.md
@@ -1,6 +1,6 @@
-@bender-tags: dialog, __next__, 547, bug
+@bender-tags: dialog, 4.17.1, 547, bug
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, image, undo, sourcearea, basicstyles
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, image, undo, sourcearea, basicstyles, elementspath
 
 
 1. Open browser's console.
@@ -8,10 +8,11 @@
 
 **Expected**
 
-Image was moved properly, the content looking good and there is no error in the console.
+* Image was moved properly.
+* The content looking good and there is no error in the console.
 
 **Unxpected**
 
-Image was not moved.
-There's error in the console.
-After the image was moved, the table was modified - an extra cell was added.
+* Image was not moved.
+* There's error in the console.
+* After the image was moved, the table was modified - an extra cell was added.

--- a/tests/plugins/tableselection/manual/draganddropimage.md
+++ b/tests/plugins/tableselection/manual/draganddropimage.md
@@ -1,4 +1,4 @@
-@bender-tags: dialog, _next_, 547, bug
+@bender-tags: dialog, __next__, 547, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, image, undo, sourcearea, basicstyles
 

--- a/tests/plugins/tableselection/manual/draganddropimage.md
+++ b/tests/plugins/tableselection/manual/draganddropimage.md
@@ -1,4 +1,4 @@
-@bender-tags: dialog, 4.17.1, 547, bug
+@bender-tags: dialog, 4.17.2, 547, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, image, undo, sourcearea, basicstyles, elementspath
 

--- a/tests/plugins/tableselection/manual/draganddropimage.md
+++ b/tests/plugins/tableselection/manual/draganddropimage.md
@@ -1,0 +1,17 @@
+@bender-tags: dialog, _next_, 547, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, image, undo, sourcearea, basicstyles
+
+
+1. Open browser's console.
+3. Using drag&drop move image to other table cell.
+
+**Expected**
+
+Image was moved properly, the content looking good and there is no error in the console.
+
+**Unxpected**
+
+Image was not moved.
+There's error in the console.
+After the image was moved, the table was modified - an extra cell was added.

--- a/tests/plugins/tableselection/manual/draganddropmixedcontent.html
+++ b/tests/plugins/tableselection/manual/draganddropmixedcontent.html
@@ -1,0 +1,47 @@
+<textarea id="editor">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>--&gt;&nbsp;<img alt="" src="http://via.placeholder.com/100" />&nbsp;<br />
+				Lorem ipsum dolor &lt;--<br />
+				sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&nbsp;</td>
+				<td>test</td>
+			</tr>
+			<tr>
+				<td>
+				<p> </p>
+
+				<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+					<tbody>
+						<tr>
+							<td> </td>
+							<td> </td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p> </p>
+				</td>
+				<td> </td>
+			</tr>
+			<tr>
+				<td> </td>
+				<td> </td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<script>
+	( function() {
+		if ( bender.tools.env.mobile ) {
+			return bender.ignore();
+		}
+
+		bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+
+		CKEDITOR.replace( 'editor', {
+			height: 350
+		} );
+	} )();
+</script>

--- a/tests/plugins/tableselection/manual/draganddropmixedcontent.md
+++ b/tests/plugins/tableselection/manual/draganddropmixedcontent.md
@@ -1,0 +1,19 @@
+@bender-tags: dialog, 4.17.1 547, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea, elementspath, image, basicstyles
+
+**Note:** Before you start moving the selected mixed content text using D&D, hold down the left mouse button for a moment on selected text.
+
+1. Open browser's console.
+2. Select content between `--> <--`.
+3. Using drag&drop move selected content to other table cell.
+
+**Expected**
+
+* Selected content was moved properly.
+* The content looking good and there is no error in the console.
+
+**Unxpected**
+
+* Selected content was not moved.
+* There's error in the console.

--- a/tests/plugins/tableselection/manual/draganddropmixedcontent.md
+++ b/tests/plugins/tableselection/manual/draganddropmixedcontent.md
@@ -1,4 +1,4 @@
-@bender-tags: dialog, 4.17.1 547, bug
+@bender-tags: dialog, 4.17.2 547, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea, elementspath, image, basicstyles
 

--- a/tests/plugins/tableselection/manual/draganddroptext.html
+++ b/tests/plugins/tableselection/manual/draganddroptext.html
@@ -29,11 +29,13 @@
 </textarea>
 
 <script>
-	if ( bender.tools.env.mobile ) {
-		bender.ignore();
-	}
+	( function() {
+		if ( bender.tools.env.mobile ) {
+			return bender.ignore();
+		}
 
-	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+		bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
 
-	CKEDITOR.replace('editor');
+		CKEDITOR.replace( 'editor' );
+	} )();
 </script>

--- a/tests/plugins/tableselection/manual/draganddroptext.html
+++ b/tests/plugins/tableselection/manual/draganddroptext.html
@@ -1,0 +1,39 @@
+<textarea id="editor">
+	<table border="1" cellspacing="1" cellpadding="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td>Move me.</td>
+				<td>test</td>
+			</tr>
+			<tr>
+				<td>
+					&nbsp;
+					<table border="1" cellspacing="1" cellpadding="1" style="width:500px">
+						<tbody>
+							<tr>
+								<td></td>
+								<td></td>
+							</tr>
+						</tbody>
+					</table>
+					&nbsp;
+				</td>
+				<td> </td>
+			</tr>
+			<tr>
+				<td></td>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</textarea>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
+
+	CKEDITOR.replace('editor');
+</script>

--- a/tests/plugins/tableselection/manual/draganddroptext.md
+++ b/tests/plugins/tableselection/manual/draganddroptext.md
@@ -1,0 +1,18 @@
+@bender-tags: dialog, _next_, 547, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea
+
+**Note:** Before you start moving the selected text using D&D, hold down the left mouse button for a moment on selected text.
+
+1. Open browser's console.
+2. Select only text `Move me.`.
+3. Using drag&drop move selected text to other table cell.
+
+**Expected**
+
+Selected text was moved properly, the content looking good and there is no error in the console.
+
+**Unxpected**
+
+Selected text was not moved.
+There's error in the console.

--- a/tests/plugins/tableselection/manual/draganddroptext.md
+++ b/tests/plugins/tableselection/manual/draganddroptext.md
@@ -1,6 +1,6 @@
-@bender-tags: dialog, __next__, 547, bug
+@bender-tags: dialog, 4.17.1 547, bug
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea, elementspath
 
 **Note:** Before you start moving the selected text using D&D, hold down the left mouse button for a moment on selected text.
 
@@ -10,9 +10,10 @@
 
 **Expected**
 
-Selected text was moved properly, the content looking good and there is no error in the console.
+* Selected text was moved properly.
+* The content looking good and there is no error in the console.
 
 **Unxpected**
 
-Selected text was not moved.
-There's error in the console.
+* Selected text was not moved.
+* There's error in the console.

--- a/tests/plugins/tableselection/manual/draganddroptext.md
+++ b/tests/plugins/tableselection/manual/draganddroptext.md
@@ -1,4 +1,4 @@
-@bender-tags: dialog, _next_, 547, bug
+@bender-tags: dialog, __next__, 547, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea
 

--- a/tests/plugins/tableselection/manual/draganddroptext.md
+++ b/tests/plugins/tableselection/manual/draganddroptext.md
@@ -1,4 +1,4 @@
-@bender-tags: dialog, 4.17.1 547, bug
+@bender-tags: dialog, 4.17.2 547, bug
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableselection, undo, sourcearea, elementspath
 


### PR DESCRIPTION
## What is the purpose of this pull request?

 Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#547](https://github.com/ckeditor/ckeditor4/issues/547): Fixed: Element/Image drag to move within the table is no longer available.
```

## What changes did you make?

D&D in tables was unavailable because the `drag` event handler cancel this event. 
To allow it I just removed the part of the code responsible for the interrupting of the event and in the same handler updated the `fakeSelection.active` flag to stop table selection.

This fix only allows moving only selected text and images. Trying to select an entire cell with `tableselection` and moving it fails.

PS. This branch has this name because there is already one frozen PR for this issue.

## Which issues does your PR resolve?

Closes #547.
