### PR TITLE
Some fixes for editor builder script

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -89,6 +89,7 @@ fi
 } || {
 	if ! [[ $jdk_version =~ $regex ]] || [ $jdk_version -gt 15 ]; then
 		printf "\n${RED}The build has been stopped. Please verify the eventual error messages above.${RESET_STYLE}\n"
+		exit 1
 	fi
 }
 

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
 # For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -6,8 +6,8 @@
 
 set -e
 
-echo "CKBuilder - Builds a release version of ckeditor4."
-echo ""
+printf "CKBuilder - Builds a release version of ckeditor4.\n"
+printf "\n"
 
 CKBUILDER_VERSION="2.3.2"
 CKBUILDER_URL="https://download.cksource.com/CKBuilder/$CKBUILDER_VERSION/ckbuilder.jar"
@@ -19,14 +19,14 @@ UNDERLINE='\033[4m'
 RESET_STYLE='\033[0m'
 
 PROGNAME=$(basename $0)
-MSG_UPDATE_FAILED="Warning: The attempt to update ckbuilder.jar failed. The existing file will be used."
-MSG_DOWNLOAD_FAILED="It was not possible to download ckbuilder.jar."
-MSG_INCORRECT_JDK_VERSION="${RED}Your JDK version is not supported, there may be a problem to finish build process. Please change the JDK version to 15 or lower.${RED} ${GREEN}https://jdk.java.net/archive/${GREEN}"
+MSG_UPDATE_FAILED="Warning: The attempt to update ckbuilder.jar failed. The existing file will be used.\n"
+MSG_DOWNLOAD_FAILED="It was not possible to download ckbuilder.jar.\n"
+MSG_INCORRECT_JDK_VERSION="${RED}Your JDK version is not supported, there may be a problem to finish build process. Please change the JDK version to 15 or lower.${RED} ${GREEN}https://jdk.java.net/archive/${GREEN}\n"
 ARGS=" $@ "
 
 function error_exit
 {
-	echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+	printf "${PROGNAME}: ${1:-"Unknown Error"}\n" 1>&2
 	exit 1
 }
 
@@ -42,14 +42,14 @@ cd $(dirname $0)
 mkdir -p ckbuilder/$CKBUILDER_VERSION
 cd ckbuilder/$CKBUILDER_VERSION
 if [ -f ckbuilder.jar ]; then
-	echo "Checking/Updating CKBuilder..."
+	printf "Checking/Updating CKBuilder...\n"
 	if command_exists curl ; then
-	curl -O -R -z ckbuilder.jar $CKBUILDER_URL || echo "$MSG_UPDATE_FAILED"
+	curl -O -R -z ckbuilder.jar $CKBUILDER_URL || printf "$MSG_UPDATE_FAILED"
 	else
-	wget -N $CKBUILDER_URL || echo "$MSG_UPDATE_FAILED"
+	wget -N $CKBUILDER_URL || printf "$MSG_UPDATE_FAILED"
 	fi
 else
-	echo "Downloading CKBuilder..."
+	printf "Downloading CKBuilder...\n"
 	if command_exists curl ; then
 	curl -O -R $CKBUILDER_URL || error_exit "$MSG_DOWNLOAD_FAILED"
 	else
@@ -59,15 +59,15 @@ fi
 cd ../..
 
 # Run the builder.
-echo ""
-echo "Starting CKBuilder..."
+printf "\n"
+printf "Starting CKBuilder...\n"
 
 jdk_version=$( echo `java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}'` | bc -l);
 regex='^[0-9]+$';
 # Builder is crashing when JDK version is newer than 15.
 if ! [[ $jdk_version =~ $regex ]] || [ $jdk_version -gt 15 ]; then
-	echo "${MSG_INCORRECT_JDK_VERSION}";
-	echo "${UNDERLINE}${YELLOW}Actual version of JDK: ${jdk_version}${RESET_STYLE}";
+	printf "${MSG_INCORRECT_JDK_VERSION}\n";
+	printf "${UNDERLINE}${YELLOW}Actual version of JDK: ${jdk_version}${RESET_STYLE}\n";
 fi
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from args.
@@ -88,24 +88,24 @@ fi
 	java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release $JAVA_ARGS --version="$VERSION" --revision="$REVISION" --overwrite
 } || {
 	if ! [[ $jdk_version =~ $regex ]] || [ $jdk_version -gt 15 ]; then
-		echo "\n${RED}The build has been stopped. Please verify the eventual error messages above.${RESET_STYLE}"
+		printf "\n${RED}The build has been stopped. Please verify the eventual error messages above.${RESET_STYLE}\n"
 	fi
 }
 
 # Copy and build tests.
 if [[ "$ARGS" == *\ \-t\ * ]]; then
-	echo ""
-	echo "Copying tests..."
+	printf "\n"
+	printf "Copying tests...\n"
 
 	cp -r ../../tests release/ckeditor/tests
 	cp -r ../../package.json release/ckeditor/package.json
 	cp -r ../../bender.js release/ckeditor/bender.js
 
-	echo ""
-	echo "Installing tests..."
+	printf "\n"
+	printf "Installing tests...\n"
 
 	(cd release/ckeditor &&	npm install && bender init)
 fi
 
-echo ""
-echo "Release created in the \"release\" directory."
+printf "\n"
+printf "Release created in the \"release\" directory.\n"


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

none

## What changes did you make?

I've introduced several fixes to the CKEditor builder:

* [removed BOM to prevent "#!/bin/bash no such file or directory" error](https://unix.stackexchange.com/questions/27054/bin-bash-no-such-file-or-directory),
* changed shebang to `#!/usr/bin/env bash`,
* [used `printf` instead of `echo` to support colors](https://unix.stackexchange.com/questions/461071/color-codes-for-echo-dont-work-when-running-a-script-over-ssh).
