### PR TITLE
Fix toolbar configurator undefined error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ API changes:
 
 * [#4918](https://github.com/ckeditor/ckeditor4/issues/4918): Explicitly set [`config.useComputedState`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-useComputedState) default value to `true`. Thanks to [Shabab Karim](https://github.com/shabab477)!
 
+Other changes:
+
+* [#5014](https://github.com/ckeditor/ckeditor4/issues/5014): Fixed: Toolbar configurator fails when plugin not defines toolbar group. Thanks to [SuperPat](https://github.com/SuperPat45)!
+
 ## CKEditor 4.17.1
 
 **Highlights:**

--- a/samples/toolbarconfigurator/js/fulltoolbareditor.js
+++ b/samples/toolbarconfigurator/js/fulltoolbareditor.js
@@ -212,7 +212,7 @@ window.ToolbarConfigurator = {};
 		var max = buttons.length;
 		for ( var i = 0; i < max; i += 1 ) {
 			var currBtn = buttons[ i ],
-				currBtnGroupName = !!currBtn.toolbar ? currBtn.toolbar.split( ',' )[ 0 ] : "other";
+				currBtnGroupName = !!currBtn.toolbar ? currBtn.toolbar.split( ',' )[ 0 ] : 'others';
 
 			groups[ currBtnGroupName ] = groups[ currBtnGroupName ] || [];
 

--- a/samples/toolbarconfigurator/js/fulltoolbareditor.js
+++ b/samples/toolbarconfigurator/js/fulltoolbareditor.js
@@ -212,7 +212,7 @@ window.ToolbarConfigurator = {};
 		var max = buttons.length;
 		for ( var i = 0; i < max; i += 1 ) {
 			var currBtn = buttons[ i ],
-				currBtnGroupName = currBtn.toolbar.split( ',' )[ 0 ];
+				currBtnGroupName = !!currBtn.toolbar ? currBtn.toolbar.split( ',' )[ 0 ] : "other";
 
 			groups[ currBtnGroupName ] = groups[ currBtnGroupName ] || [];
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Some 3rd party plugin like Zoom does not define any toolbar option when they add a toolbar button or richcombo and the toolbar configurator crash with error:
> Uncaught TypeError: currBtn.toolbar is undefined
>     groupButtons file:///C:/ckeditor/samples/toolbarconfigurator/js/fulltoolbareditor.js:215
>     init file:///C:/ckeditor/samples/toolbarconfigurator/js/fulltoolbareditor.js:54

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5014](https://github.com/ckeditor/ckeditor4/issues/5014): Fix toolbar configurator undefined error when some 3rd-party plug-ins not defining toolbar group when adding button or richcombo
```

## What changes did you make?

This fix simply add these plug-ins buttons or richCombos in an "other" group in this case.

## Which issues does your PR resolve?

Closes #5014