### PR TITLE
Add style for unfocused multiselection list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ CKEditor 4 Changelog
 Other changes:
 
 * [#5087](https://github.com/ckeditor/ckeditor4/issues/5087): Deprecated jQuery API calls in jQuery adapter were replaced by undeprecated ones. Thanks to [Fran Boon](https://github.com/flavour)!
+* [#5044](https://github.com/ckeditor/ckeditor4/issues/5044): Fixed: Lack of style for selected items in unfocused multiselection list. Thanks to [John R. D'Orazio](https://github.com/JohnRDOrazio)!
 
 ## CKEditor 4.17.2
 

--- a/skins/kama/reset.css
+++ b/skins/kama/reset.css
@@ -109,6 +109,11 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 	box-sizing: border-box;
 }
 
+.cke_reset_all select[multiple] option:checked
+{
+	background-color: rgb(206, 206, 206);
+}
+
 .cke_reset_all table
 {
 	table-layout: auto;

--- a/skins/moono-lisa/reset.css
+++ b/skins/moono-lisa/reset.css
@@ -109,6 +109,11 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 	box-sizing: border-box;
 }
 
+.cke_reset_all select[multiple] option:checked
+{
+	background-color: rgb(206, 206, 206);
+}
+
 .cke_reset_all table
 {
 	table-layout: auto;

--- a/skins/moono/reset.css
+++ b/skins/moono/reset.css
@@ -109,6 +109,11 @@ https://ckeditor.com/docs/ckeditor4/latest/guide/skin_sdk_reset.html
 	box-sizing: border-box;
 }
 
+.cke_reset_all select[multiple] option:checked
+{
+	background-color: rgb(206, 206, 206);
+}
+
 .cke_reset_all table
 {
 	table-layout: auto;

--- a/tests/core/skin/manual/_assets/multiselectfix.css
+++ b/tests/core/skin/manual/_assets/multiselectfix.css
@@ -1,0 +1,4 @@
+.cke_reset_all select[multiple] option:checked
+{
+	background-color: rgb(206, 206, 206);
+}

--- a/tests/core/skin/manual/_assets/multiselectfix.css
+++ b/tests/core/skin/manual/_assets/multiselectfix.css
@@ -1,4 +1,0 @@
-.cke_reset_all select[multiple] option:checked
-{
-	background-color: rgb(206, 206, 206);
-}

--- a/tests/core/skin/manual/kamamultiselect.html
+++ b/tests/core/skin/manual/kamamultiselect.html
@@ -1,120 +1,50 @@
-<head>
-	<link rel="stylesheet" href="_assets/multiselectfix.css">
-</head>
-<body>
+<div id="editor"></div>
+<button id="openDialogButton" disabled>Open dialog</button>
 
-	<div id="editor"></div>
-
-	<script>
-		CKEDITOR.plugins.add( 'test', {
-			requires: 'widget',
-			init: function(editor) {
-				editor.addCommand( 'mydialog', new CKEDITOR.dialogCommand( 'mydialog' ) );
-				if ( editor.contextMenu ) {
-					editor.addMenuGroup( 'mygroup', 10 );
-					editor.addMenuItem( 'My Dialog', {
-						label: 'Open dialog',
-						command: 'mydialog',
-						group: 'mygroup'
-					} );
-					editor.contextMenu.addListener( function( element ) {
-						return { 'My Dialog': CKEDITOR.TRISTATE_OFF };
-					} );
-				}
-				CKEDITOR.dialog.add( 'mydialog', function(api){
-					return {
-						title: 'Sample dialog for plugin test',
-						minWidth: 390,
-						minHeight: 130,
-						contents: [
-						{
-							id: 'tab1',
-							label: 'Label',
-							title: 'Title',
-							expand: true,
-							padding: 0,
-							elements: [
-							{
-								type: 'hbox',
-								children: [
-								{
-									type: 'select',
-									id: 'fruitSelect',
-									label: 'Select some fruit',
-									multiple: true,
-									items: fruitArray,
-									size: fruitArray.length,
-									style: 'height:100%',
-									onChange: function() {
-										const fruitSelectList = this.getInputElement().$;
-										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
-										const fruitVals = Array.from(selectedFruits).map(el => el.value);
-										const veggieSelectList = this.getDialog().getContentElement("tab1", "veggieSelect").getInputElement().$;
-										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
-										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
-										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
-									}
-								},
-								{
-									type: 'select',
-									id: 'veggieSelect',
-									label: 'Select some veggies',
-									multiple: true,
-									items: veggieArray,
-									size: veggieArray.length,
-									style: 'height:100%',
-									onChange: function() {
-										const veggieSelectList = this.getInputElement().$;
-										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
-										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
-										const fruitSelectList = this.getDialog().getContentElement("tab1", "fruitSelect").getInputElement().$;
-										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
-										const fruitVals = Array.from(selectedFruits).map(el => el.value);
-										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
-									}
-								},
-								{
-									type: 'html',
-									html: '<p>Shopping basket:</p><div style="border:1px solid Green;height: 50px;background-color:lightgreen;color:darkgreen;font-weight:bold;border-radius:12px;padding:8px;white-space: normal;word-break: break-word;" id="shoppingbasket"></div>'
-								}
-								]
-							}
-							]
-						}
-						],
-						onShow: function() {
-							this.setupContent();
-						}
-					}
-				});
+<script>
+	function addDialog() {
+		CKEDITOR.dialog.add( 'mydialog', function() {
+			var fruitArray = [
+				[ 'Apples' ],
+				[ 'Bananas' ],
+				[ 'Cherries' ]
+			];
+			return {
+				title: 'Sample dialog for plugin test',
+				contents: [ {
+					id: 'tab1',
+					label: 'Label',
+					title: 'Title',
+					elements: [ {
+						type: 'hbox',
+						children: [ {
+							type: 'select',
+							id: 'fruitSelect',
+							label: 'Select some fruit',
+							multiple: true,
+							items: fruitArray,
+							size: fruitArray.length,
+							style: 'height:100%'
+						} ]
+					} ]
+				} ]
 			}
 		});
+	}
 
-		var editor = CKEDITOR.replace( 'editor', {
-			skin: 'kama',
-			extraPlugins: 'test',
-			toolbarGroups: [
-				{ name: 'basicstyles',	groups: [ 'basicstyles' ] }
-			]
-		} );
+	var dialogButton = CKEDITOR.document.getById( 'openDialogButton' );
+	dialogButton.on( 'click', function() {
+		editor.openDialog( 'mydialog' );
+	})
 
-		const fruitArray = [
-			['Apples'],
-			['Bananas'],
-			['Cherries'],
-			['Grapefruit'],
-			['Pears'],
-			['Strawberries']
-		];
-		const veggieArray = [
-			['Beets'],
-			['Brussel sprouts'],
-			['Carrots'],
-			['Cucumbers'],
-			['Lettuce'],
-			['Tomatoes']
-		];
+	var editor = CKEDITOR.replace( 'editor', {
+		skin: 'kama',
+		on: {
+			instanceReady: function( evt ) {
+				addDialog();
+				dialogButton.removeAttribute( 'disabled' );
+			}
+		}
+	} );
 
-	</script>
-
-</body>
+</script>

--- a/tests/core/skin/manual/kamamultiselect.html
+++ b/tests/core/skin/manual/kamamultiselect.html
@@ -1,0 +1,120 @@
+<head>
+	<link rel="stylesheet" href="_assets/multiselectfix.css">
+</head>
+<body>
+
+	<div id="editor"></div>
+
+	<script>
+		CKEDITOR.plugins.add( 'test', {
+			requires: 'widget',
+			init: function(editor) {
+				editor.addCommand( 'mydialog', new CKEDITOR.dialogCommand( 'mydialog' ) );
+				if ( editor.contextMenu ) {
+					editor.addMenuGroup( 'mygroup', 10 );
+					editor.addMenuItem( 'My Dialog', {
+						label: 'Open dialog',
+						command: 'mydialog',
+						group: 'mygroup'
+					} );
+					editor.contextMenu.addListener( function( element ) {
+						return { 'My Dialog': CKEDITOR.TRISTATE_OFF };
+					} );
+				}
+				CKEDITOR.dialog.add( 'mydialog', function(api){
+					return {
+						title: 'Sample dialog for plugin test',
+						minWidth: 390,
+						minHeight: 130,
+						contents: [
+						{
+							id: 'tab1',
+							label: 'Label',
+							title: 'Title',
+							expand: true,
+							padding: 0,
+							elements: [
+							{
+								type: 'hbox',
+								children: [
+								{
+									type: 'select',
+									id: 'fruitSelect',
+									label: 'Select some fruit',
+									multiple: true,
+									items: fruitArray,
+									size: fruitArray.length,
+									style: 'height:100%',
+									onChange: function() {
+										const fruitSelectList = this.getInputElement().$;
+										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
+										const fruitVals = Array.from(selectedFruits).map(el => el.value);
+										const veggieSelectList = this.getDialog().getContentElement("tab1", "veggieSelect").getInputElement().$;
+										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
+										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
+										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
+									}
+								},
+								{
+									type: 'select',
+									id: 'veggieSelect',
+									label: 'Select some veggies',
+									multiple: true,
+									items: veggieArray,
+									size: veggieArray.length,
+									style: 'height:100%',
+									onChange: function() {
+										const veggieSelectList = this.getInputElement().$;
+										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
+										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
+										const fruitSelectList = this.getDialog().getContentElement("tab1", "fruitSelect").getInputElement().$;
+										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
+										const fruitVals = Array.from(selectedFruits).map(el => el.value);
+										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
+									}
+								},
+								{
+									type: 'html',
+									html: '<p>Shopping basket:</p><div style="border:1px solid Green;height: 50px;background-color:lightgreen;color:darkgreen;font-weight:bold;border-radius:12px;padding:8px;white-space: normal;word-break: break-word;" id="shoppingbasket"></div>'
+								}
+								]
+							}
+							]
+						}
+						],
+						onShow: function() {
+							this.setupContent();
+						}
+					}
+				});
+			}
+		});
+
+		var editor = CKEDITOR.replace( 'editor', {
+			skin: 'kama',
+			extraPlugins: 'test',
+			toolbarGroups: [
+				{ name: 'basicstyles',	groups: [ 'basicstyles' ] }
+			]
+		} );
+
+		const fruitArray = [
+			['Apples'],
+			['Bananas'],
+			['Cherries'],
+			['Grapefruit'],
+			['Pears'],
+			['Strawberries']
+		];
+		const veggieArray = [
+			['Beets'],
+			['Brussel sprouts'],
+			['Carrots'],
+			['Cucumbers'],
+			['Lettuce'],
+			['Tomatoes']
+		];
+
+	</script>
+
+</body>

--- a/tests/core/skin/manual/kamamultiselect.md
+++ b/tests/core/skin/manual/kamamultiselect.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.17.2, bug, 5044
+@bender-ckeditor-plugins: widget
+@bender-ui: collapsed
+
+1. Right click in the document area and choose 'Open dialog' from the context menu.
+1. Choose one or more elements from either one of the multiple select elements.
+1. Click outside of the multiple select element with one or more selected elements so that it loses focus.
+
+## Expected
+
+Selected elements should have a gray highlight.
+
+## Unexpected
+
+Selected elements are not highlighted, and are indistinguishable from non selected elements.

--- a/tests/core/skin/manual/kamamultiselect.md
+++ b/tests/core/skin/manual/kamamultiselect.md
@@ -2,9 +2,9 @@
 @bender-ckeditor-plugins: widget, wysiwygarea
 @bender-ui: collapsed
 
-1. Right click in the document area and choose 'Open dialog' from the context menu.
-1. Choose one or more elements from either one of the multiple select elements.
-1. Click outside of the multiple select element with one or more selected elements so that it loses focus.
+1. Click on the 'Open dialog' button.
+1. Choose one or more elements from the multiple select.
+1. Click outside of the multiple select element after one or more elements are selected so that it loses focus.
 
 ## Expected
 

--- a/tests/core/skin/manual/kamamultiselect.md
+++ b/tests/core/skin/manual/kamamultiselect.md
@@ -1,5 +1,5 @@
-@bender-tags: 4.17.2, bug, 5044
-@bender-ckeditor-plugins: widget
+@bender-tags: 4.17.3, bug, 5044
+@bender-ckeditor-plugins: widget, wysiwygarea
 @bender-ui: collapsed
 
 1. Right click in the document area and choose 'Open dialog' from the context menu.

--- a/tests/core/skin/manual/moonolisamultiselect.html
+++ b/tests/core/skin/manual/moonolisamultiselect.html
@@ -1,0 +1,120 @@
+<head>
+	<link rel="stylesheet" href="_assets/multiselectfix.css">
+</head>
+<body>
+
+	<div id="editor"></div>
+
+	<script>
+		CKEDITOR.plugins.add( 'test', {
+			requires: 'widget',
+			init: function(editor) {
+				editor.addCommand( 'mydialog', new CKEDITOR.dialogCommand( 'mydialog' ) );
+				if ( editor.contextMenu ) {
+					editor.addMenuGroup( 'mygroup', 10 );
+					editor.addMenuItem( 'My Dialog', {
+						label: 'Open dialog',
+						command: 'mydialog',
+						group: 'mygroup'
+					} );
+					editor.contextMenu.addListener( function( element ) {
+						return { 'My Dialog': CKEDITOR.TRISTATE_OFF };
+					} );
+				}
+				CKEDITOR.dialog.add( 'mydialog', function(api){
+					return {
+						title: 'Sample dialog for plugin test',
+						minWidth: 390,
+						minHeight: 130,
+						contents: [
+						{
+							id: 'tab1',
+							label: 'Label',
+							title: 'Title',
+							expand: true,
+							padding: 0,
+							elements: [
+							{
+								type: 'hbox',
+								children: [
+								{
+									type: 'select',
+									id: 'fruitSelect',
+									label: 'Select some fruit',
+									multiple: true,
+									items: fruitArray,
+									size: fruitArray.length,
+									style: 'height:100%',
+									onChange: function() {
+										const fruitSelectList = this.getInputElement().$;
+										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
+										const fruitVals = Array.from(selectedFruits).map(el => el.value);
+										const veggieSelectList = this.getDialog().getContentElement("tab1", "veggieSelect").getInputElement().$;
+										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
+										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
+										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
+									}
+								},
+								{
+									type: 'select',
+									id: 'veggieSelect',
+									label: 'Select some veggies',
+									multiple: true,
+									items: veggieArray,
+									size: veggieArray.length,
+									style: 'height:100%',
+									onChange: function() {
+										const veggieSelectList = this.getInputElement().$;
+										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
+										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
+										const fruitSelectList = this.getDialog().getContentElement("tab1", "fruitSelect").getInputElement().$;
+										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
+										const fruitVals = Array.from(selectedFruits).map(el => el.value);
+										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
+									}
+								},
+								{
+									type: 'html',
+									html: '<p>Shopping basket:</p><div style="border:1px solid Green;height: 50px;background-color:lightgreen;color:darkgreen;font-weight:bold;border-radius:12px;padding:8px;white-space: normal;word-break: break-word;" id="shoppingbasket"></div>'
+								}
+								]
+							}
+							]
+						}
+						],
+						onShow: function() {
+							this.setupContent();
+						}
+					}
+				});
+			}
+		});
+
+		var editor = CKEDITOR.replace( 'editor', {
+			skin: 'moonolisa',
+			extraPlugins: 'test',
+			toolbarGroups: [
+				{ name: 'basicstyles',	groups: [ 'basicstyles' ] }
+			]
+		} );
+
+		const fruitArray = [
+			['Apples'],
+			['Bananas'],
+			['Cherries'],
+			['Grapefruit'],
+			['Pears'],
+			['Strawberries']
+		];
+		const veggieArray = [
+			['Beets'],
+			['Brussel sprouts'],
+			['Carrots'],
+			['Cucumbers'],
+			['Lettuce'],
+			['Tomatoes']
+		];
+
+	</script>
+
+</body>

--- a/tests/core/skin/manual/moonolisamultiselect.html
+++ b/tests/core/skin/manual/moonolisamultiselect.html
@@ -42,7 +42,7 @@
 		on: {
 			instanceReady: function( evt ) {
 				addDialog();
-				dialogButton.removeAttribute('disabled')
+				dialogButton.removeAttribute( 'disabled' );
 			}
 		}
 	} );

--- a/tests/core/skin/manual/moonolisamultiselect.html
+++ b/tests/core/skin/manual/moonolisamultiselect.html
@@ -1,120 +1,50 @@
-<head>
-	<link rel="stylesheet" href="_assets/multiselectfix.css">
-</head>
-<body>
+<div id="editor"></div>
+<button id="openDialogButton" disabled>Open dialog</button>
 
-	<div id="editor"></div>
-
-	<script>
-		CKEDITOR.plugins.add( 'test', {
-			requires: 'widget',
-			init: function(editor) {
-				editor.addCommand( 'mydialog', new CKEDITOR.dialogCommand( 'mydialog' ) );
-				if ( editor.contextMenu ) {
-					editor.addMenuGroup( 'mygroup', 10 );
-					editor.addMenuItem( 'My Dialog', {
-						label: 'Open dialog',
-						command: 'mydialog',
-						group: 'mygroup'
-					} );
-					editor.contextMenu.addListener( function( element ) {
-						return { 'My Dialog': CKEDITOR.TRISTATE_OFF };
-					} );
-				}
-				CKEDITOR.dialog.add( 'mydialog', function(api){
-					return {
-						title: 'Sample dialog for plugin test',
-						minWidth: 390,
-						minHeight: 130,
-						contents: [
-						{
-							id: 'tab1',
-							label: 'Label',
-							title: 'Title',
-							expand: true,
-							padding: 0,
-							elements: [
-							{
-								type: 'hbox',
-								children: [
-								{
-									type: 'select',
-									id: 'fruitSelect',
-									label: 'Select some fruit',
-									multiple: true,
-									items: fruitArray,
-									size: fruitArray.length,
-									style: 'height:100%',
-									onChange: function() {
-										const fruitSelectList = this.getInputElement().$;
-										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
-										const fruitVals = Array.from(selectedFruits).map(el => el.value);
-										const veggieSelectList = this.getDialog().getContentElement("tab1", "veggieSelect").getInputElement().$;
-										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
-										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
-										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
-									}
-								},
-								{
-									type: 'select',
-									id: 'veggieSelect',
-									label: 'Select some veggies',
-									multiple: true,
-									items: veggieArray,
-									size: veggieArray.length,
-									style: 'height:100%',
-									onChange: function() {
-										const veggieSelectList = this.getInputElement().$;
-										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
-										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
-										const fruitSelectList = this.getDialog().getContentElement("tab1", "fruitSelect").getInputElement().$;
-										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
-										const fruitVals = Array.from(selectedFruits).map(el => el.value);
-										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
-									}
-								},
-								{
-									type: 'html',
-									html: '<p>Shopping basket:</p><div style="border:1px solid Green;height: 50px;background-color:lightgreen;color:darkgreen;font-weight:bold;border-radius:12px;padding:8px;white-space: normal;word-break: break-word;" id="shoppingbasket"></div>'
-								}
-								]
-							}
-							]
-						}
-						],
-						onShow: function() {
-							this.setupContent();
-						}
-					}
-				});
+<script>
+	function addDialog() {
+		CKEDITOR.dialog.add( 'mydialog', function() {
+			var fruitArray = [
+				[ 'Apples' ],
+				[ 'Bananas' ],
+				[ 'Cherries' ]
+			];
+			return {
+				title: 'Sample dialog for plugin test',
+				contents: [ {
+					id: 'tab1',
+					label: 'Label',
+					title: 'Title',
+					elements: [ {
+						type: 'hbox',
+						children: [ {
+							type: 'select',
+							id: 'fruitSelect',
+							label: 'Select some fruit',
+							multiple: true,
+							items: fruitArray,
+							size: fruitArray.length,
+							style: 'height:100%'
+						} ]
+					} ]
+				} ]
 			}
 		});
+	}
 
-		var editor = CKEDITOR.replace( 'editor', {
-			skin: 'moonolisa',
-			extraPlugins: 'test',
-			toolbarGroups: [
-				{ name: 'basicstyles',	groups: [ 'basicstyles' ] }
-			]
-		} );
+	var dialogButton = CKEDITOR.document.getById( 'openDialogButton' );
+	dialogButton.on( 'click', function() {
+		editor.openDialog( 'mydialog' );
+	})
 
-		const fruitArray = [
-			['Apples'],
-			['Bananas'],
-			['Cherries'],
-			['Grapefruit'],
-			['Pears'],
-			['Strawberries']
-		];
-		const veggieArray = [
-			['Beets'],
-			['Brussel sprouts'],
-			['Carrots'],
-			['Cucumbers'],
-			['Lettuce'],
-			['Tomatoes']
-		];
+	var editor = CKEDITOR.replace( 'editor', {
+		skin: 'moono-lisa',
+		on: {
+			instanceReady: function( evt ) {
+				addDialog();
+				dialogButton.removeAttribute('disabled')
+			}
+		}
+	} );
 
-	</script>
-
-</body>
+</script>

--- a/tests/core/skin/manual/moonolisamultiselect.md
+++ b/tests/core/skin/manual/moonolisamultiselect.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.17.2, bug, 5044
+@bender-ckeditor-plugins: widget
+@bender-ui: collapsed
+
+1. Right click in the document area and choose 'Open dialog' from the context menu.
+1. Choose one or more elements from either one of the multiple select elements.
+1. Click outside of the multiple select element with one or more selected elements so that it loses focus.
+
+## Expected
+
+Selected elements should have a gray highlight.
+
+## Unexpected
+
+Selected elements are not highlighted, and are indistinguishable from non selected elements.

--- a/tests/core/skin/manual/moonolisamultiselect.md
+++ b/tests/core/skin/manual/moonolisamultiselect.md
@@ -2,9 +2,9 @@
 @bender-ckeditor-plugins: widget, wysiwygarea
 @bender-ui: collapsed
 
-1. Right click in the document area and choose 'Open dialog' from the context menu.
-1. Choose one or more elements from either one of the multiple select elements.
-1. Click outside of the multiple select element with one or more selected elements so that it loses focus.
+1. Click on the 'Open dialog' button.
+1. Choose one or more elements from the multiple select.
+1. Click outside of the multiple select element after one or more elements are selected so that it loses focus.
 
 ## Expected
 

--- a/tests/core/skin/manual/moonolisamultiselect.md
+++ b/tests/core/skin/manual/moonolisamultiselect.md
@@ -1,5 +1,5 @@
-@bender-tags: 4.17.2, bug, 5044
-@bender-ckeditor-plugins: widget
+@bender-tags: 4.17.3, bug, 5044
+@bender-ckeditor-plugins: widget, wysiwygarea
 @bender-ui: collapsed
 
 1. Right click in the document area and choose 'Open dialog' from the context menu.

--- a/tests/core/skin/manual/moonomultiselect.html
+++ b/tests/core/skin/manual/moonomultiselect.html
@@ -1,120 +1,50 @@
-<head>
-	<link rel="stylesheet" href="_assets/multiselectfix.css">
-</head>
-<body>
+<div id="editor"></div>
+<button id="openDialogButton" disabled>Open dialog</button>
 
-	<div id="editor"></div>
-
-	<script>
-		CKEDITOR.plugins.add( 'test', {
-			requires: 'widget',
-			init: function(editor) {
-				editor.addCommand( 'mydialog', new CKEDITOR.dialogCommand( 'mydialog' ) );
-				if ( editor.contextMenu ) {
-					editor.addMenuGroup( 'mygroup', 10 );
-					editor.addMenuItem( 'My Dialog', {
-						label: 'Open dialog',
-						command: 'mydialog',
-						group: 'mygroup'
-					} );
-					editor.contextMenu.addListener( function( element ) {
-						return { 'My Dialog': CKEDITOR.TRISTATE_OFF };
-					} );
-				}
-				CKEDITOR.dialog.add( 'mydialog', function(api){
-					return {
-						title: 'Sample dialog for plugin test',
-						minWidth: 390,
-						minHeight: 130,
-						contents: [
-						{
-							id: 'tab1',
-							label: 'Label',
-							title: 'Title',
-							expand: true,
-							padding: 0,
-							elements: [
-							{
-								type: 'hbox',
-								children: [
-								{
-									type: 'select',
-									id: 'fruitSelect',
-									label: 'Select some fruit',
-									multiple: true,
-									items: fruitArray,
-									size: fruitArray.length,
-									style: 'height:100%',
-									onChange: function() {
-										const fruitSelectList = this.getInputElement().$;
-										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
-										const fruitVals = Array.from(selectedFruits).map(el => el.value);
-										const veggieSelectList = this.getDialog().getContentElement("tab1", "veggieSelect").getInputElement().$;
-										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
-										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
-										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
-									}
-								},
-								{
-									type: 'select',
-									id: 'veggieSelect',
-									label: 'Select some veggies',
-									multiple: true,
-									items: veggieArray,
-									size: veggieArray.length,
-									style: 'height:100%',
-									onChange: function() {
-										const veggieSelectList = this.getInputElement().$;
-										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
-										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
-										const fruitSelectList = this.getDialog().getContentElement("tab1", "fruitSelect").getInputElement().$;
-										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
-										const fruitVals = Array.from(selectedFruits).map(el => el.value);
-										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
-									}
-								},
-								{
-									type: 'html',
-									html: '<p>Shopping basket:</p><div style="border:1px solid Green;height: 50px;background-color:lightgreen;color:darkgreen;font-weight:bold;border-radius:12px;padding:8px;white-space: normal;word-break: break-word;" id="shoppingbasket"></div>'
-								}
-								]
-							}
-							]
-						}
-						],
-						onShow: function() {
-							this.setupContent();
-						}
-					}
-				});
+<script>
+	function addDialog() {
+		CKEDITOR.dialog.add( 'mydialog', function() {
+			var fruitArray = [
+				[ 'Apples' ],
+				[ 'Bananas' ],
+				[ 'Cherries' ]
+			];
+			return {
+				title: 'Sample dialog for plugin test',
+				contents: [ {
+					id: 'tab1',
+					label: 'Label',
+					title: 'Title',
+					elements: [ {
+						type: 'hbox',
+						children: [ {
+							type: 'select',
+							id: 'fruitSelect',
+							label: 'Select some fruit',
+							multiple: true,
+							items: fruitArray,
+							size: fruitArray.length,
+							style: 'height:100%'
+						} ]
+					} ]
+				} ]
 			}
 		});
+	}
 
-		var editor = CKEDITOR.replace( 'editor', {
-			skin: 'moono',
-			extraPlugins: 'test',
-			toolbarGroups: [
-				{ name: 'basicstyles',	groups: [ 'basicstyles' ] }
-			]
-		} );
+	var dialogButton = CKEDITOR.document.getById( 'openDialogButton' );
+	dialogButton.on( 'click', function() {
+		editor.openDialog( 'mydialog' );
+	})
 
-		const fruitArray = [
-			['Apples'],
-			['Bananas'],
-			['Cherries'],
-			['Grapefruit'],
-			['Pears'],
-			['Strawberries']
-		];
-		const veggieArray = [
-			['Beets'],
-			['Brussel sprouts'],
-			['Carrots'],
-			['Cucumbers'],
-			['Lettuce'],
-			['Tomatoes']
-		];
+	var editor = CKEDITOR.replace( 'editor', {
+		skin: 'moono',
+		on: {
+			instanceReady: function( evt ) {
+				addDialog();
+				dialogButton.removeAttribute( 'disabled' );
+			}
+		}
+	} );
 
-	</script>
-
-</body>
+</script>

--- a/tests/core/skin/manual/moonomultiselect.html
+++ b/tests/core/skin/manual/moonomultiselect.html
@@ -1,0 +1,120 @@
+<head>
+	<link rel="stylesheet" href="_assets/multiselectfix.css">
+</head>
+<body>
+
+	<div id="editor"></div>
+
+	<script>
+		CKEDITOR.plugins.add( 'test', {
+			requires: 'widget',
+			init: function(editor) {
+				editor.addCommand( 'mydialog', new CKEDITOR.dialogCommand( 'mydialog' ) );
+				if ( editor.contextMenu ) {
+					editor.addMenuGroup( 'mygroup', 10 );
+					editor.addMenuItem( 'My Dialog', {
+						label: 'Open dialog',
+						command: 'mydialog',
+						group: 'mygroup'
+					} );
+					editor.contextMenu.addListener( function( element ) {
+						return { 'My Dialog': CKEDITOR.TRISTATE_OFF };
+					} );
+				}
+				CKEDITOR.dialog.add( 'mydialog', function(api){
+					return {
+						title: 'Sample dialog for plugin test',
+						minWidth: 390,
+						minHeight: 130,
+						contents: [
+						{
+							id: 'tab1',
+							label: 'Label',
+							title: 'Title',
+							expand: true,
+							padding: 0,
+							elements: [
+							{
+								type: 'hbox',
+								children: [
+								{
+									type: 'select',
+									id: 'fruitSelect',
+									label: 'Select some fruit',
+									multiple: true,
+									items: fruitArray,
+									size: fruitArray.length,
+									style: 'height:100%',
+									onChange: function() {
+										const fruitSelectList = this.getInputElement().$;
+										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
+										const fruitVals = Array.from(selectedFruits).map(el => el.value);
+										const veggieSelectList = this.getDialog().getContentElement("tab1", "veggieSelect").getInputElement().$;
+										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
+										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
+										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
+									}
+								},
+								{
+									type: 'select',
+									id: 'veggieSelect',
+									label: 'Select some veggies',
+									multiple: true,
+									items: veggieArray,
+									size: veggieArray.length,
+									style: 'height:100%',
+									onChange: function() {
+										const veggieSelectList = this.getInputElement().$;
+										const selectedVeggies = document.querySelectorAll(`#${veggieSelectList.id} option:checked`);
+										const veggieVals = Array.from(selectedVeggies).map(el => el.value);
+										const fruitSelectList = this.getDialog().getContentElement("tab1", "fruitSelect").getInputElement().$;
+										const selectedFruits = document.querySelectorAll(`#${fruitSelectList.id} option:checked`);
+										const fruitVals = Array.from(selectedFruits).map(el => el.value);
+										document.getElementById('shoppingbasket').innerText = fruitVals.concat(veggieVals).join(', ');
+									}
+								},
+								{
+									type: 'html',
+									html: '<p>Shopping basket:</p><div style="border:1px solid Green;height: 50px;background-color:lightgreen;color:darkgreen;font-weight:bold;border-radius:12px;padding:8px;white-space: normal;word-break: break-word;" id="shoppingbasket"></div>'
+								}
+								]
+							}
+							]
+						}
+						],
+						onShow: function() {
+							this.setupContent();
+						}
+					}
+				});
+			}
+		});
+
+		var editor = CKEDITOR.replace( 'editor', {
+			skin: 'moono',
+			extraPlugins: 'test',
+			toolbarGroups: [
+				{ name: 'basicstyles',	groups: [ 'basicstyles' ] }
+			]
+		} );
+
+		const fruitArray = [
+			['Apples'],
+			['Bananas'],
+			['Cherries'],
+			['Grapefruit'],
+			['Pears'],
+			['Strawberries']
+		];
+		const veggieArray = [
+			['Beets'],
+			['Brussel sprouts'],
+			['Carrots'],
+			['Cucumbers'],
+			['Lettuce'],
+			['Tomatoes']
+		];
+
+	</script>
+
+</body>

--- a/tests/core/skin/manual/moonomultiselect.md
+++ b/tests/core/skin/manual/moonomultiselect.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.17.2, bug, 5044
+@bender-ckeditor-plugins: widget
+@bender-ui: collapsed
+
+1. Right click in the document area and choose 'Open dialog' from the context menu.
+1. Choose one or more elements from either one of the multiple select elements.
+1. Click outside of the multiple select element with one or more selected elements so that it loses focus.
+
+## Expected
+
+Selected elements should have a gray highlight.
+
+## Unexpected
+
+Selected elements are not highlighted, and are indistinguishable from non selected elements.

--- a/tests/core/skin/manual/moonomultiselect.md
+++ b/tests/core/skin/manual/moonomultiselect.md
@@ -2,9 +2,9 @@
 @bender-ckeditor-plugins: widget, wysiwygarea
 @bender-ui: collapsed
 
-1. Right click in the document area and choose 'Open dialog' from the context menu.
-1. Choose one or more elements from either one of the multiple select elements.
-1. Click outside of the multiple select element with one or more selected elements so that it loses focus.
+1. Click on the 'Open dialog' button.
+1. Choose one or more elements from the multiple select.
+1. Click outside of the multiple select element after one or more elements are selected so that it loses focus.
 
 ## Expected
 

--- a/tests/core/skin/manual/moonomultiselect.md
+++ b/tests/core/skin/manual/moonomultiselect.md
@@ -1,5 +1,5 @@
-@bender-tags: 4.17.2, bug, 5044
-@bender-ckeditor-plugins: widget
+@bender-tags: 4.17.3, bug, 5044
+@bender-ckeditor-plugins: widget, wysiwygarea
 @bender-ui: collapsed
 
 1. Right click in the document area and choose 'Open dialog' from the context menu.


### PR DESCRIPTION
## What is the purpose of this pull request?

Bug fix for issue #5044 

## Does your PR contain necessary tests?

This patch contains a simple addition of CSS rules, to bring styling back to multiple select controls for when they lose focus. The browser styling is reset by the skins, so new styling needs to be reinstated for such specific cases.

### This PR contains

- [ ] Unit tests
- [x] Manual tests
- [ ] N/A
- 
## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5044](https://github.com/ckeditor/ckeditor4/issues/5044):
  * add rule for selected options of multiple selects, to skins/kama/reset.css
  * add rule for selected options of multiple selects, to skins/moono-lisa/reset.css
  * add rule for selected options of multiple selects, to skins/moono/reset.css
```

## What changes did you make?

Added rule in the stylesheets of each skin, to reinstate styling of selected options in multiple selects.

## Which issues does your PR resolve?

Closes #5044.

