### PR TITLE
Fix for integration between Word and Easy Image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixed issues:
 * [#4761](https://github.com/ckeditor/ckeditor4/issues/4761): Fixed: not all resources loaded by the editor respect the cache key.
 * [#4987](https://github.com/ckeditor/ckeditor4/issues/4987): Fixed: [Find/Replace](https://ckeditor.com/cke4/addon/find) is not recognizing more than one space character.
 * [#5004](https://github.com/ckeditor/ckeditor4/issues/5004): Fixed: `MutationObserver` used in [IFrame Editing Area](https://ckeditor.com/cke4/addon/wysiwygarea) plugin causes memory leaks.
+* [#4994](https://github.com/ckeditor/ckeditor4/issues/4994): Fixed: [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin caused content pasted from Word to turn into an image.
 
 API changes:
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -251,15 +251,15 @@
 
 			setUp: function( editor, definition ) {
 				editor.on( 'paste', function( evt ) {
-					var method = evt.data.method,
-						dataTransfer = evt.data.dataTransfer,
+					var dataTransfer = evt.data.dataTransfer,
+						isFileTransfer = dataTransfer && dataTransfer.isFileTransfer(),
 						filesCount = dataTransfer && dataTransfer.getFilesCount();
 
 					if ( editor.readOnly ) {
 						return;
 					}
 
-					if ( method === 'drop' || ( method === 'paste' && filesCount ) ) {
+					if ( isFileTransfer ) {
 						var matchedFiles = [],
 							curFile;
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -274,28 +274,32 @@
 						}
 					}
 
-					if ( matchedFiles.length ) {
-						evt.cancel();
-						// At the time being we expect no other actions to happen after the widget was inserted.
-						evt.stop();
-
-						CKEDITOR.tools.array.forEach( matchedFiles, function( curFile, index ) {
-							var loader = ret._spawnLoader( editor, curFile, definition, curFile.name );
-
-							ret._insertWidget( editor, definition, URL.createObjectURL( curFile ), true, { uploadId: loader.id } );
-
-							// Now modify the selection so that the next widget won't replace the current one.
-							// This selection workaround is required to store multiple files.
-							if ( index !== matchedFiles.length - 1 ) {
-								// We don't want to modify selection for the last element, so that the last widget remains selected.
-								var sel = editor.getSelection(),
-									ranges = sel.getRanges();
-
-								ranges[ 0 ].enlarge( CKEDITOR.ENLARGE_ELEMENT );
-								ranges[ 0 ].collapse( false );
-							}
-						} );
+					if ( matchedFiles.length === 0 ) {
+						return;
 					}
+
+					evt.cancel();
+					// At the time being we expect no other actions to happen after the widget was inserted.
+					evt.stop();
+
+					CKEDITOR.tools.array.forEach( matchedFiles, function( curFile, index ) {
+						var loader = ret._spawnLoader( editor, curFile, definition, curFile.name );
+
+						ret._insertWidget( editor, definition, URL.createObjectURL( curFile ), true, { uploadId: loader.id } );
+
+						// Now modify the selection so that the next widget won't replace the current one.
+						// This selection workaround is required to store multiple files.
+						if ( index === matchedFiles.length - 1 ) {
+							// We don't want to modify selection for the last element, so that the last widget remains selected.
+							return;
+						}
+
+						var sel = editor.getSelection(),
+							ranges = sel.getRanges();
+
+						ranges[ 0 ].enlarge( CKEDITOR.ENLARGE_ELEMENT );
+						ranges[ 0 ].collapse( false );
+					} );
 				} );
 			},
 

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -255,48 +255,46 @@
 						isFileTransfer = dataTransfer && dataTransfer.isFileTransfer(),
 						filesCount = dataTransfer && dataTransfer.getFilesCount();
 
-					if ( editor.readOnly ) {
+					if ( editor.readOnly || !isFileTransfer ) {
 						return;
 					}
 
-					if ( isFileTransfer ) {
-						var matchedFiles = [],
-							curFile;
+					var matchedFiles = [],
+						curFile;
 
-						// Refetch the definition... original definition looks like an outdated copy and it doesn't
-						// include members inherited from imagebase.
-						definition = editor.widgets.registered[ definition.name ];
+					// Refetch the definition... original definition looks like an outdated copy and it doesn't
+					// include members inherited from imagebase.
+					definition = editor.widgets.registered[ definition.name ];
 
-						for ( var i = 0; i < filesCount; i++ ) {
-							curFile = dataTransfer.getFile( i );
+					for ( var i = 0; i < filesCount; i++ ) {
+						curFile = dataTransfer.getFile( i );
 
-							if ( CKEDITOR.fileTools.isTypeSupported( curFile, definition.supportedTypes ) ) {
-								matchedFiles.push( curFile );
+						if ( CKEDITOR.fileTools.isTypeSupported( curFile, definition.supportedTypes ) ) {
+							matchedFiles.push( curFile );
+						}
+					}
+
+					if ( matchedFiles.length ) {
+						evt.cancel();
+						// At the time being we expect no other actions to happen after the widget was inserted.
+						evt.stop();
+
+						CKEDITOR.tools.array.forEach( matchedFiles, function( curFile, index ) {
+							var loader = ret._spawnLoader( editor, curFile, definition, curFile.name );
+
+							ret._insertWidget( editor, definition, URL.createObjectURL( curFile ), true, { uploadId: loader.id } );
+
+							// Now modify the selection so that the next widget won't replace the current one.
+							// This selection workaround is required to store multiple files.
+							if ( index !== matchedFiles.length - 1 ) {
+								// We don't want to modify selection for the last element, so that the last widget remains selected.
+								var sel = editor.getSelection(),
+									ranges = sel.getRanges();
+
+								ranges[ 0 ].enlarge( CKEDITOR.ENLARGE_ELEMENT );
+								ranges[ 0 ].collapse( false );
 							}
-						}
-
-						if ( matchedFiles.length ) {
-							evt.cancel();
-							// At the time being we expect no other actions to happen after the widget was inserted.
-							evt.stop();
-
-							CKEDITOR.tools.array.forEach( matchedFiles, function( curFile, index ) {
-								var loader = ret._spawnLoader( editor, curFile, definition, curFile.name );
-
-								ret._insertWidget( editor, definition, URL.createObjectURL( curFile ), true, { uploadId: loader.id } );
-
-								// Now modify the selection so that the next widget won't replace the current one.
-								// This selection workaround is required to store multiple files.
-								if ( index !== matchedFiles.length - 1 ) {
-									// We don't want to modify selection for the last element, so that the last widget remains selected.
-									var sel = editor.getSelection(),
-										ranges = sel.getRanges();
-
-									ranges[ 0 ].enlarge( CKEDITOR.ENLARGE_ELEMENT );
-									ranges[ 0 ].collapse( false );
-								}
-							} );
-						}
+						} );
 					}
 				} );
 			},

--- a/tests/plugins/easyimage/manual/wordintegration.html
+++ b/tests/plugins/easyimage/manual/wordintegration.html
@@ -1,0 +1,11 @@
+<textarea id="editor">
+	<p>Paste here</p>
+</textarea>
+
+<script>
+	if ( !CKEDITOR.env.chrome ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/easyimage/manual/wordintegration.html
+++ b/tests/plugins/easyimage/manual/wordintegration.html
@@ -3,9 +3,5 @@
 </textarea>
 
 <script>
-	if ( !CKEDITOR.env.chrome ) {
-		bender.ignore();
-	}
-
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/easyimage/manual/wordintegration.html
+++ b/tests/plugins/easyimage/manual/wordintegration.html
@@ -3,5 +3,11 @@
 </textarea>
 
 <script>
+	CKEDITOR.on( 'instanceReady', function( evt ) {
+		if ( !evt.editor.plugins.easyimage.isSupportedEnvironment() ) {
+			bender.ignore();
+		}
+	} );
+
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/easyimage/manual/wordintegration.md
+++ b/tests/plugins/easyimage/manual/wordintegration.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.17.2, bug, 4994
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, easyimage
+
+## Procedure
+
+1. Copy any text content from Word.
+1. Paste it into the editor
+
+## Expected
+
+Content is pasted as a text.
+
+## Unexpected
+
+Content is pasted as an image.

--- a/tests/plugins/easyimage/manual/wordintegration.md
+++ b/tests/plugins/easyimage/manual/wordintegration.md
@@ -2,11 +2,9 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, easyimage
 
-## Procedure
-
 1. Copy any text content from Word.
 1. Paste it into the editor
 
-	**Expected** Content is pasted as a text.
+**Expected** Content is pasted as text.
 
-	**Unexpected** Content is pasted as an image.
+**Unexpected** Content is pasted as an image.

--- a/tests/plugins/easyimage/manual/wordintegration.md
+++ b/tests/plugins/easyimage/manual/wordintegration.md
@@ -7,10 +7,6 @@
 1. Copy any text content from Word.
 1. Paste it into the editor
 
-## Expected
+	**Expected** Content is pasted as a text.
 
-Content is pasted as a text.
-
-## Unexpected
-
-Content is pasted as an image.
+	**Unexpected** Content is pasted as an image.

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -1,7 +1,7 @@
 /* bender-tags: editor, clipboard, upload */
 /* bender-ckeditor-plugins: sourcearea, wysiwygarea, easyimage */
 /* bender-include: %BASE_PATH%/plugins/clipboard/_helpers/pasting.js, %BASE_PATH%/plugins/imagebase/features/_helpers/tools.js */
-/* global imageBaseFeaturesTools, pasteFiles, assertPasteEvent */
+/* global imageBaseFeaturesTools, assertPasteEvent */
 
 ( function() {
 	'use strict';
@@ -24,6 +24,7 @@
 	}
 
 	var assertPasteFiles = imageBaseFeaturesTools.assertPasteFiles,
+		pasteFiles = imageBaseFeaturesTools.pasteFiles,
 		tests = {
 			init: function() {
 				// We need to ignore entire test suit to prevent of fireing init, which breaks test suit on IE8-IE10.

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -27,7 +27,7 @@
 		pasteFiles = imageBaseFeaturesTools.pasteFiles,
 		tests = {
 			init: function() {
-				// We need to ignore entire test suit to prevent of fireing init, which breaks test suit on IE8-IE10.
+				// We need to ignore the entire test suit to prevent firing init, which breaks the test suit on IE8-IE10.
 				if ( !this.editor.plugins.easyimage.isSupportedEnvironment() ) {
 					return;
 				}
@@ -127,7 +127,7 @@
 			},
 
 			setUp: function() {
-				// We need to ignore entire test suit to prevent of fireing init, which breaks test suit on IE8-IE10.
+				// We need to ignore the entire test suit to prevent firing init, which breaks the test suit on IE8-IE10.
 				if ( !this.editor.plugins.easyimage.isSupportedEnvironment() ) {
 					assert.ignore();
 				}

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -29,7 +29,7 @@
 			init: function() {
 				// We need to ignore entire test suit to prevent of fireing init, which breaks test suit on IE8-IE10.
 				if ( !this.editor.plugins.easyimage.isSupportedEnvironment() ) {
-					bender.ignore();
+					return;
 				}
 
 				var sampleCloudServicesResponse = {
@@ -127,6 +127,11 @@
 			},
 
 			setUp: function() {
+				// We need to ignore entire test suit to prevent of fireing init, which breaks test suit on IE8-IE10.
+				if ( !this.editor.plugins.easyimage.isSupportedEnvironment() ) {
+					assert.ignore();
+				}
+
 				if ( bender.config.isTravis && CKEDITOR.env.gecko ) {
 					assert.ignore();
 				}

--- a/tests/plugins/imagebase/features/_helpers/tools.js
+++ b/tests/plugins/imagebase/features/_helpers/tools.js
@@ -4,6 +4,16 @@
 	'use strict';
 
 	window.imageBaseFeaturesTools = {
+		/**
+		 * Helper for pasting files
+		 *
+		 * @param {CKEDITOR.editor} editor
+		 * @param {File[]} files
+		 * @param {String} dataValue Content for paste's evt.data.dataValue.
+		 * @param {Object} pasteData Additional data about paste, e.g. method.
+		 * @param {Object} pasteData.additionalData Object with additional paste data in form of MIME type → data.
+		 */
+		pasteFiles: pasteFiles,
 		/*
 		 * Main assertion for pasting files.
 		 *

--- a/tests/plugins/imagebase/features/upload.js
+++ b/tests/plugins/imagebase/features/upload.js
@@ -162,6 +162,21 @@
 				} );
 			},
 
+			// (#4994)
+			'test pasting supported file alongside HTML content does not create a widget': function() {
+				var editor = this.editor;
+
+				assertPasteFiles( editor, {
+					files: [ bender.tools.getTestPngFile() ],
+					additionalData: {
+						'text/html': '<p>Lorem ipsum</p>'
+					},
+					callback: function( widgets ) {
+						assert.areSame( 0, widgets.length, 'Widgets count' );
+					}
+				} );
+			},
+
 			'test multiple files create multiple widgets': function() {
 				var editor = this.editor;
 

--- a/tests/plugins/imagebase/features/upload.js
+++ b/tests/plugins/imagebase/features/upload.js
@@ -166,6 +166,10 @@
 			'test pasting supported file alongside HTML content does not create a widget': function() {
 				var editor = this.editor;
 
+				if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+					assert.ignore();
+				}
+
 				assertPasteFiles( editor, {
 					files: [ bender.tools.getTestPngFile() ],
 					additionalData: {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4994](https://github.com/ckeditor/ckeditor4/issues/4994): Fixed: content from Word is pasted as image when [Easy Image](https://ckeditor.com/cke4/addon/easyimage) plugin is enabled.
```

## What changes did you make?

The issue was connected with how `imagebase` plugin handles pasting to the editor. It simply checked if there are any files inside clipboard data. However, Word includes a screenshot of the content alongside content in text format, resulting in pasting the image. Switching to [`CKEDITOR.plugins.clipboard.dataTransfer#isFileTransfer()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard_dataTransfer.html#method-isFileTransfer) seems to do the trick.

## Which issues does your PR resolve?

Closes #4994.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
