### PR TITLE
Fix for incorrect replacing with phrases with several spaces inside

### DIFF
--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -489,15 +489,7 @@
 					// Turn off highlight for a while when saving snapshots.
 					this.matchRange.removeHighlight();
 					var domRange = this.matchRange.toDomRange(),
-						textWithPreservedSpaces = newString.replace( consecutiveWhitespaceRegex,
-							function( whitespace ) {
-								var newSpaces = CKEDITOR.tools.array.map( whitespace, function( space, i ) {
-									return i % 2 === 0 ? nonBreakingSpace : space;
-								} );
-
-								return newSpaces.join( '' );
-							} ),
-						text = editor.document.createText( textWithPreservedSpaces );
+						text = createTextNodeWithPreservedSpaces( editor, newString );
 
 					if ( !isReplaceAll ) {
 						// Save undo snaps before and after the replacement.
@@ -837,6 +829,19 @@
 				}
 			}
 		};
+
+		function createTextNodeWithPreservedSpaces( editor, text ) {
+			var textWithPreservedSpaces = text.replace( consecutiveWhitespaceRegex,
+				function( whitespace ) {
+					var newSpaces = CKEDITOR.tools.array.map( whitespace, function( space, i ) {
+						return i % 2 === 0 ? nonBreakingSpace : space;
+					} );
+
+					return newSpaces.join( '' );
+				} );
+
+			return editor.document.createText( textWithPreservedSpaces );
+		}
 	}
 
 	CKEDITOR.dialog.add( 'find', findDialog );

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -387,6 +387,8 @@
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 		var spaceSeparatorRegex = /[\u0020\u00a0\u1680\u202f\u205f\u3000\u2000-\u200a]/;
+		var consecutiveWhitespaceRegex = /[\u0020\u00a0\u1680\u202f\u205f\u3000\u2000-\u200a]{2,}/g;
+		var nonBreakingSpace = '\xA0';
 
 		function isWordSeparator( c ) {
 			if ( !c )
@@ -486,8 +488,17 @@
 				if ( this.matchRange && this.matchRange.isMatched() && !this.matchRange._.isReplaced && !this.matchRange.isReadOnly() && !matchOptionsChanged ) {
 					// Turn off highlight for a while when saving snapshots.
 					this.matchRange.removeHighlight();
-					var domRange = this.matchRange.toDomRange();
-					var text = editor.document.createText( newString );
+					var domRange = this.matchRange.toDomRange(),
+						textWithPreservedSpaces = newString.replace( consecutiveWhitespaceRegex,
+							function( whitespace ) {
+								var newSpaces = CKEDITOR.tools.array.map( whitespace, function( space, i ) {
+									return i % 2 === 0 ? nonBreakingSpace : space;
+								} );
+
+								return newSpaces.join( '' );
+							} ),
+						text = editor.document.createText( textWithPreservedSpaces );
+
 					if ( !isReplaceAll ) {
 						// Save undo snaps before and after the replacement.
 						var selection = editor.getSelection();

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -833,9 +833,10 @@
 		function createTextNodeWithPreservedSpaces( editor, text ) {
 			var textWithPreservedSpaces = text.replace( consecutiveWhitespaceRegex,
 				function( whitespace ) {
-					var newSpaces = CKEDITOR.tools.array.map( whitespace, function( space, i ) {
-						return i % 2 === 0 ? nonBreakingSpace : space;
-					} );
+					var whitespaceArray = whitespace.split( '' ),
+						newSpaces = CKEDITOR.tools.array.map( whitespaceArray, function( space, i ) {
+							return i % 2 === 0 ? nonBreakingSpace : space;
+						} );
 
 					return newSpaces.join( '' );
 				} );

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -263,6 +263,41 @@ bender.test( {
 		} );
 	},
 
+	// (#5061)
+	'test replace one of occurences of phrase with phrase with several spaces inside': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>replace me</p>' );
+
+		bot.dialog( 'replace', function( dialog ) {
+			dialog.setValueOf( 'replace', 'txtFindReplace', 'replace me' );
+			dialog.setValueOf( 'replace', 'txtReplace', 'foo   bar' );
+			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
+			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
+
+			assert.areSame( '<p><span title="highlight">foo&nbsp; &nbsp;bar</span></p>', bot.getData( true ) );
+
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	// (#5061)
+	'test replace all occurences of phrase with phrase with several spaces inside': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>[replace me]</p><p>replace me</p>' );
+
+		bot.dialog( 'replace', function( dialog ) {
+			dialog.setValueOf( 'replace', 'txtReplace', 'foo   bar' );
+			dialog.getContentElement( 'replace', 'btnReplaceAll' ).click();
+			dialog.getButton( 'cancel' ).click();
+
+			assert.areSame( '<p>foo&nbsp; &nbsp;bar</p><p>foo&nbsp; &nbsp;bar</p>', bot.getData( false, true ) );
+
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
 	// (#4987)
 	'test space separator: SPACE': function() {
 		var bot = this.editorBot,

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -264,7 +264,7 @@ bender.test( {
 	},
 
 	// (#5061)
-	'test replace one of occurences of phrase with phrase with several spaces inside': function() {
+	'test replace one of the occurrences of the phrase with a phrase with several spaces inside': function() {
 		var bot = this.editorBot;
 
 		bot.setHtmlWithSelection( '<p>replace me</p>' );
@@ -274,15 +274,14 @@ bender.test( {
 			dialog.setValueOf( 'replace', 'txtReplace', 'foo   bar' );
 			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
 			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
-
-			assert.areSame( '<p><span title="highlight">foo&nbsp; &nbsp;bar</span></p>', bot.getData( true ) );
-
 			dialog.getButton( 'cancel' ).click();
+
+			assert.areSame( '<p>foo&nbsp; &nbsp;bar</p>', bot.getData() );
 		} );
 	},
 
 	// (#5061)
-	'test replace all occurences of phrase with phrase with several spaces inside': function() {
+	'test replace all the occurrences of the phrase with a phrase with several spaces inside': function() {
 		var bot = this.editorBot;
 
 		bot.setHtmlWithSelection( '<p>[replace me]</p><p>replace me</p>' );
@@ -292,9 +291,7 @@ bender.test( {
 			dialog.getContentElement( 'replace', 'btnReplaceAll' ).click();
 			dialog.getButton( 'cancel' ).click();
 
-			assert.areSame( '<p>foo&nbsp; &nbsp;bar</p><p>foo&nbsp; &nbsp;bar</p>', bot.getData( false, true ) );
-
-			dialog.getButton( 'cancel' ).click();
+			assert.areSame( '<p>foo&nbsp; &nbsp;bar</p><p>foo&nbsp; &nbsp;bar</p>', bot.getData() );
 		} );
 	},
 

--- a/tests/plugins/find/manual/replacedoublespace.html
+++ b/tests/plugins/find/manual/replacedoublespace.html
@@ -1,0 +1,9 @@
+<textarea id="editor">
+	<p>Replace me</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/find/manual/replacedoublespace.html
+++ b/tests/plugins/find/manual/replacedoublespace.html
@@ -3,7 +3,5 @@
 </textarea>
 
 <script>
-	CKEDITOR.replace( 'editor', {
-		language: 'en'
-	} );
+	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/find/manual/replacedoublespace.md
+++ b/tests/plugins/find/manual/replacedoublespace.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.17.2, bug, 5061
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, find, sourcearea
+
+1. Open Find and Replace dialog and move to `Replace` tab.
+1. In `Find what:` input type `Replace me`.
+1. In `Replace with` input type `Foo   bar` (note **three spaces** between words).
+1. Click `Replace` button.
+
+**Expected** Three spaces between "Foo" and "bar" are preserved.
+
+**Unexpected** There is only one space between "Foo" and "bar".

--- a/tests/plugins/find/manual/replacedoublespace.md
+++ b/tests/plugins/find/manual/replacedoublespace.md
@@ -5,7 +5,7 @@
 1. Open Find and Replace dialog and move to `Replace` tab.
 1. In `Find what:` input type `Replace me`.
 1. In `Replace with` input type `Foo   bar` (note **three spaces** between words).
-1. Click `Replace` button.
+1. Click `Replace All` button.
 
 **Expected** Three spaces between "Foo" and "bar" are preserved.
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5061](https://github.com/ckeditor/ckeditor4/issues/5061): Fixed: [Find / Replace](https://ckeditor.com/cke4/addon/find) plugin incorrectly handles multiple whitespace during replacing text.
```

## What changes did you make?

Creating a text node from any text removes any consecutive whitespace. To prevent that I've added a `replace()` that replaced every odd space with a non-breaking one.

The only concern I have is if we want to replace all spaces with the non-breaking one or only "normal" spaces (` `)? For now the code replaces all of them.

## Which issues does your PR resolve?

Closes #5061.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
