### PR TITLE
Fix find and replace words with double space

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Fixed issues:
 * [#4873](https://github.com/ckeditor/ckeditor4/issues/4873): Fixed: Pasting content from MS Word and Outlook with horizontal lines prevents images from being uploaded.
 * [#4952](https://github.com/ckeditor/ckeditor4/issues/4952): Fixed: Dragging and dropping images within a table cells appends additional elements.
 * [#4761](https://github.com/ckeditor/ckeditor4/issues/4761): Fixed: not all resources loaded by the editor respect the cache key.
+* [#4987](https://github.com/ckeditor/ckeditor4/issues/4987): Fixed: [Find/Replace](https://ckeditor.com/cke4/addon/find) is not recognizing more than one space character.
 
 API changes:
 

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -365,7 +365,7 @@
 				while ( true ) {
 					var currentPatternCharacter = this._.pattern.charAt( this._.state );
 					// #4987
-					if ( c == currentPatternCharacter || isWordSeparator( c ) ) {
+					if ( c == currentPatternCharacter || compareCharacterWithPattern( c, currentPatternCharacter ) ) {
 						this._.state++;
 						if ( this._.state == this._.pattern.length ) {
 							this._.state = 0;
@@ -386,12 +386,20 @@
 		};
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
+		var spaceSeparatorRegex = /[\u0020\u00a0\u1680\u202f\u205f\u3000\u2000-\u200a]/;
 
 		function isWordSeparator( c ) {
 			if ( !c )
 				return true;
 			var code = c.charCodeAt( 0 );
 			return ( code >= 9 && code <= 0xd ) || ( code >= 0x2000 && code <= 0x200a ) || wordSeparatorRegex.test( c );
+		}
+
+		function compareCharacterWithPattern( character, currentPatternCharacter ) {
+			var isCharacterASpaceSeparator = spaceSeparatorRegex.test( character ),
+				isPatternCharacterASpaceSeparator = spaceSeparatorRegex.test( currentPatternCharacter );
+
+			return isCharacterASpaceSeparator && isPatternCharacterASpaceSeparator;
 		}
 
 		var finder = {

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -365,7 +365,7 @@
 				while ( true ) {
 					var currentPatternCharacter = this._.pattern.charAt( this._.state );
 					// #4987
-					if ( c == currentPatternCharacter || isWhiteSpace( currentPatternCharacter ) ) {
+					if ( c == currentPatternCharacter || isWordSeparator( c ) ) {
 						this._.state++;
 						if ( this._.state == this._.pattern.length ) {
 							this._.state = 0;
@@ -378,24 +378,6 @@
 						this._.state = this._.overlap[ this._.state ];
 					}
 				}
-
-				/*
-					Whitespace comes in two forms: ' ' and &nbsp;
-					We should return true if one of them occurs.
-					There may be case like:
-
-						Search range: <p>ckeditor&nbsp test</p>
-						Search input: 'ckeditor  test'
-
-					In visual side there will be no difference. The difference is in UTF-16 codes. #4987
-				*/
-				function isWhiteSpace( character ) {
-					if ( character.charCodeAt( 0 ) === 160 || character.charCodeAt() === 32 ) {
-						return true;
-					}
-
-					return false;
-				}
 			},
 
 			reset: function() {
@@ -405,12 +387,12 @@
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 
-		var isWordSeparator = function( c ) {
+		function isWordSeparator( c ) {
 			if ( !c )
 				return true;
 			var code = c.charCodeAt( 0 );
 			return ( code >= 9 && code <= 0xd ) || ( code >= 0x2000 && code <= 0x200a ) || wordSeparatorRegex.test( c );
-		};
+		}
 
 		var finder = {
 			searchRange: null,

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -363,7 +363,9 @@
 					c = c.toLowerCase();
 
 				while ( true ) {
-					if ( c == this._.pattern.charAt( this._.state ) ) {
+					var currentPatternCharacter = this._.pattern.charAt( this._.state );
+					// #4987
+					if ( c == currentPatternCharacter || isWhiteSpace( currentPatternCharacter ) ) {
 						this._.state++;
 						if ( this._.state == this._.pattern.length ) {
 							this._.state = 0;
@@ -373,8 +375,26 @@
 					} else if ( !this._.state ) {
 						return KMP_NOMATCH;
 					} else {
-						this._.state = this._.overlap[this._.state];
+						this._.state = this._.overlap[ this._.state ];
 					}
+				}
+
+				/*
+					Whitespace comes in two forms: ' ' and &nbsp;
+					We should return true if one of them occurs.
+					There may be case like:
+
+						Search range: <p>ckeditor&nbsp test</p>
+						Search input: 'ckeditor  test'
+
+					In visual side there will be no difference. The difference is in UTF-16 codes. #4987
+				*/
+				function isWhiteSpace( character ) {
+					if ( character.charCodeAt( 0 ) === 160 || character.charCodeAt() === 32 ) {
+						return true;
+					}
+
+					return false;
 				}
 			},
 

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -365,7 +365,7 @@
 				while ( true ) {
 					var currentPatternCharacter = this._.pattern.charAt( this._.state );
 					// #4987
-					if ( c == currentPatternCharacter || compareCharacterWithPattern( c, currentPatternCharacter ) ) {
+					if ( compareCharacterWithPattern( c, currentPatternCharacter ) ) {
 						this._.state++;
 						if ( this._.state == this._.pattern.length ) {
 							this._.state = 0;
@@ -396,6 +396,10 @@
 		}
 
 		function compareCharacterWithPattern( character, currentPatternCharacter ) {
+			if ( character == currentPatternCharacter ) {
+				return true;
+			}
+
 			var isCharacterASpaceSeparator = spaceSeparatorRegex.test( character ),
 				isPatternCharacterASpaceSeparator = spaceSeparatorRegex.test( currentPatternCharacter );
 

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -195,6 +195,37 @@ bender.test( {
 		} );
 	},
 
+	'test find word when pattern starting with empty space': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>example&nbsp;[&nbsp;text]</p>' );
+
+		bot.dialog( 'find', function( dialog ) {
+			dialog.getContentElement( 'find', 'btnFind' ).click();
+
+			assert.areSame( '<p>example&nbsp;<span title="highlight">&nbsp;text</span></p>', bot.getData( true ) );
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	'test find text without spaces between words should thrown alert with proper message': function() {
+		var bot = this.editorBot,
+			spy = sinon.stub( window, 'alert' );
+
+		bot.setHtmlWithSelection( '<p>exampletext</p>' );
+
+		bot.dialog( 'find', function( dialog ) {
+			dialog.setValueOf( 'find', 'txtFindFind', 'example  text' );
+			dialog.getContentElement( 'find', 'btnFind' ).click();
+
+			assert.isTrue( spy.calledOnce, 'Find text without spaces between words should thrown alert' );
+			assert.areEqual( spy.args[ 0 ][ 0 ], this.editorBot.editor.lang.find.notFoundMsg,
+				'Find text without spaces between words should have proper alert message' );
+
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
 	'test find and replace text with double space between words': function() {
 		var bot = this.editorBot;
 
@@ -226,5 +257,81 @@ bender.test( {
 
 			dialog.getButton( 'cancel' ).click();
 		} );
+	},
+
+	'test word separator: SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u0020' );
+	},
+
+	'test word separator: OGHAM SPACE MARK': function() {
+		assertSpaceSeparator( this.editorBot, '\u1680' );
+	},
+
+	'test word separator: EN QUAD': function() {
+		assertSpaceSeparator( this.editorBot, '\u2000' );
+	},
+
+	'test word separator: EM QUAD': function() {
+		assertSpaceSeparator( this.editorBot, '\u2001' );
+	},
+
+	'test word separator: EN SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2002' );
+	},
+
+	'test word separator: EM SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2003' );
+	},
+
+	'test word separator: THREE-PER-EM SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2004' );
+	},
+
+	'test word separator: FOUR-PER-EM SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2005' );
+	},
+
+	'test word separator: SIX-PER-EM SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2006' );
+	},
+
+	'test word separator: FIGURE SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2007' );
+	},
+
+	'test word separator: PUNCTUATION SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2008' );
+	},
+
+	'test word separator: THIN SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u2009' );
+	},
+
+	'test word separator: HAIR SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u200A' );
+	},
+
+	'test word separator: NARROW NO-BREAK SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u202F' );
+	},
+
+	'test word separator: IDEOGRAPHIC SPACE': function() {
+		assertSpaceSeparator( this.editorBot, '\u3000' );
 	}
+
 } );
+
+function assertSpaceSeparator( bot, unicode ) {
+	var expected = '<p><span title="highlight">test' + unicode + 'test</span></p>',
+		unicodeRaw = unicode.codePointAt( 0 ).toString( 16 );
+
+	bot.setHtmlWithSelection( '<p>test' + unicode + 'test</p>' );
+
+	bot.dialog( 'find', function( dialog ) {
+		dialog.setValueOf( 'find', 'txtFindFind', 'test' + unicode + 'test' );
+		dialog.getContentElement( 'find', 'btnFind' ).click();
+
+		assert.areSame( expected, bot.getData( true ), 'Word separator with unicode: \\u' + unicodeRaw + ' is incorrect' );
+		dialog.getButton( 'cancel' ).click();
+	} );
+}

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -267,86 +267,97 @@ bender.test( {
 	},
 
 	// #4987
-	'test word separator: SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u0020', 'SPACE' );
+	'test space separator: SPACE': function() {
+		var bot = this.editorBot,
+			expected = '<p>test<span title="highlight">&nbsp; </span>test</p>';
+
+		bot.setHtmlWithSelection( '<p>test&nbsp; test</p>' );
+
+		bot.dialog( 'find', function( dialog ) {
+			dialog.setValueOf( 'find', 'txtFindFind', '  ' );
+			dialog.getContentElement( 'find', 'btnFind' ).click();
+
+			assert.areSame( expected, bot.getData( true ), 'Word separator SPACE is incorrect' );
+			dialog.getButton( 'cancel' ).click();
+		} );
 	},
 
 	// #4987
-	'test word separator: OGHAM SPACE MARK': function() {
+	'test space separator: OGHAM SPACE MARK': function() {
 		assertSpaceSeparator( this.editorBot, '\u1680', 'OGHAM SPACE MARK' );
 	},
 
 	// #4987
-	'test word separator: EN QUAD': function() {
+	'test space separator: EN QUAD': function() {
 		assertSpaceSeparator( this.editorBot, '\u2000', 'EN QUAD' );
 	},
 
 	// #4987
-	'test word separator: EM QUAD': function() {
+	'test space separator: EM QUAD': function() {
 		assertSpaceSeparator( this.editorBot, '\u2001', 'EM QUAD' );
 	},
 
 	// #4987
-	'test word separator: EN SPACE': function() {
+	'test space separator: EN SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2002', 'EN SPACE' );
 	},
 
 	// #4987
-	'test word separator: EM SPACE': function() {
+	'test space separator: EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2003', 'EM SPACE' );
 	},
 
 	// #4987
-	'test word separator: THREE-PER-EM SPACE': function() {
+	'test space separator: THREE-PER-EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2004', 'THREE-PER-EM SPACE' );
 	},
 
 	// #4987
-	'test word separator: FOUR-PER-EM SPACE': function() {
+	'test space separator: FOUR-PER-EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2005', 'FOUR-PER-EM SPACE' );
 	},
 
 	// #4987
-	'test word separator: SIX-PER-EM SPACE': function() {
+	'test space separator: SIX-PER-EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2006', 'SIX-PER-EM SPACE' );
 	},
 
 	// #4987
-	'test word separator: FIGURE SPACE': function() {
+	'test space separator: FIGURE SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2007', 'FIGURE SPACE' );
 	},
 
 	// #4987
-	'test word separator: PUNCTUATION SPACE': function() {
+	'test space separator: PUNCTUATION SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2008', 'PUNCTUATION SPACE' );
 	},
 
 	// #4987
-	'test word separator: THIN SPACE': function() {
+	'test space separator: THIN SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2009', 'THIN SPACE' );
 	},
 
 	// #4987
-	'test word separator: HAIR SPACE': function() {
+	'test space separator: HAIR SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u200A', 'HAIR SPACE' );
 	},
 
 	// #4987
-	'test word separator: NARROW NO-BREAK SPACE': function() {
+	'test space separator: NARROW NO-BREAK SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u202F', 'NARROW NO-BREAK SPACE' );
 	},
 
 	// #4987
-	'test word separator: IDEOGRAPHIC SPACE': function() {
+	'test space separator: IDEOGRAPHIC SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u3000', 'IDEOGRAPHIC SPACE' );
 	}
 
 } );
 
 function assertSpaceSeparator( bot, unicode, name ) {
-	var expected = '<p><span title="highlight">test' + unicode + 'test</span></p>';
+	var expected = '<p>test<span title="highlight">' + unicode + ' </span>test</p>';
 
-	bot.setHtmlWithSelection( '<p>[test' + unicode + 'test]</p>' );
+	bot.setHtmlWithSelection( '<p>test[' + unicode + ' ]test</p>' );
 
 	bot.dialog( 'find', function( dialog ) {
 		dialog.getContentElement( 'find', 'btnFind' ).click();

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -351,7 +351,7 @@ function assertSpaceSeparator( bot, unicode, name ) {
 	bot.dialog( 'find', function( dialog ) {
 		dialog.getContentElement( 'find', 'btnFind' ).click();
 
-		assert.areSame( expected, bot.getData( true ), 'Word separator ' + name + ' is incorrect');
+		assert.areSame( expected, bot.getData( true ), 'Word separator ' + name + ' is incorrect' );
 		dialog.getButton( 'cancel' ).click();
 	} );
 }

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -148,6 +148,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test find text with double space between words': function() {
 		var bot = this.editorBot;
 
@@ -163,6 +164,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test find text with double &nbsp; between words': function() {
 		var bot = this.editorBot;
 
@@ -178,6 +180,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test find text with double space between words in read-only mode': function() {
 		var bot = this.editorBot;
 
@@ -195,6 +198,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test find word when pattern starting with empty space': function() {
 		var bot = this.editorBot;
 
@@ -208,6 +212,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test find text without spaces between words should thrown alert with proper message': function() {
 		var bot = this.editorBot,
 			spy = sinon.stub( window, 'alert' );
@@ -226,6 +231,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test find and replace text with double space between words': function() {
 		var bot = this.editorBot;
 
@@ -243,6 +249,7 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test replace all texts with double spaces between words': function() {
 		var bot = this.editorBot;
 
@@ -259,79 +266,92 @@ bender.test( {
 		} );
 	},
 
+	// #4987
 	'test word separator: SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u0020' );
+		assertSpaceSeparator( this.editorBot, '\u0020', 'SPACE' );
 	},
 
+	// #4987
 	'test word separator: OGHAM SPACE MARK': function() {
-		assertSpaceSeparator( this.editorBot, '\u1680' );
+		assertSpaceSeparator( this.editorBot, '\u1680', 'OGHAM SPACE MARK' );
 	},
 
+	// #4987
 	'test word separator: EN QUAD': function() {
-		assertSpaceSeparator( this.editorBot, '\u2000' );
+		assertSpaceSeparator( this.editorBot, '\u2000', 'EN QUAD' );
 	},
 
+	// #4987
 	'test word separator: EM QUAD': function() {
-		assertSpaceSeparator( this.editorBot, '\u2001' );
+		assertSpaceSeparator( this.editorBot, '\u2001', 'EM QUAD' );
 	},
 
+	// #4987
 	'test word separator: EN SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2002' );
+		assertSpaceSeparator( this.editorBot, '\u2002', 'EN SPACE' );
 	},
 
+	// #4987
 	'test word separator: EM SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2003' );
+		assertSpaceSeparator( this.editorBot, '\u2003', 'EM SPACE' );
 	},
 
+	// #4987
 	'test word separator: THREE-PER-EM SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2004' );
+		assertSpaceSeparator( this.editorBot, '\u2004', 'THREE-PER-EM SPACE' );
 	},
 
+	// #4987
 	'test word separator: FOUR-PER-EM SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2005' );
+		assertSpaceSeparator( this.editorBot, '\u2005', 'FOUR-PER-EM SPACE' );
 	},
 
+	// #4987
 	'test word separator: SIX-PER-EM SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2006' );
+		assertSpaceSeparator( this.editorBot, '\u2006', 'SIX-PER-EM SPACE' );
 	},
 
+	// #4987
 	'test word separator: FIGURE SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2007' );
+		assertSpaceSeparator( this.editorBot, '\u2007', 'FIGURE SPACE' );
 	},
 
+	// #4987
 	'test word separator: PUNCTUATION SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2008' );
+		assertSpaceSeparator( this.editorBot, '\u2008', 'PUNCTUATION SPACE' );
 	},
 
+	// #4987
 	'test word separator: THIN SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2009' );
+		assertSpaceSeparator( this.editorBot, '\u2009', 'THIN SPACE' );
 	},
 
+	// #4987
 	'test word separator: HAIR SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u200A' );
+		assertSpaceSeparator( this.editorBot, '\u200A', 'HAIR SPACE' );
 	},
 
+	// #4987
 	'test word separator: NARROW NO-BREAK SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u202F' );
+		assertSpaceSeparator( this.editorBot, '\u202F', 'NARROW NO-BREAK SPACE' );
 	},
 
+	// #4987
 	'test word separator: IDEOGRAPHIC SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u3000' );
+		assertSpaceSeparator( this.editorBot, '\u3000', 'IDEOGRAPHIC SPACE' );
 	}
 
 } );
 
-function assertSpaceSeparator( bot, unicode ) {
-	var expected = '<p><span title="highlight">test' + unicode + 'test</span></p>',
-		unicodeRaw = unicode.codePointAt( 0 ).toString( 16 );
+function assertSpaceSeparator( bot, unicode, name ) {
+	var expected = '<p><span title="highlight">test' + unicode + 'test</span></p>';
 
-	bot.setHtmlWithSelection( '<p>test' + unicode + 'test</p>' );
+	bot.setHtmlWithSelection( '<p>[test' + unicode + 'test]</p>' );
 
 	bot.dialog( 'find', function( dialog ) {
-		dialog.setValueOf( 'find', 'txtFindFind', 'test' + unicode + 'test' );
 		dialog.getContentElement( 'find', 'btnFind' ).click();
 
-		assert.areSame( expected, bot.getData( true ), 'Word separator with unicode: \\u' + unicodeRaw + ' is incorrect' );
+		assert.areSame( expected, bot.getData( true ), 'Word separator ' + name + ' is incorrect');
 		dialog.getButton( 'cancel' ).click();
 	} );
 }

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -146,5 +146,85 @@ bender.test( {
 
 			dialog.getButton( 'cancel' ).click();
 		} );
+	},
+
+	'test find text with double space between words': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>example&nbsp; text</p>' );
+
+		bot.dialog( 'find', function( dialog ) {
+			dialog.setValueOf( 'find', 'txtFindFind', 'example  text' );
+			dialog.getContentElement( 'find', 'btnFind' ).click();
+
+
+			assert.areSame( '<p><span title="highlight">example&nbsp; text</span></p>', bot.getData( true ) );
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	'test find text with double &nbsp; between words': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>example&nbsp;&nbsp;text</p>' );
+
+		bot.dialog( 'find', function( dialog ) {
+			dialog.setValueOf( 'find', 'txtFindFind', 'example  text' );
+			dialog.getContentElement( 'find', 'btnFind' ).click();
+
+
+			assert.areSame( '<p><span title="highlight">example&nbsp;&nbsp;text</span></p>', bot.getData( true ) );
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	'test find text with double space between words in read-only mode': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>example&nbsp; text</p>' );
+		bot.editor.setReadOnly( true );
+
+		bot.dialog( 'find', function( dialog ) {
+			dialog.setValueOf( 'find', 'txtFindFind', 'example  text' );
+			dialog.getContentElement( 'find', 'btnFind' ).click();
+
+			bot.editor.setReadOnly( false );
+
+			assert.areSame( '<p><span title="highlight">example&nbsp; text</span></p>', bot.getData( true ) );
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	'test find and replace text with double space between words': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>example&nbsp; text from CKEditor4</p>' );
+
+		bot.dialog( 'replace', function( dialog ) {
+			dialog.setValueOf( 'replace', 'txtFindReplace', 'example  text' );
+			dialog.setValueOf( 'replace', 'txtReplace', 'changed example text' );
+			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
+			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
+
+			assert.areSame( '<p><span title="highlight">changed example text</span> from ckeditor4</p>', bot.getData( true ) );
+
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	'test replace all texts with double spaces between words': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>[example&nbsp; text]</p><p>example&nbsp; text</p>' );
+
+		bot.dialog( 'replace', function( dialog ) {
+			dialog.setValueOf( 'replace', 'txtReplace', 'replaced text' );
+			dialog.getContentElement( 'replace', 'btnReplaceAll' ).click();
+			dialog.getButton( 'cancel' ).click();
+
+			assert.areSame( '<p>replaced text</p><p>replaced text</p>', bot.getData( false, true ) );
+
+			dialog.getButton( 'cancel' ).click();
+		} );
 	}
 } );

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -148,7 +148,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test find text with double space between words': function() {
 		var bot = this.editorBot;
 
@@ -164,7 +164,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test find text with double &nbsp; between words': function() {
 		var bot = this.editorBot;
 
@@ -180,7 +180,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test find text with double space between words in read-only mode': function() {
 		var bot = this.editorBot;
 
@@ -198,7 +198,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test find word when pattern starting with empty space': function() {
 		var bot = this.editorBot;
 
@@ -212,7 +212,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test find text without spaces between words should thrown alert with proper message': function() {
 		var bot = this.editorBot,
 			spy = sinon.stub( window, 'alert' );
@@ -231,7 +231,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test find and replace text with double space between words': function() {
 		var bot = this.editorBot;
 
@@ -249,8 +249,8 @@ bender.test( {
 		} );
 	},
 
-	// #4987
-	'test replace all texts with double spaces between words': function() {
+	// (#4987)
+	'test replace all text with double spaces between words': function() {
 		var bot = this.editorBot;
 
 		bot.setHtmlWithSelection( '<p>[example&nbsp; text]</p><p>example&nbsp; text</p>' );
@@ -266,7 +266,7 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: SPACE': function() {
 		var bot = this.editorBot,
 			expected = '<p>test<span title="highlight">&nbsp; </span>test</p>';
@@ -282,72 +282,72 @@ bender.test( {
 		} );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: OGHAM SPACE MARK': function() {
 		assertSpaceSeparator( this.editorBot, '\u1680', 'OGHAM SPACE MARK' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: EN QUAD': function() {
 		assertSpaceSeparator( this.editorBot, '\u2000', 'EN QUAD' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: EM QUAD': function() {
 		assertSpaceSeparator( this.editorBot, '\u2001', 'EM QUAD' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: EN SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2002', 'EN SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2003', 'EM SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: THREE-PER-EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2004', 'THREE-PER-EM SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: FOUR-PER-EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2005', 'FOUR-PER-EM SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: SIX-PER-EM SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2006', 'SIX-PER-EM SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: FIGURE SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2007', 'FIGURE SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: PUNCTUATION SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2008', 'PUNCTUATION SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: THIN SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u2009', 'THIN SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: HAIR SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u200A', 'HAIR SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: NARROW NO-BREAK SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u202F', 'NARROW NO-BREAK SPACE' );
 	},
 
-	// #4987
+	// (#4987)
 	'test space separator: IDEOGRAPHIC SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u3000', 'IDEOGRAPHIC SPACE' );
 	}

--- a/tests/plugins/find/manual/findandreplacedoublespacepattern.html
+++ b/tests/plugins/find/manual/findandreplacedoublespacepattern.html
@@ -1,0 +1,7 @@
+<textarea id="editor">
+	<p>CKEditor4&nbsp; search</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/find/manual/findandreplacedoublespacepattern.md
+++ b/tests/plugins/find/manual/findandreplacedoublespacepattern.md
@@ -1,0 +1,21 @@
+@bender-tags: 4.17.2, bug, 4987
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, find, sourcearea
+@bender-include: helpers/utils.js
+
+**Note:** There are two spaces between the words in step 2.
+
+1. Open Find and Replace dialog and move to `Find` tab.
+2. In `Find what:` input type `CKEditor4  search`.
+3. Click `Find` button.
+
+**Expected**
+
+Find works fine with double spaced between words.
+The search text is highlighted on the editable.
+
+**Unexpected**
+
+The searched text was not found, an alert was displayed: ```The specified text was not found```.
+
+4. Repeat above steps for the `Replace` tab and try to find and replace the search text.

--- a/tests/plugins/find/manual/findandreplacedoublespacepattern.md
+++ b/tests/plugins/find/manual/findandreplacedoublespacepattern.md
@@ -1,7 +1,6 @@
 @bender-tags: 4.17.2, bug, 4987
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, find, sourcearea
-@bender-include: helpers/utils.js
 
 **Note:** There are two spaces between the words in step 2.
 

--- a/tests/plugins/find/manual/findandreplacedoublespacepattern.md
+++ b/tests/plugins/find/manual/findandreplacedoublespacepattern.md
@@ -2,7 +2,9 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, find, sourcearea
 
-**Note:** There are two spaces between the words in step 2.
+**Note:** 
+
+There are two spaces between the words in step 2.
 
 1. Open Find and Replace dialog and move to `Find` tab.
 2. In `Find what:` input type `CKEditor4  search`.
@@ -18,3 +20,7 @@ The search text is highlighted on the editable.
 The searched text was not found, an alert was displayed: ```The specified text was not found```.
 
 4. Repeat above steps for the `Replace` tab and try to find and replace the search text.
+
+**Additional:**
+
+Check if space character in languages with different alphabets (like Japanese, Arabic) works correctly by changing OS keyboard language.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4987](https://github.com/ckeditor/ckeditor4/issues/4987): Fixed: [Find/Replace](https://ckeditor.com/cke4/addon/find) Find and replace a word with double spaces is not working.
```

## What changes did you make?

There was a problem with comparing empty spaces in `kmpMatcher`. 

When we added more than one space between words, the editor adds `&nbsp;` for the correct display of spaces while in search input this `&nbsp;` does not occur causing a difference in UTF code. 

I created a simple function for checking if the compared character is one of the possible empty spaces.

## Which issues does your PR resolve?

Closes #4987.
