### PR TITLE
Expose toggle buttons in accessibility tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,14 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.18.1 [IN DEVELOPMENT]
 
+New features:
+
+* [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.
+
+Fixed Issues:
+
+* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): The selected states of toolbar buttons are not announced by screen readers.
+
 ## CKEditor 4.18.0
 
 **Security Updates:**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,15 +3,13 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.19.0 [IN DEVELOPMENT]
 
-## CKEditor 4.18.1 [IN DEVELOPMENT]
-
 New features:
 
 * [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.
 
 Fixed Issues:
 
-* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): The selected states of toolbar buttons are not announced by screen readers.
+* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Toolbar buttons toggle state is not correctly announced by screen readers.
 
 ## CKEditor 4.18.0
 

--- a/plugins/basicstyles/plugin.js
+++ b/plugins/basicstyles/plugin.js
@@ -37,6 +37,7 @@ CKEDITOR.plugins.add( 'basicstyles', {
 				// Register the button, if the button plugin is loaded.
 				if ( editor.ui.addButton ) {
 					editor.ui.addButton( buttonName, {
+						isToggle: true,
 						label: buttonLabel,
 						command: commandName,
 						toolbar: 'basicstyles,' + ( order += 10 )

--- a/plugins/bidi/plugin.js
+++ b/plugins/bidi/plugin.js
@@ -225,6 +225,7 @@
 
 				if ( editor.ui.addButton ) {
 					editor.ui.addButton( buttonName, {
+						isToggle: true,
 						label: buttonLabel,
 						command: commandName,
 						toolbar: 'bidi,' + order

--- a/plugins/blockquote/plugin.js
+++ b/plugins/blockquote/plugin.js
@@ -242,6 +242,7 @@
 			editor.addCommand( 'blockquote', commandObject );
 
 			editor.ui.addButton && editor.ui.addButton( 'Blockquote', {
+				isToggle: true,
 				label: editor.lang.blockquote.toolbar,
 				command: 'blockquote',
 				toolbar: 'blocks,10'

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -14,7 +14,8 @@
 		' aria-labelledby="{id}_label"' +
 		' aria-describedby="{id}_description"' +
 		' aria-haspopup="{hasArrow}"' +
-		' aria-disabled="{ariaDisabled}"';
+		' aria-disabled="{ariaDisabled}"' +
+		'{toggleHtml}';
 
 	// Some browsers don't cancel key events in the keydown but in the
 	// keypress.
@@ -51,7 +52,10 @@
 	( CKEDITOR.env.hc ? '&#9660;' : '' ) +
 		'</span>';
 
+	var templateToggle = ' aria-pressed="false"';
+
 	var btnArrowTpl = CKEDITOR.addTemplate( 'buttonArrow', templateArrow ),
+		toggleBtnTpl = CKEDITOR.addTemplate( 'toggleButton', templateToggle ),
 		btnTpl = CKEDITOR.addTemplate( 'button', template );
 
 	CKEDITOR.plugins.add( 'button', {
@@ -81,6 +85,7 @@
 		CKEDITOR.tools.extend( this, definition,
 		// Set defaults.
 		{
+			isToggle: definition.isToggle || false,
 			title: definition.label,
 			click: definition.click ||
 			function( editor ) {
@@ -308,7 +313,8 @@
 				focusFn: focusFn,
 				clickFn: clickFn,
 				style: CKEDITOR.skin.getIconStyle( iconPath, ( editor.lang.dir == 'rtl' ), overridePath, this.iconOffset ),
-				arrowHtml: this.hasArrow ? btnArrowTpl.output() : ''
+				arrowHtml: this.hasArrow ? btnArrowTpl.output() : '',
+				toggleHtml: this.isToggle ? toggleBtnTpl.output() : ''
 			};
 
 			btnTpl.output( params, output );
@@ -337,14 +343,11 @@
 				element.setState( state, 'cke_button' );
 				element.setAttribute( 'aria-disabled', state == CKEDITOR.TRISTATE_DISABLED );
 
-				if ( !this.hasArrow ) {
-					// Note: aria-pressed attribute should not be added to menuButton instances. (https://dev.ckeditor.com/ticket/11331)
-					if ( state === CKEDITOR.TRISTATE_ON ) {
-						element.setAttribute( 'aria-pressed', true );
-					} else {
-						element.removeAttribute( 'aria-pressed' );
-					}
-				} else {
+				if ( this.isToggle && !this.hasArrow ) {
+					// Note: aria-pressed attribute should not be added to menuButton instances. (https://dev.ckeditor.com/ticket/11331).
+					// Do not remove the attribute, set its value (#2444).
+					element.setAttribute( 'aria-pressed', state === CKEDITOR.TRISTATE_ON );
+				} else if ( this.hasArrow ) {
 					// Indicates that menu button is opened (#421).
 					element.setAttribute( 'aria-expanded', state == CKEDITOR.TRISTATE_ON );
 				}
@@ -437,6 +440,8 @@
 	 * 		} )
 	 * @param {String/Boolean} definition.hasArrow If Boolean, it indicates whether the button should have a dropdown. If a string, it acts
 	 * as a value of the button's `aria-haspopup` attribute. Since **4.11.0** it supports the string as a value.
+	 * @param {Boolean} [definition.isToggle=false] Indicates if the button should be treated as a toggle one
+	 * (button that can be switched on and off, e.g. the "Bold" button). This option is supported since the **4.18.1** version.
 	 */
 	CKEDITOR.ui.prototype.addButton = function( name, definition ) {
 		this.add( name, CKEDITOR.UI_BUTTON, definition );

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -342,7 +342,7 @@
 
 				if ( this.isToggle && !this.hasArrow ) {
 					// Note: aria-pressed attribute should not be added to menuButton instances. (https://dev.ckeditor.com/ticket/11331).
-					// Do not remove the attribute, set its value (#2444).
+					// For other buttons, do not remove the attribute, instead set its value (#2444).
 					element.setAttribute( 'aria-pressed', state === CKEDITOR.TRISTATE_ON );
 				} else if ( this.hasArrow ) {
 					// Indicates that menu button is opened (#421).

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -52,10 +52,7 @@
 	( CKEDITOR.env.hc ? '&#9660;' : '' ) +
 		'</span>';
 
-	var templateToggle = ' aria-pressed="false"';
-
 	var btnArrowTpl = CKEDITOR.addTemplate( 'buttonArrow', templateArrow ),
-		toggleBtnTpl = CKEDITOR.addTemplate( 'toggleButton', templateToggle ),
 		btnTpl = CKEDITOR.addTemplate( 'button', template );
 
 	CKEDITOR.plugins.add( 'button', {
@@ -314,7 +311,7 @@
 				clickFn: clickFn,
 				style: CKEDITOR.skin.getIconStyle( iconPath, ( editor.lang.dir == 'rtl' ), overridePath, this.iconOffset ),
 				arrowHtml: this.hasArrow ? btnArrowTpl.output() : '',
-				toggleHtml: this.isToggle ? toggleBtnTpl.output() : ''
+				toggleHtml: this.isToggle ? 'aria-pressed="false"' : ''
 			};
 
 			btnTpl.output( params, output );

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -438,7 +438,7 @@
 	 * @param {String/Boolean} definition.hasArrow If Boolean, it indicates whether the button should have a dropdown. If a string, it acts
 	 * as a value of the button's `aria-haspopup` attribute. Since **4.11.0** it supports the string as a value.
 	 * @param {Boolean} [definition.isToggle=false] Indicates if the button should be treated as a toggle one
-	 * (button that can be switched on and off, e.g. the "Bold" button). This option is supported since the **4.18.1** version.
+	 * (button that can be switched on and off, e.g. the "Bold" button). This option is supported since the **4.19.0** version.
 	 */
 	CKEDITOR.ui.prototype.addButton = function( name, definition ) {
 		this.add( name, CKEDITOR.UI_BUTTON, definition );

--- a/plugins/button/plugin.js
+++ b/plugins/button/plugin.js
@@ -15,7 +15,7 @@
 		' aria-describedby="{id}_description"' +
 		' aria-haspopup="{hasArrow}"' +
 		' aria-disabled="{ariaDisabled}"' +
-		'{toggleHtml}';
+		'{toggleAriaHtml}';
 
 	// Some browsers don't cancel key events in the keydown but in the
 	// keypress.
@@ -311,7 +311,7 @@
 				clickFn: clickFn,
 				style: CKEDITOR.skin.getIconStyle( iconPath, ( editor.lang.dir == 'rtl' ), overridePath, this.iconOffset ),
 				arrowHtml: this.hasArrow ? btnArrowTpl.output() : '',
-				toggleHtml: this.isToggle ? 'aria-pressed="false"' : ''
+				toggleAriaHtml: this.isToggle ? 'aria-pressed="false"' : ''
 			};
 
 			btnTpl.output( params, output );

--- a/plugins/copyformatting/plugin.js
+++ b/plugins/copyformatting/plugin.js
@@ -85,6 +85,7 @@
 			editor.addCommand( 'applyFormatting', plugin.commands.applyFormatting );
 
 			editor.ui.addButton( 'CopyFormatting', {
+				isToggle: true,
 				label: editor.lang.copyformatting.label,
 				command: 'copyFormatting',
 				toolbar: 'cleanup,0'

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -226,21 +226,25 @@
 
 			if ( editor.ui.addButton ) {
 				editor.ui.addButton( 'JustifyLeft', {
+					isToggle: true,
 					label: editor.lang.common.alignLeft,
 					command: 'justifyleft',
 					toolbar: 'align,10'
 				} );
 				editor.ui.addButton( 'JustifyCenter', {
+					isToggle: true,
 					label: editor.lang.common.center,
 					command: 'justifycenter',
 					toolbar: 'align,20'
 				} );
 				editor.ui.addButton( 'JustifyRight', {
+					isToggle: true,
 					label: editor.lang.common.alignRight,
 					command: 'justifyright',
 					toolbar: 'align,30'
 				} );
 				editor.ui.addButton( 'JustifyBlock', {
+					isToggle: true,
 					label: editor.lang.common.justify,
 					command: 'justifyblock',
 					toolbar: 'align,40'

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -855,12 +855,14 @@
 			// Register the toolbar button.
 			if ( editor.ui.addButton ) {
 				editor.ui.addButton( 'NumberedList', {
+					isToggle: true,
 					label: editor.lang.list.numberedlist,
 					command: 'numberedlist',
 					directional: true,
 					toolbar: 'list,10'
 				} );
 				editor.ui.addButton( 'BulletedList', {
+					isToggle: true,
 					label: editor.lang.list.bulletedlist,
 					command: 'bulletedlist',
 					directional: true,

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -248,17 +248,6 @@
 
 					this.toggleState();
 
-					// Toggle button label.
-					var button = this.uiItems[ 0 ];
-					// Only try to change the button if it exists (https://dev.ckeditor.com/ticket/6166)
-					if ( button ) {
-						var label = ( this.state == CKEDITOR.TRISTATE_OFF ) ? lang.maximize.maximize : lang.maximize.minimize;
-						var buttonNode = CKEDITOR.document.getById( button._.id );
-						buttonNode.getChild( 1 ).setHtml( label );
-						buttonNode.setAttribute( 'title', label );
-						buttonNode.setAttribute( 'href', 'javascript:void("' + label + '");' ); // jshint ignore:line
-					}
-
 					// Restore selection and scroll position in editing area.
 					if ( editor.mode == 'wysiwyg' ) {
 						if ( savedSelection ) {
@@ -289,6 +278,7 @@
 			} );
 
 			editor.ui.addButton && editor.ui.addButton( 'Maximize', {
+				isToggle: true,
 				label: lang.maximize.maximize,
 				command: 'maximize',
 				toolbar: 'tools,10'

--- a/plugins/sourcearea/plugin.js
+++ b/plugins/sourcearea/plugin.js
@@ -69,6 +69,7 @@
 
 			if ( editor.ui.addButton ) {
 				editor.ui.addButton( 'Source', {
+					isToggle: true,
 					label: editor.lang.sourcearea.toolbar,
 					command: 'source',
 					toolbar: 'mode,10'

--- a/tests/plugins/basicstyles/aria.js
+++ b/tests/plugins/basicstyles/aria.js
@@ -1,0 +1,16 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar, basicstyles */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+bender.editor = true;
+
+// (#2444)
+bender.test( buttonTools.createAriaPressedTests( 'test_editor', [
+	'Bold',
+	'Italic',
+	'Underline',
+	'Strike',
+	'Subscript',
+	'Superscript'
+] ) );

--- a/tests/plugins/bidi/aria.js
+++ b/tests/plugins/bidi/aria.js
@@ -1,0 +1,12 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar,bidi*/
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+bender.editor = true;
+
+// (#2444)
+bender.test( buttonTools.createAriaPressedTests( 'test_editor', [
+	'BidiLtr',
+	'BidiRtl'
+] ) );

--- a/tests/plugins/blockquote/aria.js
+++ b/tests/plugins/blockquote/aria.js
@@ -1,0 +1,11 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar,blockquote */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+bender.editor = true;
+
+// (#2444)
+bender.test( buttonTools.createAriaPressedTests( 'test_editor', [
+	'Blockquote'
+] ) );

--- a/tests/plugins/button/_helpers/buttontools.js
+++ b/tests/plugins/button/_helpers/buttontools.js
@@ -11,7 +11,7 @@ window.buttonTools = {
 	// Expected attribute value may be a regexp.
 	// @param {Object} expectedAttributes
 	// @param {CKEDITOR.ui.button} button UI button to be tested.
-	assertAttribtues: function( expectedAttributes, button ) {
+	assertAttributes: function( expectedAttributes, button ) {
 		var buttonElement = this.getButtonDomElement( button ),
 			expectedValue,
 			attributeValue;
@@ -42,5 +42,49 @@ window.buttonTools = {
 	// @return {CKEDITOR.dom.element}
 	getButtonDomElement: function( uiButton ) {
 		return CKEDITOR.document.getById( uiButton._.id );
+	},
+
+	createAriaPressedTests: function( editorName, buttons ) {
+		var tests = {};
+
+		CKEDITOR.tools.array.forEach( buttons, function( button ) {
+			createTestCasesForButton( button );
+		} );
+
+		return tests;
+
+		function createTestCasesForButton( button ) {
+			tests[ 'test ' + button + ' button initial state' ] = createTestCase( button, 'false' );
+
+			tests[ 'test ' + button + ' button state after switching on' ] = createTestCase( button, 'true', [
+				CKEDITOR.TRISTATE_ON
+			] );
+
+			tests[ 'test ' + button + ' button state after switching off' ] = createTestCase( button, 'false', [
+				CKEDITOR.TRISTATE_OFF
+			] );
+
+			tests[ 'test ' + button + ' button state after disabling while being switched on' ] = createTestCase(
+				button,
+				'false', [
+					CKEDITOR.TRISTATE_ON,
+					CKEDITOR.TRISTATE_DISABLED
+				] );
+		}
+
+		function createTestCase( buttonName, expected, stateChanges ) {
+			return function() {
+				var button = window.buttonTools.getUiItem( CKEDITOR.instances[ editorName ], buttonName ),
+					expectedAttributes = {
+						'aria-pressed': expected
+					};
+
+				CKEDITOR.tools.array.forEach( stateChanges || [], function( state ) {
+					button.setState( state );
+				} );
+
+				window.buttonTools.assertAttributes( expectedAttributes, button );
+			};
+		}
 	}
 };

--- a/tests/plugins/button/_helpers/buttontools.js
+++ b/tests/plugins/button/_helpers/buttontools.js
@@ -1,0 +1,46 @@
+window.buttonTools = {
+	// Standard aria attributes for button element.
+	typicalButtonAttributes: {
+		'aria-disabled': 'false',
+		'role': 'button',
+		'aria-haspopup': 'false',
+		'aria-labelledby': /^cke_\d+_label$/
+	},
+
+	// Asserts that button has given attributes, with given values.
+	// Expected attribute value may be a regexp.
+	// @param {Object} expectedAttributes
+	// @param {CKEDITOR.ui.button} button UI button to be tested.
+	assertAttribtues: function( expectedAttributes, button ) {
+		var buttonElement = this.getButtonDomElement( button ),
+			expectedValue,
+			attributeValue;
+
+		for ( var attrName in expectedAttributes ) {
+			assert.isTrue( buttonElement.hasAttribute( attrName ), 'Button HTML element does not contain ' + attrName + ' attribute.' );
+
+			expectedValue = expectedAttributes[ attrName ];
+			attributeValue = buttonElement.getAttribute( attrName );
+
+			if ( expectedValue instanceof RegExp )
+				assert.isTrue( expectedValue.test( attributeValue ), 'Attribute ' + attrName + ' did not matched expected ' + expectedValue + ' regex' );
+			else
+				assert.areSame( expectedValue, attributeValue, 'Invalid value for attribute ' + attrName + '.' );
+		}
+	},
+
+	// Returns button object.
+	// @param {CKEDITOR.editor} editor
+	// @param {String} name Name of the button in ui.
+	// @return {CKEDITOR.ui.button}
+	getUiItem: function( editor, name ) {
+		return editor.ui.get( name );
+	},
+
+	// Returns html element for given menu.
+	// @param {CKEDITOR.ui.button} uiButton
+	// @return {CKEDITOR.dom.element}
+	getButtonDomElement: function( uiButton ) {
+		return CKEDITOR.document.getById( uiButton._.id );
+	}
+};

--- a/tests/plugins/button/_helpers/buttontools.js
+++ b/tests/plugins/button/_helpers/buttontools.js
@@ -17,15 +17,19 @@ window.buttonTools = {
 			attributeValue;
 
 		for ( var attrName in expectedAttributes ) {
-			assert.isTrue( buttonElement.hasAttribute( attrName ), 'Button HTML element does not contain ' + attrName + ' attribute.' );
+			assert.isTrue( buttonElement.hasAttribute( attrName ), 'Button HTML element does not contain ' +
+				attrName + ' attribute.' );
 
 			expectedValue = expectedAttributes[ attrName ];
 			attributeValue = buttonElement.getAttribute( attrName );
 
-			if ( expectedValue instanceof RegExp )
-				assert.isTrue( expectedValue.test( attributeValue ), 'Attribute ' + attrName + ' did not matched expected ' + expectedValue + ' regex' );
-			else
+			if ( expectedValue instanceof RegExp ) {
+				assert.isTrue( expectedValue.test( attributeValue ), 'Attribute ' + attrName +
+					' did not matched expected ' + expectedValue + ' regex' );
+			}
+			else {
 				assert.areSame( expectedValue, attributeValue, 'Invalid value for attribute ' + attrName + '.' );
+			}
 		}
 	},
 

--- a/tests/plugins/button/_helpers/buttontools.js
+++ b/tests/plugins/button/_helpers/buttontools.js
@@ -1,6 +1,6 @@
 window.buttonTools = {
 	// Standard aria attributes for button element.
-	typicalButtonAttributes: {
+	buttonStandardAriaAttributes: {
 		'aria-disabled': 'false',
 		'role': 'button',
 		'aria-haspopup': 'false',

--- a/tests/plugins/button/aria.js
+++ b/tests/plugins/button/aria.js
@@ -3,7 +3,7 @@
 
 bender.editor = {
 	config: {
-		toolbar: [ [ 'custom_btn', 'disabled_btn', 'haspopup_btn', 'arrow_btn' ] ],
+		toolbar: [ [ 'custom_btn', 'disabled_btn', 'haspopup_btn', 'arrow_btn', 'toggle_btn' ] ],
 		on: {
 			'pluginsLoaded': function( evt ) {
 				var editor = evt.editor;
@@ -21,6 +21,11 @@ bender.editor = {
 
 				editor.ui.addButton( 'arrow_btn', {
 					label: 'arrow button'
+				} );
+
+				editor.ui.addButton( 'toggle_btn', {
+					label: 'toggle button',
+					isToggle: true
 				} );
 			}
 		}
@@ -83,6 +88,53 @@ bender.test( {
 
 		this.assertAttribtues( expectedAttributes, button );
 		assert.areEqual( 'arrow button', label.getText(), 'innerText of label doesn\'t match' );
+	},
+
+	// (#2444)
+	'test toggle button initial state': function() {
+		var button = this.getUiItem( 'toggle_btn' ),
+			expectedAttributes = {
+				'aria-pressed': 'false'
+			};
+
+		this.assertAttribtues( expectedAttributes, button );
+	},
+
+	// (#2444)
+	'test toggle button state after switching on': function() {
+		var button = this.getUiItem( 'toggle_btn' ),
+			expectedAttributes = {
+				'aria-pressed': 'true'
+			};
+
+		button.setState( CKEDITOR.TRISTATE_ON );
+
+		this.assertAttribtues( expectedAttributes, button );
+	},
+
+	// (#2444)
+	'test toggle button state after switching off': function() {
+		var button = this.getUiItem( 'toggle_btn' ),
+			expectedAttributes = {
+				'aria-pressed': 'false'
+			};
+
+		button.setState( CKEDITOR.TRISTATE_OFF );
+
+		this.assertAttribtues( expectedAttributes, button );
+	},
+
+	// (#2444)
+	'test toggle button state after disabling while being switched on': function() {
+		var button = this.getUiItem( 'toggle_btn' ),
+			expectedAttributes = {
+				'aria-pressed': 'false'
+			};
+
+		button.setState( CKEDITOR.TRISTATE_ON );
+		button.setState( CKEDITOR.TRISTATE_DISABLED );
+
+		this.assertAttribtues( expectedAttributes, button );
 	},
 
 	// Asserts that button has given attributes, with given values.

--- a/tests/plugins/button/aria.js
+++ b/tests/plugins/button/aria.js
@@ -1,5 +1,7 @@
 /* bender-tags: editor */
 /* bender-ckeditor-plugins: button,toolbar */
+/* bender-include: _helpers/buttontools.js */
+/* global buttonTools */
 
 bender.editor = {
 	config: {
@@ -33,33 +35,23 @@ bender.editor = {
 };
 
 bender.test( {
-	setUp: function() {
-		// Standard aria attributes for button element.
-		this.typicalButtonAttributes = {
-			'aria-disabled': 'false',
-			'role': 'button',
-			'aria-haspopup': 'false',
-			'aria-labelledby': /^cke_\d+_label$/
-		};
-	},
-
 	'test default button attributes': function() {
-		var btn = this.getUiItem( 'custom_btn' ),
-			expectedAttributes = this.typicalButtonAttributes;
+		var btn = buttonTools.getUiItem( this.editor, 'custom_btn' ),
+			expectedAttributes = buttonTools.typicalButtonAttributes;
 
-		this.assertAttribtues( expectedAttributes, btn );
+		buttonTools.assertAttribtues( expectedAttributes, btn );
 	},
 
 	'test disabled button': function() {
-		var btn = this.getUiItem( 'disabled_btn' ),
-			expectedAttributes = this.typicalButtonAttributes;
+		var btn = buttonTools.getUiItem( this.editor, 'disabled_btn' ),
+			expectedAttributes = buttonTools.typicalButtonAttributes;
 
 		expectedAttributes[ 'aria-disabled' ] = 'true';
-		this.assertAttribtues( expectedAttributes, btn );
+		buttonTools.assertAttribtues( expectedAttributes, btn );
 	},
 
 	'test button label': function() {
-		var btn = this.getButtonDomElement( this.getUiItem( 'custom_btn' ) ),
+		var btn = buttonTools.getButtonDomElement( buttonTools.getUiItem( this.editor, 'custom_btn' ) ),
 			label = CKEDITOR.document.getById( btn.getAttribute( 'aria-labelledby' ) );
 
 		assert.isTrue( !!label, 'Label element not found' );
@@ -68,14 +60,14 @@ bender.test( {
 
 	// WAI-ARIA 1.1 has added new values for aria-haspopup property (#2072).
 	'test aria-haspopup': function() {
-		var btn = this.getUiItem( 'haspopup_btn' ),
+		var btn = buttonTools.getUiItem( this.editor, 'haspopup_btn' ),
 			btnEl = CKEDITOR.document.getById( btn._.id );
 		assert.areEqual( btnEl.getAttribute( 'aria-haspopup' ), 'menu' );
 	},
 
 	// (#421)
 	'test button label with arrow': function() {
-		var button = this.getUiItem( 'arrow_btn' ),
+		var button = buttonTools.getUiItem( this.editor, 'arrow_btn' ),
 			expectedAttributes = {
 				'aria-expanded': 'true'
 			};
@@ -83,50 +75,50 @@ bender.test( {
 		button.hasArrow = true;
 		button.setState( CKEDITOR.TRISTATE_ON );
 
-		var buttonEl = this.getButtonDomElement( button ),
+		var buttonEl = buttonTools.getButtonDomElement( button ),
 			label = CKEDITOR.document.getById( buttonEl.getAttribute( 'aria-labelledby' ) );
 
-		this.assertAttribtues( expectedAttributes, button );
+		buttonTools.assertAttribtues( expectedAttributes, button );
 		assert.areEqual( 'arrow button', label.getText(), 'innerText of label doesn\'t match' );
 	},
 
 	// (#2444)
 	'test toggle button initial state': function() {
-		var button = this.getUiItem( 'toggle_btn' ),
+		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
 			expectedAttributes = {
 				'aria-pressed': 'false'
 			};
 
-		this.assertAttribtues( expectedAttributes, button );
+		buttonTools.assertAttribtues( expectedAttributes, button );
 	},
 
 	// (#2444)
 	'test toggle button state after switching on': function() {
-		var button = this.getUiItem( 'toggle_btn' ),
+		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
 			expectedAttributes = {
 				'aria-pressed': 'true'
 			};
 
 		button.setState( CKEDITOR.TRISTATE_ON );
 
-		this.assertAttribtues( expectedAttributes, button );
+		buttonTools.assertAttribtues( expectedAttributes, button );
 	},
 
 	// (#2444)
 	'test toggle button state after switching off': function() {
-		var button = this.getUiItem( 'toggle_btn' ),
+		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
 			expectedAttributes = {
 				'aria-pressed': 'false'
 			};
 
 		button.setState( CKEDITOR.TRISTATE_OFF );
 
-		this.assertAttribtues( expectedAttributes, button );
+		buttonTools.assertAttribtues( expectedAttributes, button );
 	},
 
 	// (#2444)
 	'test toggle button state after disabling while being switched on': function() {
-		var button = this.getUiItem( 'toggle_btn' ),
+		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
 			expectedAttributes = {
 				'aria-pressed': 'false'
 			};
@@ -134,42 +126,6 @@ bender.test( {
 		button.setState( CKEDITOR.TRISTATE_ON );
 		button.setState( CKEDITOR.TRISTATE_DISABLED );
 
-		this.assertAttribtues( expectedAttributes, button );
-	},
-
-	// Asserts that button has given attributes, with given values.
-	// Expected attribute value may be a regexp.
-	// @param {Object} expectedAttributes
-	// @param {CKEDITOR.ui.button} button UI button to be tested.
-	assertAttribtues: function( expectedAttributes, button ) {
-		var buttonElement = this.getButtonDomElement( button ),
-			expectedValue,
-			attributeValue;
-
-		for ( var attrName in expectedAttributes ) {
-			assert.isTrue( buttonElement.hasAttribute( attrName ), 'Button HTML element does not contain ' + attrName + ' attribute.' );
-
-			expectedValue = expectedAttributes[ attrName ];
-			attributeValue = buttonElement.getAttribute( attrName );
-
-			if ( expectedValue instanceof RegExp )
-				assert.isTrue( expectedValue.test( attributeValue ), 'Attribute ' + attrName + ' did not matched expected ' + expectedValue + ' regex' );
-			else
-				assert.areSame( expectedValue, attributeValue, 'Invalid value for attribute ' + attrName + '.' );
-		}
-	},
-
-	// Returns button object.
-	// @param {String} name Name of the button in ui.
-	// @return {CKEDITOR.ui.button}
-	getUiItem: function( name ) {
-		return this.editor.ui.get( name );
-	},
-
-	// Returns html element for given menu.
-	// @param {CKEDITOR.ui.button} uiButton
-	// @return {CKEDITOR.dom.element}
-	getButtonDomElement: function( uiButton ) {
-		return CKEDITOR.document.getById( uiButton._.id );
+		buttonTools.assertAttribtues( expectedAttributes, button );
 	}
 } );

--- a/tests/plugins/button/aria.js
+++ b/tests/plugins/button/aria.js
@@ -3,129 +3,88 @@
 /* bender-include: _helpers/buttontools.js */
 /* global buttonTools */
 
-bender.editor = {
-	config: {
-		toolbar: [ [ 'custom_btn', 'disabled_btn', 'haspopup_btn', 'arrow_btn', 'toggle_btn' ] ],
-		on: {
-			'pluginsLoaded': function( evt ) {
-				var editor = evt.editor;
-				editor.ui.addButton( 'custom_btn', {
-					label: 'aria label'
-				} );
-				editor.ui.addButton( 'disabled_btn', {
-					label: 'disabled button',
-					modes: {} // This button should be disabled because it does not work in any of modes.
-				} );
+( function() {
+	bender.editor = {
+		config: {
+			toolbar: [ [ 'custom_btn', 'disabled_btn', 'haspopup_btn', 'arrow_btn', 'toggle_btn' ] ],
+			on: {
+				'pluginsLoaded': function( evt ) {
+					var editor = evt.editor;
+					editor.ui.addButton( 'custom_btn', {
+						label: 'aria label'
+					} );
+					editor.ui.addButton( 'disabled_btn', {
+						label: 'disabled button',
+						modes: {} // This button should be disabled because it does not work in any of modes.
+					} );
 
-				editor.ui.addButton( 'haspopup_btn', {
-					hasArrow: 'menu'
-				} );
+					editor.ui.addButton( 'haspopup_btn', {
+						hasArrow: 'menu'
+					} );
 
-				editor.ui.addButton( 'arrow_btn', {
-					label: 'arrow button'
-				} );
+					editor.ui.addButton( 'arrow_btn', {
+						label: 'arrow button'
+					} );
 
-				editor.ui.addButton( 'toggle_btn', {
-					label: 'toggle button',
-					isToggle: true
-				} );
+					editor.ui.addButton( 'toggle_btn', {
+						label: 'toggle button',
+						isToggle: true
+					} );
+				}
 			}
 		}
-	}
-};
+	};
 
-bender.test( {
-	'test default button attributes': function() {
-		var btn = buttonTools.getUiItem( this.editor, 'custom_btn' ),
-			expectedAttributes = buttonTools.typicalButtonAttributes;
+	var tests = {
+		'test default button attributes': function() {
+			var btn = buttonTools.getUiItem( this.editor, 'custom_btn' ),
+				expectedAttributes = buttonTools.typicalButtonAttributes;
 
-		buttonTools.assertAttribtues( expectedAttributes, btn );
-	},
+			buttonTools.assertAttributes( expectedAttributes, btn );
+		},
 
-	'test disabled button': function() {
-		var btn = buttonTools.getUiItem( this.editor, 'disabled_btn' ),
-			expectedAttributes = buttonTools.typicalButtonAttributes;
+		'test disabled button': function() {
+			var btn = buttonTools.getUiItem( this.editor, 'disabled_btn' ),
+				expectedAttributes = buttonTools.typicalButtonAttributes;
 
-		expectedAttributes[ 'aria-disabled' ] = 'true';
-		buttonTools.assertAttribtues( expectedAttributes, btn );
-	},
+			expectedAttributes[ 'aria-disabled' ] = 'true';
+			buttonTools.assertAttributes( expectedAttributes, btn );
+		},
 
-	'test button label': function() {
-		var btn = buttonTools.getButtonDomElement( buttonTools.getUiItem( this.editor, 'custom_btn' ) ),
-			label = CKEDITOR.document.getById( btn.getAttribute( 'aria-labelledby' ) );
+		'test button label': function() {
+			var btn = buttonTools.getButtonDomElement( buttonTools.getUiItem( this.editor, 'custom_btn' ) ),
+				label = CKEDITOR.document.getById( btn.getAttribute( 'aria-labelledby' ) );
 
-		assert.isTrue( !!label, 'Label element not found' );
-		assert.areEqual( 'aria label', label.getText(), 'innerText of label doesn\'t match' );
-	},
+			assert.isTrue( !!label, 'Label element not found' );
+			assert.areEqual( 'aria label', label.getText(), 'innerText of label doesn\'t match' );
+		},
 
-	// WAI-ARIA 1.1 has added new values for aria-haspopup property (#2072).
-	'test aria-haspopup': function() {
-		var btn = buttonTools.getUiItem( this.editor, 'haspopup_btn' ),
-			btnEl = CKEDITOR.document.getById( btn._.id );
-		assert.areEqual( btnEl.getAttribute( 'aria-haspopup' ), 'menu' );
-	},
+		// WAI-ARIA 1.1 has added new values for aria-haspopup property (#2072).
+		'test aria-haspopup': function() {
+			var btn = buttonTools.getUiItem( this.editor, 'haspopup_btn' ),
+				btnEl = CKEDITOR.document.getById( btn._.id );
+			assert.areEqual( btnEl.getAttribute( 'aria-haspopup' ), 'menu' );
+		},
 
-	// (#421)
-	'test button label with arrow': function() {
-		var button = buttonTools.getUiItem( this.editor, 'arrow_btn' ),
-			expectedAttributes = {
-				'aria-expanded': 'true'
-			};
+		// (#421)
+		'test button label with arrow': function() {
+			var button = buttonTools.getUiItem( this.editor, 'arrow_btn' ),
+				expectedAttributes = {
+					'aria-expanded': 'true'
+				};
 
-		button.hasArrow = true;
-		button.setState( CKEDITOR.TRISTATE_ON );
+			button.hasArrow = true;
+			button.setState( CKEDITOR.TRISTATE_ON );
 
-		var buttonEl = buttonTools.getButtonDomElement( button ),
-			label = CKEDITOR.document.getById( buttonEl.getAttribute( 'aria-labelledby' ) );
+			var buttonEl = buttonTools.getButtonDomElement( button ),
+				label = CKEDITOR.document.getById( buttonEl.getAttribute( 'aria-labelledby' ) );
 
-		buttonTools.assertAttribtues( expectedAttributes, button );
-		assert.areEqual( 'arrow button', label.getText(), 'innerText of label doesn\'t match' );
-	},
+			buttonTools.assertAttributes( expectedAttributes, button );
+			assert.areEqual( 'arrow button', label.getText(), 'innerText of label doesn\'t match' );
+		}
+	};
 
-	// (#2444)
-	'test toggle button initial state': function() {
-		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
-			expectedAttributes = {
-				'aria-pressed': 'false'
-			};
+	CKEDITOR.tools.extend( tests, buttonTools.createAriaPressedTests( 'test_editor', [ 'toggle_btn' ] ) );
+	bender.test( tests );
+} )();
 
-		buttonTools.assertAttribtues( expectedAttributes, button );
-	},
-
-	// (#2444)
-	'test toggle button state after switching on': function() {
-		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
-			expectedAttributes = {
-				'aria-pressed': 'true'
-			};
-
-		button.setState( CKEDITOR.TRISTATE_ON );
-
-		buttonTools.assertAttribtues( expectedAttributes, button );
-	},
-
-	// (#2444)
-	'test toggle button state after switching off': function() {
-		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
-			expectedAttributes = {
-				'aria-pressed': 'false'
-			};
-
-		button.setState( CKEDITOR.TRISTATE_OFF );
-
-		buttonTools.assertAttribtues( expectedAttributes, button );
-	},
-
-	// (#2444)
-	'test toggle button state after disabling while being switched on': function() {
-		var button = buttonTools.getUiItem( this.editor, 'toggle_btn' ),
-			expectedAttributes = {
-				'aria-pressed': 'false'
-			};
-
-		button.setState( CKEDITOR.TRISTATE_ON );
-		button.setState( CKEDITOR.TRISTATE_DISABLED );
-
-		buttonTools.assertAttribtues( expectedAttributes, button );
-	}
-} );

--- a/tests/plugins/button/aria.js
+++ b/tests/plugins/button/aria.js
@@ -38,14 +38,14 @@
 	var tests = {
 		'test default button attributes': function() {
 			var btn = buttonTools.getUiItem( this.editor, 'custom_btn' ),
-				expectedAttributes = buttonTools.typicalButtonAttributes;
+				expectedAttributes = buttonTools.buttonStandardAriaAttributes;
 
 			buttonTools.assertAttributes( expectedAttributes, btn );
 		},
 
 		'test disabled button': function() {
 			var btn = buttonTools.getUiItem( this.editor, 'disabled_btn' ),
-				expectedAttributes = buttonTools.typicalButtonAttributes;
+				expectedAttributes = buttonTools.buttonStandardAriaAttributes;
 
 			expectedAttributes[ 'aria-disabled' ] = 'true';
 			buttonTools.assertAttributes( expectedAttributes, btn );

--- a/tests/plugins/button/manual/togglebutton.html
+++ b/tests/plugins/button/manual/togglebutton.html
@@ -1,0 +1,44 @@
+<p><code>[aria-pressed]</code> value: <span id="aria-pressed-value">editor is loading…</span></p>
+<div id="editor">
+	<p>Whatever</p>
+</div>
+
+<script>
+	( function() {
+		CKEDITOR.replace( 'editor', {
+			toolbar: [ [ 'toggleButton' ] ],
+			on: {
+				pluginsLoaded: function( evt ) {
+					evt.editor.addCommand( 'toggleButton', {
+						exec: function() {
+							if ( this.state === CKEDITOR.TRISTATE_OFF ) {
+								this.setState( CKEDITOR.TRISTATE_ON );
+							} else {
+								this.setState( CKEDITOR.TRISTATE_OFF );
+							}
+
+							renderButtonState();
+						}
+					} );
+
+					evt.editor.ui.addButton( 'toggleButton', {
+						label: 'Toggle button',
+						icon: 'Link',
+						isToggle: true,
+						command: 'toggleButton'
+					} );
+				},
+
+				instanceReady: renderButtonState
+			}
+		} );
+
+		function renderButtonState() {
+			var button = CKEDITOR.document.findOne( '.cke_button__togglebutton' ),
+				stateIndicator = CKEDITOR.document.getById( 'aria-pressed-value' ),
+				currentState = button.getAttribute( 'aria-pressed' )
+
+			stateIndicator.setHtml( currentState );
+		}
+	} )();
+</script>

--- a/tests/plugins/button/manual/togglebutton.md
+++ b/tests/plugins/button/manual/togglebutton.md
@@ -1,0 +1,20 @@
+@bender-tags: 4.18.1, 2444, feature, button
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link
+
+1. Wait for editor to fully load.
+1. Check the info about `[aria-pressed]` attribute's value that is above the editor.
+
+	**Expected** The value equals `false`.
+
+	**Unexected** The value equals `true` or is not set.
+1. Click the button in the toolbar.
+
+	**Expected** The value equals `true`.
+
+	**Unexected** The value equals `false` or is not set.
+1. Click the button once more.
+
+	**Expected** The value equals `false`.
+
+	**Unexected** The value equals `true` or is not set.

--- a/tests/plugins/button/manual/togglebutton.md
+++ b/tests/plugins/button/manual/togglebutton.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, 2444, feature, button
+@bender-tags: 4.19.0, 2444, feature, button
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/button/manual/togglebuttons.html
+++ b/tests/plugins/button/manual/togglebuttons.html
@@ -33,13 +33,10 @@
 				'basicstyles',
 				'bidi',
 				'blockquote',
-				// 'colorbutton'
 				'copyformatting',
 				'justify',
-				// 'language',
 				'list',
-				// 'maximize',
-				'sourcearea',
+				'sourcearea'
 			],
 			removeButtons: 'Indent,Outdent',
 			on: {

--- a/tests/plugins/button/manual/togglebuttons.html
+++ b/tests/plugins/button/manual/togglebuttons.html
@@ -1,0 +1,72 @@
+<style>
+	table {
+		margin-top: 20px;
+	}
+	td, th {
+		padding: 10px;
+		text-align: center;
+	}
+	tbody th {
+		font-weight: normal;
+	}
+</style>
+<div id="editor">
+	<p>Whatever</p>
+</div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">Button</th>
+			<th scope="col"><code>[aria-pressed]</code> value</th>
+		</tr>
+	</thead>
+	<tbody id="states"></tbody>
+</table>
+
+<script>
+	( function() {
+		CKEDITOR.replace( 'editor', {
+			language: 'en',
+			plugins: [
+				'toolbar',
+				'wysiwygarea',
+				'basicstyles',
+				'bidi',
+				'blockquote',
+				// 'colorbutton'
+				'copyformatting',
+				'justify',
+				// 'language',
+				'list',
+				// 'maximize',
+				'sourcearea',
+			],
+			removeButtons: 'Indent,Outdent',
+			on: {
+				instanceReady: function( evt ) {
+					var editor = evt.editor;
+
+					editor.on( 'afterCommandExec', renderButtonStates );
+					editor.on( 'selectionChange', renderButtonStates );
+					editor.on( 'mode', renderButtonStates );
+					CKEDITOR.document.findOne( '.cke_top' ).on( 'mouseup', renderButtonStates );
+
+					renderButtonStates();
+				}
+			}
+		} );
+
+		function renderButtonStates() {
+			var buttons = CKEDITOR.document.find( '.cke_toolbar .cke_button' ).toArray(),
+				statesContainer = CKEDITOR.document.getById( 'states' ),
+				statesHtml = CKEDITOR.tools.array.map( buttons, function( button ) {
+					var currentState = button.getAttribute( 'aria-pressed' ),
+						buttonLabel = button.findOne( '.cke_button_label' ).getHtml();
+
+					return '<tr><th scope="row">' + buttonLabel + '</th><td>' + currentState + '</td></tr>';
+				} ).join( '' );
+
+				statesContainer.setHtml( statesHtml );
+		}
+	} )();
+</script>

--- a/tests/plugins/button/manual/togglebuttons.md
+++ b/tests/plugins/button/manual/togglebuttons.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.18.1, 2444, feature, button
+@bender-ui: collapsed
+
+1. Wait for editor to fully load.
+1. Check the info about `[aria-pressed]` attributes' values that is below the editor.
+
+	**Expected** Values should reflect states of buttons.
+1. Have fun with buttons in the toolbar.
+
+	**Expected** Values should reflect states of buttons.

--- a/tests/plugins/button/manual/togglebuttons.md
+++ b/tests/plugins/button/manual/togglebuttons.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, 2444, feature, button
+@bender-tags: 4.19.0, 2444, feature, button
 @bender-ui: collapsed
 
 1. Wait for editor to fully load.

--- a/tests/plugins/button/manual/togglebuttonscreenreader.html
+++ b/tests/plugins/button/manual/togglebuttonscreenreader.html
@@ -1,0 +1,29 @@
+<div id="editor">
+	<p>Whatever</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		toolbar: [ [ 'toggleButton' ] ],
+		on: {
+			pluginsLoaded: function( evt ) {
+				evt.editor.addCommand( 'toggleButton', {
+					exec: function() {
+						if ( this.state === CKEDITOR.TRISTATE_OFF ) {
+							this.setState( CKEDITOR.TRISTATE_ON );
+						} else {
+							this.setState( CKEDITOR.TRISTATE_OFF );
+						}
+					}
+				} );
+
+				evt.editor.ui.addButton( 'toggleButton', {
+					label: 'Sample button',
+					icon: 'Link',
+					isToggle: true,
+					command: 'toggleButton'
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/button/manual/togglebuttonscreenreader.md
+++ b/tests/plugins/button/manual/togglebuttonscreenreader.md
@@ -1,0 +1,34 @@
+@bender-tags: 4.18.1, 2444, feature, button
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, link
+
+**Note** This test is intended for screen reader.
+
+1. Move focus to the button in the editor's toolbar.
+
+	**Expected** Screen reader announces the button as togglable and currently switched off/unpressed.
+1. Activate the button via keyboard.
+1. Move the focus back to the button.
+
+	**Expected** Screen reader announces the button as togglable and currently switched on/pressed.
+1. Activate the button via keyboarf
+1. Move the focus back to the button.
+
+	**Expected** Screen reader announces the button as togglable and currently switched off/unpressed.
+
+## Sample screen reader outputs
+
+### VoiceOver on macOS
+
+* off: "&lt;button name&gt;, toggle button"
+* on: "&lt;button name&gt;, toggle button, selected"
+
+### NVDA
+
+* off: "&lt;button name&gt;, toggle button, not pressed"
+* on: "&lt;button name&gt;, toggle button, pressed"
+
+### JAWS
+
+* off: "&lt;button name&gt;, toggle button"
+* on: "&lt;button name&gt;, toggle button, pressed"

--- a/tests/plugins/button/manual/togglebuttonscreenreader.md
+++ b/tests/plugins/button/manual/togglebuttonscreenreader.md
@@ -11,7 +11,7 @@
 1. Move the focus back to the button.
 
 	**Expected** Screen reader announces the button as togglable and currently switched on/pressed.
-1. Activate the button via keyboarf
+1. Activate the button via the keyboard.
 1. Move the focus back to the button.
 
 	**Expected** Screen reader announces the button as togglable and currently switched off/unpressed.

--- a/tests/plugins/button/manual/togglebuttonscreenreader.md
+++ b/tests/plugins/button/manual/togglebuttonscreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, 2444, feature, button
+@bender-tags: 4.19.0, 2444, feature, button
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, link
 

--- a/tests/plugins/copyformatting/aria.js
+++ b/tests/plugins/copyformatting/aria.js
@@ -1,0 +1,11 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar,copyformatting */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+bender.editor = true;
+
+// (#2444)
+bender.test( buttonTools.createAriaPressedTests( 'test_editor', [
+	'CopyFormatting'
+] ) );

--- a/tests/plugins/justify/aria.js
+++ b/tests/plugins/justify/aria.js
@@ -1,0 +1,14 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar,justify */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+bender.editor = true;
+
+// (#2444)
+bender.test( buttonTools.createAriaPressedTests( 'test_editor', [
+	'JustifyLeft',
+	'JustifyCenter',
+	'JustifyRight',
+	'JustifyBlock'
+] ) );

--- a/tests/plugins/list/aria.js
+++ b/tests/plugins/list/aria.js
@@ -1,0 +1,12 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar,list */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+bender.editor = true;
+
+// (#2444)
+bender.test( buttonTools.createAriaPressedTests( 'test_editor', [
+	'NumberedList',
+	'BulletedList'
+] ) );

--- a/tests/plugins/maximize/aria.js
+++ b/tests/plugins/maximize/aria.js
@@ -1,0 +1,33 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar, maximize */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+( function() {
+	bender.editor = true;
+
+	// (#2444)
+	var tests = buttonTools.createAriaPressedTests( 'test_editor', [
+		'Maximize'
+	] );
+
+	// (#2444)
+	tests[ 'the label is not changed after maximizing the editor' ] = function() {
+		var editor = this.editor,
+			button = buttonTools.getUiItem( editor, 'Maximize' ),
+			domButton = buttonTools.getButtonDomElement( button ),
+			initialLabel = button.label;
+
+		editor.once( 'afterCommandExec', function() {
+			var label = domButton.findOne( '.cke_button_label' ).getHtml();
+
+			editor.execCommand( 'maximize' );
+
+			assert.areSame( initialLabel, label );
+		} );
+
+		editor.execCommand( 'maximize' );
+	};
+
+	bender.test( tests );
+} )();

--- a/tests/plugins/maximize/manual/togglebutton.html
+++ b/tests/plugins/maximize/manual/togglebutton.html
@@ -1,0 +1,27 @@
+<div id="editor"></div>
+
+<script>
+	( function() {
+		CKEDITOR.replace( 'editor', {
+			language: 'en',
+			toolbar: [ [ 'Maximize' ] ],
+			extraAllowedContent: 'b',
+			on: {
+				instanceReady: renderButtonState,
+				afterCommandExec: renderButtonState
+			}
+		} );
+
+		function renderButtonState( evt ) {
+			var editor = evt.editor,
+				button = CKEDITOR.document.findOne( '.cke_button__maximize' ),
+				buttonLabelElement = button.findOne( '.cke_button_label' ),
+				isPressed = button.getAttribute( 'aria-pressed' ),
+				label = buttonLabelElement.getHtml(),
+				statusHtml = '<p>Is pressed: <b>' + isPressed + '</b>' +
+					'<p>Label: <b>' + label + '</b>'
+
+			editor.setData( statusHtml );
+		}
+	} )();
+</script>

--- a/tests/plugins/maximize/manual/togglebutton.md
+++ b/tests/plugins/maximize/manual/togglebutton.md
@@ -1,0 +1,20 @@
+@bender-tags: 4.18.1, 2444, feature, button
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, maximize
+
+1. Wait for editor to fully load.
+1. Check the info about the "Maximize" button that is rendered inside the editor
+
+	**Expected** The "Is pressed" equals `false` and "Label" equals "Maximize".
+
+	**Unexected** The "Is pressed" equals `true` or is not set.
+1. Click the button in the toolbar.
+
+	**Expected** The "Is pressed" equals `true` and "Label" equals "Maximize".
+
+	**Unexected** The "Is pressed" equals `false` or "Label" equals "Minimize".
+1. Click the button once more.
+
+	**Expected** The "Is pressed" equals `false` and "Label" equals "Maximize".
+
+	**Unexected** The "Is pressed" equals `true` or is not set.

--- a/tests/plugins/maximize/manual/togglebutton.md
+++ b/tests/plugins/maximize/manual/togglebutton.md
@@ -3,7 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, maximize
 
 1. Wait for editor to fully load.
-1. Check the info about the "Maximize" button that is rendered inside the editor
+1. Check the info about the "Maximize" button that is rendered inside the editor.
 
 	**Expected** The "Is pressed" equals `false` and "Label" equals "Maximize".
 

--- a/tests/plugins/maximize/manual/togglebutton.md
+++ b/tests/plugins/maximize/manual/togglebutton.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, 2444, feature, button
+@bender-tags: 4.19.0, 2444, feature, button
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, maximize
 

--- a/tests/plugins/menubutton/manual/menubuttonscreenreader.html
+++ b/tests/plugins/menubutton/manual/menubuttonscreenreader.html
@@ -1,0 +1,10 @@
+<div id="editor">
+	<p>Whatever</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		toolbar: [ [ 'Language' ] ],
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/menubutton/manual/menubuttonscreenreader.md
+++ b/tests/plugins/menubutton/manual/menubuttonscreenreader.md
@@ -1,0 +1,32 @@
+@bender-tags: 4.18.1, 2444, feature, button
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, language
+
+**Note** This test is intended for screen reader.
+
+1. Move focus to the button in the editor's toolbar.
+
+	**Expected** Screen reader announces the button as having popup and currently collapsed.
+1. Activate the button via keyboard.
+
+	**Expected** Screen reader announces the menu.
+1. Press <kbd>Escape</kbd>.
+
+	**Expected** Screen reader announces the button as having popup and currently collapsed.
+
+## Sample screen reader outputs
+
+### VoiceOver on macOS
+
+* button: "&lt;button name&gt;, menu pop-up collapsed, button"
+* menu: ("plop" sound) "&lt;first item name&gt; you are currently in the menu"
+
+### NVDA
+
+* button: &lt;button name&gt; button collapsed submenu
+* menu: ("beep" sound) "&lt;first item name&gt; not checked 1 of 3"
+
+### JAWS
+
+* off: "&lt;button name&gt;, button menu. Press space to activate the menu, then navigate with arrow keys"
+* menu: "Menu, &lt;first item name&gt; not checked 1 of 3. To move through items press up and down arrow"

--- a/tests/plugins/menubutton/manual/menubuttonscreenreader.md
+++ b/tests/plugins/menubutton/manual/menubuttonscreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, 2444, feature, button
+@bender-tags: 4.19.0, 2444, feature, button
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, language
 

--- a/tests/plugins/sourcearea/aria.js
+++ b/tests/plugins/sourcearea/aria.js
@@ -1,0 +1,43 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: toolbar,sourcearea */
+/* bender-include: ../button/_helpers/buttontools.js */
+/* global buttonTools */
+
+( function() {
+	bender.editor = true;
+
+	// (#2444)
+	var tests = buttonTools.createAriaPressedTests( 'test_editor', [
+		'Source'
+	] );
+
+	tests[ 'test updating [aria-pressed] attribute while changing editor\'s mode' ] = function() {
+		var editor = this.editor,
+			button = buttonTools.getUiItem( editor, 'Source' ),
+			sourceExpected = {
+				'aria-pressed': 'true'
+			},
+			wysiwygExpected = {
+				'aria-pressed': 'false'
+			};
+
+		editor.setMode( 'source', function() {
+			resume( function() {
+				buttonTools.assertAttributes( sourceExpected, button );
+
+				editor.setMode( 'wysiwyg', function() {
+					resume( function() {
+						buttonTools.assertAttributes( wysiwygExpected, button );
+					} );
+				} );
+
+				wait();
+			} );
+		} );
+
+		wait();
+	};
+
+	bender.test( tests );
+} )();
+


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
New features:

* [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.

Fixed Issues:

* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): The selected states of toolbar buttons are not announced by screen readers.
```

## What changes did you make?

I've changed the way of handling the `[aria-pressed]` attribute in the `button` plugin. After the changes, the attribute is always present on the button and only its value is changed (previously the attribute was removed when the button was not pressed). Additionally, I've added the `isToggle` option to the button's definition which indicates that the button is togglable (this option is needed to handle the initial state of the toggle buttons).

I've then added `isToogle` option to plugins using toggle buttons:

* basicstyles,
* bidi,
* blockquote,
* copyformatting,
* justify,
* list,
* sourcearea.

However, there are still some plugins that require additional attention:

* language and colorbutton – these plugins use menu buttons that are also togglable, however, screen readers do not support such combination, so the information about the state of the toggle button is lost,
* maximize – this plugin uses the toggle button but instead of conveying the state using the `[aria-pressed]` attribute, it changes the label of the button (from "Maximize" to "Minimize"; I'd suggest replacing the current method with the `[aria-pressed]` one, used in other plugins.

## Which issues does your PR resolve?

Closes #2444.
Closes #4543.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
