### PR TITLE
Fix `find&replace` failing tests

### DIFF
--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: find */
+/* bender-ckeditor-plugins: find,entities, */
 
 bender.editor = {
 	config: {
@@ -296,12 +296,12 @@ bender.test( {
 
 	// (#4987)
 	'test space separator: EN SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2002', 'EN SPACE' );
+		assertSpaceSeparator( this.editorBot, '\u2002', 'EN SPACE', '&ensp;' );
 	},
 
 	// (#4987)
 	'test space separator: EM SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2003', 'EM SPACE' );
+		assertSpaceSeparator( this.editorBot, '\u2003', 'EM SPACE', '&emsp;' );
 	},
 
 	// (#4987)
@@ -331,7 +331,7 @@ bender.test( {
 
 	// (#4987)
 	'test space separator: THIN SPACE': function() {
-		assertSpaceSeparator( this.editorBot, '\u2009', 'THIN SPACE' );
+		assertSpaceSeparator( this.editorBot, '\u2009', 'THIN SPACE', '&thinsp;' );
 	},
 
 	// (#4987)
@@ -351,8 +351,10 @@ bender.test( {
 
 } );
 
-function assertSpaceSeparator( bot, unicode, name ) {
-	var expected = '<p>test<span title="highlight">' + unicode + ' </span>test</p>';
+function assertSpaceSeparator( bot, unicode, name, expectedHtmlEntities ) {
+	// In some cases editor return html entities instead of empty space expressed as ' '. #5055
+	var spaceCharacter = expectedHtmlEntities || unicode,
+		expected = '<p>test<span title="highlight">' + spaceCharacter + ' </span>test</p>';
 
 	bot.setHtmlWithSelection( '<p>test[' + unicode + ' ]test</p>' );
 

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -152,12 +152,10 @@ bender.test( {
 	'test find text with double space between words': function() {
 		var bot = this.editorBot;
 
-		bot.setHtmlWithSelection( '<p>example&nbsp; text</p>' );
+		bot.setHtmlWithSelection( '<p>[example&nbsp; text]</p>' );
 
 		bot.dialog( 'find', function( dialog ) {
-			dialog.setValueOf( 'find', 'txtFindFind', 'example  text' );
 			dialog.getContentElement( 'find', 'btnFind' ).click();
-
 
 			assert.areSame( '<p><span title="highlight">example&nbsp; text</span></p>', bot.getData( true ) );
 			dialog.getButton( 'cancel' ).click();
@@ -235,10 +233,9 @@ bender.test( {
 	'test find and replace text with double space between words': function() {
 		var bot = this.editorBot;
 
-		bot.setHtmlWithSelection( '<p>example&nbsp; text from CKEditor4</p>' );
+		bot.setHtmlWithSelection( '<p>[example&nbsp; text] from CKEditor4</p>' );
 
 		bot.dialog( 'replace', function( dialog ) {
-			dialog.setValueOf( 'replace', 'txtFindReplace', 'example  text' );
 			dialog.setValueOf( 'replace', 'txtReplace', 'changed example text' );
 			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();
 			dialog.getContentElement( 'replace', 'btnFindReplace' ).click();


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix failing tests

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

The `entities` plugin treats some of the Unicode as HTML Entities in the output instead of `' '` (blank space). So I added an additional parameter in the `assertSpaceSeparator()` function to properly handle cases like this. 

## Which issues does your PR resolve?

Closes #5054, #5055
