### PR TITLE
Fix convertToPx relying on calculator that is not present in body anymore

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -972,7 +972,7 @@
 			var calculator;
 
 			return function( cssLength ) {
-				if ( !calculator ) {
+				if ( !calculator || !CKEDITOR.document.getBody().contains(calculator) ) {
 					calculator = CKEDITOR.dom.element.createFromHtml( '<div style="position:absolute;left:-9999px;' +
 						'top:-9999px;margin:0px;padding:0px;border:0px;"' +
 						'></div>', CKEDITOR.document );


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix

# Proposed changelog message

```
* Fix fullscreen setting editor to 0px width after second invocation when using CKEDITOR with framework that replaces body content on navigation
```

## What changes did you make?

The `Fullscreen` default plugin invokes `CKEDITOR.editor.prototype.resize`, which relies on `convertCssUnitToPx( width )` and then `CKEDITOR.tools.convertToPx` for it's calculation.

The bug is in `convertToPx`. It creates a `div` HTML Element to perform it's calculation (appending it to `<body>` and invoking `.clientWidth()` on it), and stores this element on the `calculator` variable, creating a closure; the `if` checks if `calculator` is already set and, if it is, it avoids creating and appending the HTML Element to the DOM again.

However, when using CKEDITOR with any framework that handles navigation via AJAX/Fetch (like Rails Turbolinks / Turbo), which replace your entire `<body>` during navigation, if you (1) maximize a CKEDITOR instance, (2) navigate to any other page that also has a CKEDITOR instance and try to maximize it, your UI will break and the editor will be set to 0px width (I'm not attaching a screenshot because the editor simply disappears with 0px width from the screen)

This happens because on (1) the `calculator` variable will be set with the `div` HTML Element, and on (2) it will detect `calculator` was already set and not append the calculator DIV to the DOM, even tough the old calculator is not present in the DOM anymore because the entire `<body>` was replaced during the navigation.

So it will proceed to call `.clientWidth()` on that HTML element which is not present in the DOM anymore, always returning `0`. 

This bugs happens even if you cleanup after yourself by invoking `destroy()` in the CKEDITOR instance before the navigation, because the `calculator` closure is still present pointing to that `div` HTML Element that will not belong to the DOM anymore.

My PR simple checks if the `calculator` variable, even tough has already been set, actually contains a HTML element that is effectively present in the DOM, solving the bug. 


## Which issues does your PR resolve?

No issue, offering PR directly.
