### PR TITLE
Fix `balloontoolbar/positioning` failing test

### DIFF
--- a/tests/plugins/balloontoolbar/positioning.js
+++ b/tests/plugins/balloontoolbar/positioning.js
@@ -175,10 +175,11 @@
 					spy = sinon.spy( balloonToolbar, 'reposition' ),
 					// This test randomly fails when run from dashboard. That's because balloon toolbar
 					// uses also other listeners to reposition, which might be fired before `change`.
-					// Prevent all other event's for this TC to check if it's correctly repositions on `change` #(2979).
+					// Prevent all other event's for this TC to check if it's correctly repositions on `change` #(2979, #5056).
 					listeners = [
 						editor.on( 'resize', cancelEvent ),
 						CKEDITOR.document.getWindow().on( 'resize', cancelEvent ),
+						CKEDITOR.document.getWindow().on( 'scroll', cancelEvent ),
 						editor.editable().getDocument().on( 'scroll', cancelEvent )
 					],
 					initialPosition,


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

This test failed on any browser(not only on IE) where the browser size was so small that require an additional `scroll` event invoked to the position where the test was invoked. This resulted in an additional call to the `baloonToolbar.reposition` method.

## Which issues does your PR resolve?

Closes #5056
