### PR TITLE
Remove unnecessary plugins from `previewcdn` test

### DIFF
--- a/tests/plugins/preview/manual/previewcdn.html
+++ b/tests/plugins/preview/manual/previewcdn.html
@@ -11,94 +11,99 @@
 <div id="fake_observable_item"></div>
 
 <script>
-	if ( bender.tools.env.mobile ) {
-		bender.ignore();
-	}
-
-	// 1. Load local editor by default with bender.
-	// 2. Remove existing instance and add script with editor from CDN.
-	// 3. Wait for the new editor to be loaded from CDN and initialize it.
-	// 4. Add icons in IE <11 from local.
-	var editorVersion = '',
-		path = getCKEditorCORSLink( window.location );
-
-	CKEDITOR.replace( 'editor', {
-		// Set fake element as observableParent due to removing existing instance of the editor.
-		observableParent: document.getElementById( 'fake_observable_item' )
-	} );
-
-	CKEDITOR.once( 'instanceReady', function() {
-		var scripts = document.querySelectorAll( 'script' ),
-			head = CKEDITOR.document.getHead();
-			pluginsList = CKEDITOR.tools.object.keys( this.plugins.registered ).join();
-
-		CKEDITOR.tools.array.forEach( scripts, function( script ){
-			script.parentNode.removeChild( script );
-		} );
-
-		CKEDITOR.instances.editor.destroy();
-		window.CKEDITOR = null;
-
-		var newScript = document.createElement( 'script' ),
-			loadingBox = document.getElementById( 'loading_box' ),
-			loadingText = 'Simulating loading editor from CDN';
-
-		newScript.type = 'text/javascript';
-		newScript.src = path + '/ckeditor.js';
-		document.getElementsByTagName('head')[0].appendChild( newScript );
-
-		var interval = setInterval( function() {
-			try {
-				if( CKEDITOR.status === 'loaded' ){
-					clearInterval( interval );
-
-					CKEDITOR.replace( 'editor_cdn', { plugins: pluginsList } );
-					loadingBox.innerText = editorVersion + ' editor version was loaded successfully!';
-
-					// There is problem in IE <11 with receiving icons from githack so we must add it manually.
-					if( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ){
-						CKEDITOR.once( 'instanceReady', function() {
-							fixButtonsIcons();
-						} );
-					}
-				} else {
-					loadingText += '.';
-					loadingBox.innerText = loadingText;
-				}
-			} catch ( e ) {}
-		}, 200 );
-	} );
-
-	function fixButtonsIcons() {
-		var buttons = document.querySelectorAll( '.cke_button .cke_button_icon' );
-
-		CKEDITOR.tools.array.forEach( buttons, function( button ){
-			var actualPath = button.style.backgroundImage,
-				origin = window.location.protocol + '//' + window.location.host,
-				fixedPath = actualPath.split( path ).join( origin );
-
-			button.style.backgroundImage = fixedPath;
-		} );
-	}
-
-	function getCKEditorCORSLink( location ){
-		var protocol = location.protocol,
-			hostName = location.hostname,
-			port = location.port,
-			pathName = '/apps/ckeditor',
-			possibleNewHostNames = [ '0.0.0.0', '127.0.0.1', 'localhost' ],
-			isLocalHostName = CKEDITOR.tools.indexOf( possibleNewHostNames, hostName ) !== -1;
-
-		// If we are not on localhost, simulate CORS via Githack.
-		if ( isLocalHostName ) {
-			editorVersion = 'Local';
-			var newHostName = CKEDITOR.tools.array.find( possibleNewHostNames , function( value ) {
-				return value != hostName;
-			} );
-			return protocol + '//' + newHostName + ':' + port + pathName;
+	( function () {
+		if ( bender.tools.env.mobile ) {
+			return bender.ignore();
 		}
 
-		editorVersion = 'Recent master';
-		return 'https://raw.githack.com/ckeditor/ckeditor4/master';
-	}
+		// 1. Load local editor by default with bender.
+		// 2. Remove existing instance and add script with editor from CDN.
+		// 3. Wait for the new editor to be loaded from CDN and initialize it.
+		// 4. Add icons in IE <11 from local.
+		var editorVersion = '',
+			path = getCKEditorCORSLink( window.location );
+
+		CKEDITOR.replace( 'editor', {
+			// Set fake element as observableParent due to removing existing instance of the editor.
+			observableParent: document.getElementById( 'fake_observable_item' )
+		} );
+
+		CKEDITOR.once( 'instanceReady', function () {
+			var scripts = document.querySelectorAll( 'script' ),
+				head = CKEDITOR.document.getHead(),
+				pluginsList = CKEDITOR.tools.object.keys( this.plugins.registered ).join();
+
+			CKEDITOR.tools.array.forEach( scripts, function ( script ) {
+				script.parentNode.removeChild( script );
+			} );
+
+			CKEDITOR.instances.editor.destroy();
+			window.CKEDITOR = null;
+
+			var newScript = document.createElement( 'script' ),
+				loadingBox = document.getElementById( 'loading_box' ),
+				loadingText = 'Simulating loading editor from CDN';
+
+			newScript.type = 'text/javascript';
+			newScript.src = path + '/ckeditor.js';
+			document.getElementsByTagName( 'head' )[ 0 ].appendChild( newScript );
+
+			var interval = setInterval( function () {
+				try {
+					if ( CKEDITOR.status === 'loaded' ) {
+						clearInterval( interval );
+
+						CKEDITOR.replace( 'editor_cdn', {
+							plugins: pluginsList,
+							removePlugins: 'scayt,exportpdf'
+						} );
+						loadingBox.innerText = editorVersion + ' editor version was loaded successfully!';
+
+						// There is problem in IE <11 with receiving icons from githack so we must add it manually.
+						if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+							CKEDITOR.once( 'instanceReady', function () {
+								fixButtonsIcons();
+							} );
+						}
+					} else {
+						loadingText += '.';
+						loadingBox.innerText = loadingText;
+					}
+				} catch ( e ) { }
+			}, 200 );
+		} );
+
+		function fixButtonsIcons() {
+			var buttons = document.querySelectorAll( '.cke_button .cke_button_icon' );
+
+			CKEDITOR.tools.array.forEach( buttons, function ( button ) {
+				var actualPath = button.style.backgroundImage,
+					origin = window.location.protocol + '//' + window.location.host,
+					fixedPath = actualPath.split( path ).join( origin );
+
+				button.style.backgroundImage = fixedPath;
+			} );
+		}
+
+		function getCKEditorCORSLink( location ) {
+			var protocol = location.protocol,
+				hostName = location.hostname,
+				port = location.port,
+				pathName = '/apps/ckeditor',
+				possibleNewHostNames = [ '0.0.0.0', '127.0.0.1', 'localhost' ],
+				isLocalHostName = CKEDITOR.tools.indexOf( possibleNewHostNames, hostName ) !== -1;
+
+			// If we are not on localhost, simulate CORS via Githack.
+			if ( isLocalHostName ) {
+				editorVersion = 'Local';
+				var newHostName = CKEDITOR.tools.array.find( possibleNewHostNames, function ( value ) {
+					return value != hostName;
+				} );
+				return protocol + '//' + newHostName + ':' + port + pathName;
+			}
+
+			editorVersion = 'Recent master';
+			return 'https://raw.githack.com/ckeditor/ckeditor4/master';
+		}
+	} )();
 </script>


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

When trying to load the editor from CDN on the built package there was a problem with loading `scayt` and `exportpdf` plugins. These plugins are unnecessary for this test so I just remove them. 

Additionally, I fix ignoring tests on mobile devices. 

## Which issues does your PR resolve?

Closes #4958.
