### PR TITLE
Add manual test for cache keys in CDN

### DIFF
--- a/tests/core/ckeditor/manual/assetscachekeycdn.html
+++ b/tests/core/ckeditor/manual/assetscachekeycdn.html
@@ -1,0 +1,114 @@
+<div id="editor"></div>
+<button disabled id="loadButton">Load external editor</button>
+<div id="loading_box" style="margin: 20px 0"></div>
+<div id="editor_cdn">
+	<p>A simple editor</p>
+</div>
+<div id="fake_observable_item"></div>
+
+<script>
+	( function () {
+		if ( bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) ) {
+			return bender.ignore();
+		}
+
+		// 1. Load local editor by default with bender.
+		// 2. Remove existing instance and add script with editor from CDN.
+		// 3. Wait for the new editor to be loaded from CDN and initialize it.
+		// 4. Add icons in IE <11 from local.
+		var editorVersion = '',
+			path = getCKEditorCORSLink( window.location ),
+			loadButton = CKEDITOR.document.getById( 'loadButton' );
+
+		CKEDITOR.replace( 'editor', {
+			// Set fake element as observableParent due to removing existing instance of the editor.
+			observableParent: document.getElementById( 'fake_observable_item' )
+		} );
+
+		CKEDITOR.once( 'instanceReady', function() {
+			loadButton.$.disabled = false;
+			loadButton.once( 'click', loadExternalEditor );
+		} );
+
+		function loadExternalEditor() {
+			var scripts = document.querySelectorAll( 'script' ),
+				styles = document.querySelectorAll( 'style' ),
+				head = CKEDITOR.document.getHead();
+
+			CKEDITOR.tools.array.forEach( styles, function ( style ) {
+				style.parentNode.removeChild( style );
+			} );
+
+			CKEDITOR.tools.array.forEach( scripts, function ( script ) {
+				script.parentNode.removeChild( script );
+			} );
+
+			CKEDITOR.instances.editor.destroy();
+			window.CKEDITOR = null;
+
+			var newScript = document.createElement( 'script' ),
+				loadingBox = document.getElementById( 'loading_box' ),
+				loadingText = 'Simulating loading editor from CDN';
+
+			newScript.type = 'text/javascript';
+			newScript.src = path + '/ckeditor.js';
+			document.getElementsByTagName( 'head' )[ 0 ].appendChild( newScript );
+
+			var interval = setInterval( function () {
+				try {
+					if ( CKEDITOR.status === 'loaded' ) {
+						clearInterval( interval );
+
+						CKEDITOR.replace( 'editor_cdn', {
+							removePlugins: 'scayt,exportpdf'
+						} );
+						loadingBox.innerText = editorVersion + ' editor version was loaded successfully!';
+
+						// There is problem in IE <11 with receiving icons from githack so we must add it manually.
+						if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
+							CKEDITOR.once( 'instanceReady', function () {
+								fixButtonsIcons();
+							} );
+						}
+					} else {
+						loadingText += '.';
+						loadingBox.innerText = loadingText;
+					}
+				} catch ( e ) { }
+			}, 200 );
+		}
+
+		function fixButtonsIcons() {
+			var buttons = document.querySelectorAll( '.cke_button .cke_button_icon' );
+
+			CKEDITOR.tools.array.forEach( buttons, function ( button ) {
+				var actualPath = button.style.backgroundImage,
+					origin = window.location.protocol + '//' + window.location.host,
+					fixedPath = actualPath.split( path ).join( origin );
+
+				button.style.backgroundImage = fixedPath;
+			} );
+		}
+
+		function getCKEditorCORSLink( location ) {
+			var protocol = location.protocol,
+				hostName = location.hostname,
+				port = location.port,
+				pathName = '/apps/ckeditor',
+				possibleNewHostNames = [ '0.0.0.0', '127.0.0.1', 'localhost' ],
+				isLocalHostName = CKEDITOR.tools.indexOf( possibleNewHostNames, hostName ) !== -1;
+
+			// We can use local editor only if it's a built version.
+			if ( isLocalHostName && CKEDITOR.timestamp ) {
+				editorVersion = 'Local build';
+				var newHostName = CKEDITOR.tools.array.find( possibleNewHostNames, function ( value ) {
+					return value != hostName;
+				} );
+				return protocol + '//' + newHostName + ':' + port + pathName;
+			}
+
+			editorVersion = 'Nightly build';
+			return 'https://nightly.ckeditor.com/full';
+		}
+	} )();
+</script>

--- a/tests/core/ckeditor/manual/assetscachekeycdn.html
+++ b/tests/core/ckeditor/manual/assetscachekeycdn.html
@@ -15,7 +15,6 @@
 		// 1. Load local editor by default with bender.
 		// 2. Remove existing instance and add script with editor from CDN.
 		// 3. Wait for the new editor to be loaded from CDN and initialize it.
-		// 4. Add icons in IE <11 from local.
 		var editorVersion = '',
 			path = getCKEditorCORSLink( window.location ),
 			loadButton = CKEDITOR.document.getById( 'loadButton' );
@@ -32,12 +31,7 @@
 
 		function loadExternalEditor() {
 			var scripts = document.querySelectorAll( 'script' ),
-				styles = document.querySelectorAll( 'style' ),
 				head = CKEDITOR.document.getHead();
-
-			CKEDITOR.tools.array.forEach( styles, function ( style ) {
-				style.parentNode.removeChild( style );
-			} );
 
 			CKEDITOR.tools.array.forEach( scripts, function ( script ) {
 				script.parentNode.removeChild( script );
@@ -63,31 +57,12 @@
 							removePlugins: 'scayt,exportpdf'
 						} );
 						loadingBox.innerText = editorVersion + ' editor version was loaded successfully!';
-
-						// There is problem in IE <11 with receiving icons from githack so we must add it manually.
-						if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
-							CKEDITOR.once( 'instanceReady', function () {
-								fixButtonsIcons();
-							} );
-						}
 					} else {
 						loadingText += '.';
 						loadingBox.innerText = loadingText;
 					}
 				} catch ( e ) { }
 			}, 200 );
-		}
-
-		function fixButtonsIcons() {
-			var buttons = document.querySelectorAll( '.cke_button .cke_button_icon' );
-
-			CKEDITOR.tools.array.forEach( buttons, function ( button ) {
-				var actualPath = button.style.backgroundImage,
-					origin = window.location.protocol + '//' + window.location.host,
-					fixedPath = actualPath.split( path ).join( origin );
-
-				button.style.backgroundImage = fixedPath;
-			} );
 		}
 
 		function getCKEditorCORSLink( location ) {

--- a/tests/core/ckeditor/manual/assetscachekeycdn.md
+++ b/tests/core/ckeditor/manual/assetscachekeycdn.md
@@ -1,0 +1,15 @@
+@bender-tags: bug, 4.17.2, 4761
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea
+
+1. Wait for the "Load external editor" button to become enabled.
+1. Open console and switch to "Network" tab. Clear it if needed.
+1. Click "Load external editor" button and observe incoming requests
+
+ **Expected** All resources have a cache key appended to their URLs.
+
+ **Unexpected** Some resources don't have a cache key appended to their URLs.
+
+## Notes
+
+The test uses a nightly version of the editor if it's not launched from local built version.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

skip

## What changes did you make?

I've added a manual test for cache keys and CDN. It uses the same technique proposed by @KarolDawidziuk in `/tests/plugins/preview/manual/previewcdn` however, as we need a built version, it points to CKEditor 4 Nightly or to a local version if it's a built one.

## Which issues does your PR resolve?

Closes #5034.
