### PR TITLE
Add functionality to cancel awaiting for delayed editor creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ CKEditor 4 Changelog
 New features:
 
 * [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.
-* [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): Added an option to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature as a function handle to editor creators ([`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo)).
+* [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): Added an option allowing to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature as a function handle to editor creators ([`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo)).
 
 Fixed Issues:
 
@@ -15,6 +15,9 @@ Fixed Issues:
 * [#4904](https://github.com/ckeditor/ckeditor4/issues/4904): Fixed: Selection in table via keyboard is broken after adding new table row.
 * [#5049](https://github.com/ckeditor/ckeditor4/issues/5049): Fixed: Editor fails in strict mode.
 
+API changes:
+
+* [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): [`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo) functions are now returning a handle function allowing to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature.
 ## CKEditor 4.18.0
 
 **Security Updates:**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CKEditor 4 Changelog
 New features:
 
 * [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.
+* [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): Added an option to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature as a function handle to editor creators ([`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo)).
 
 Fixed Issues:
 

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -155,6 +155,10 @@
 	/**
 	 * Calls the {@link CKEDITOR#inline `CKEDITOR.inline()`} method for all page elements with the `contenteditable` attribute set to
 	 * `true` that are allowed in the {@link CKEDITOR.dtd#$editable} object.
+	 *
+	 * Since 4.17 this function also supports {@glink features/delayed_creation Delayed Editor Creation} feature
+	 * allowing to postpone editor initialization.
+	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
 	 */
 	CKEDITOR.inlineAll = function() {
 		var el,

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -49,7 +49,7 @@
 	 * @param {Object/String} element The DOM element or its ID.
 	 * @param {Object} [instanceConfig] The specific configurations to apply to this editor instance.
 	 * See {@link CKEDITOR.config}.
-	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or a cancelation function.
 	 * If {@glink features/delayed_creation Delayed Editor Creation} feature has not been set and
 	 * element is missing in DOM, this function will return `null`.
 	 */

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -37,8 +37,7 @@
 
 		// (#4461)
 		if ( CKEDITOR.editor.shouldDelayEditorCreation( element, instanceConfig ) ) {
-			CKEDITOR.editor.initializeDelayedEditorCreation( element, instanceConfig, 'inline' );
-			return null;
+			return CKEDITOR.editor.initializeDelayedEditorCreation( element, instanceConfig, 'inline' );
 		}
 
 		var textarea = element.is( 'textarea' ) ? element : null,

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -23,10 +23,35 @@
 	 * If you do so, an additional `<div>` element with editable content will be created
 	 * directly after the `<textarea>` element and the `<textarea>` element will be hidden.
 	 *
+	 * Since 4.17 this function also supports {@glink features/delayed_creation Delayed Editor Creation} feature
+	 * allowing to postpone editor initialization.
+	 *
+	 * Since 4.19 if the editor has been configured to use {@glink features/delayed_creation Delayed Editor Creation}
+	 * feature and the editor has not been initialized yet, this function will return a handle allowing
+	 * to cancel interval set by {@link CKEDITOR.config#delayIfDetached} and
+	 * {@link CKEDITOR.config#delayIfDetached_interval} options.
+	 *
+	 * ```javascript
+	 * var cancelInterval = CKEDITOR.inline( 'editor', {
+	 * 	delayIfDetached: true,
+	 * 	delayIfDetached_interval: 50 // Default value, you can skip that option.
+	 * } );
+	 *
+	 * cancelInterval(); // Cancel editor initialization if needed.
+	 * ```
+	 *
+	 * It's recommended to use this function to prevent potential memory leaks. Use it if you know
+	 * that the editor host element will never be attached to the DOM. As an example, execute cancel handle
+	 * in your component cleanup logic (e.g. `onDestroy` lifecycle methods in popular frontend frameworks).
+	 *
+	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
+	 *
 	 * @param {Object/String} element The DOM element or its ID.
 	 * @param {Object} [instanceConfig] The specific configurations to apply to this editor instance.
 	 * See {@link CKEDITOR.config}.
-	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation or null.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation.
+	 * If {@glink features/delayed_creation Delayed Editor Creation} feature has not been set and
+	 * element is missing in DOM, this function will return `null`.
 	 */
 	CKEDITOR.inline = function( element, instanceConfig ) {
 		element = CKEDITOR.editor._getEditorElement( element );

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -26,7 +26,7 @@
 	 * @param {Object/String} element The DOM element or its ID.
 	 * @param {Object} [instanceConfig] The specific configurations to apply to this editor instance.
 	 * See {@link CKEDITOR.config}.
-	 * @returns {CKEDITOR.editor} The editor instance created.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation or null.
 	 */
 	CKEDITOR.inline = function( element, instanceConfig ) {
 		element = CKEDITOR.editor._getEditorElement( element );

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -56,7 +56,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 * @param {Object} [config] The specific configuration to apply to this
 	 * editor instance. Configuration set here will override the global CKEditor settings
 	 * (see {@link CKEDITOR.config}).
-	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or a cancelation function.
 	 * If {@glink features/delayed_creation Delayed Editor Creation} feature has not been set and
 	 * element is missing in DOM, this function will return `null`.
 	 */
@@ -103,6 +103,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 * It's recommended to use this function to prevent potential memory leaks. Use it if you know
 	 * that the editor host element will never be attached to the DOM. As an example, execute cancel handle
 	 * in your component cleanup logic (e.g. `onDestroy` lifecycle methods in popular frontend frameworks).
+	 *
 	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
 	 *
 	 * @param {Object/String} element The DOM element, its ID, or name.
@@ -110,7 +111,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 * editor instance. Configuration set here will override the global CKEditor settings
 	 * (see {@link CKEDITOR.config}).
 	 * @param {String} [data] Since 3.3. Initial value for the instance.
-	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or a cancelation function.
 	 * If {@glink features/delayed_creation Delayed Editor Creation} feature has not been set and
 	 * element is missing in DOM, this function will return `null`.
 	 */
@@ -159,7 +160,6 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 *
 	 * Since 4.17 this function also supports {@glink features/delayed_creation Delayed Editor Creation} feature
 	 * allowing to postpone editor initialization.
-	 *
 	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
 	 *
 	 * @param {String} [className] The `<textarea>` class name.

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -345,8 +345,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 
 		// (#4461)
 		if ( CKEDITOR.editor.shouldDelayEditorCreation( element, config ) ) {
-			CKEDITOR.editor.initializeDelayedEditorCreation( element, config, 'replace' );
-			return null;
+			return CKEDITOR.editor.initializeDelayedEditorCreation( element, config, 'replace' );
 		}
 
 		// Create the editor instance.

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -29,11 +29,36 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 *		var textarea = document.body.appendChild( document.createElement( 'textarea' ) );
 	 *		CKEDITOR.replace( textarea );
 	 *
+	 * Since 4.17 this function also supports {@glink features/delayed_creation Delayed Editor Creation} feature
+	 * allowing to postpone editor initialization.
+	 *
+	 * Since 4.19 if the editor has been configured to use {@glink features/delayed_creation Delayed Editor Creation}
+	 * feature and the editor has not been initialized yet, this function will return a handle allowing
+	 * to cancel interval set by {@link CKEDITOR.config#delayIfDetached} and
+	 * {@link CKEDITOR.config#delayIfDetached_interval} options.
+	 *
+	 * ```javascript
+	 * var cancelInterval = CKEDITOR.replace( 'editor', {
+	 * 	delayIfDetached: true,
+	 * 	delayIfDetached_interval: 50 // Default value, you can skip that option.
+	 * } );
+	 *
+	 * cancelInterval(); // Cancel editor initialization if needed.
+	 * ```
+	 *
+	 * It's recommended to use this function to prevent potential memory leaks. Use it if you know
+	 * that the editor host element will never be attached to the DOM. As an example, execute cancel handle
+	 * in your component cleanup logic (e.g. `onDestroy` lifecycle methods in popular frontend frameworks).
+	 *
+	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
+	 *
 	 * @param {Object/String} element The DOM element (textarea), its ID, or name.
 	 * @param {Object} [config] The specific configuration to apply to this
 	 * editor instance. Configuration set here will override the global CKEditor settings
 	 * (see {@link CKEDITOR.config}).
-	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation or null.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation.
+	 * If {@glink features/delayed_creation Delayed Editor Creation} feature has not been set and
+	 * element is missing in DOM, this function will return `null`.
 	 */
 	CKEDITOR.replace = function( element, config ) {
 		return createInstance( element, config, null, CKEDITOR.ELEMENT_MODE_REPLACE );

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -33,7 +33,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 * @param {Object} [config] The specific configuration to apply to this
 	 * editor instance. Configuration set here will override the global CKEditor settings
 	 * (see {@link CKEDITOR.config}).
-	 * @returns {CKEDITOR.editor} The editor instance created.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation or null.
 	 */
 	CKEDITOR.replace = function( element, config ) {
 		return createInstance( element, config, null, CKEDITOR.ELEMENT_MODE_REPLACE );
@@ -63,7 +63,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 * editor instance. Configuration set here will override the global CKEditor settings
 	 * (see {@link CKEDITOR.config}).
 	 * @param {String} [data] Since 3.3. Initial value for the instance.
-	 * @returns {CKEDITOR.editor} The editor instance created.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation or null.
 	 */
 	CKEDITOR.appendTo = function( element, config, data ) {
 		return createInstance( element, config, data, CKEDITOR.ELEMENT_MODE_APPENDTO );

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -83,12 +83,36 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 *			</body>
 	 *		</html>
 	 *
+	 * Since 4.17 this function also supports {@glink features/delayed_creation Delayed Editor Creation} feature
+	 * allowing to postpone editor initialization.
+	 *
+	 * Since 4.19 if the editor has been configured to use {@glink features/delayed_creation Delayed Editor Creation}
+	 * feature and the editor has not been initialized yet, this function will return a handle allowing
+	 * to cancel interval set by {@link CKEDITOR.config#delayIfDetached} and
+	 * {@link CKEDITOR.config#delayIfDetached_interval} options.
+	 *
+	 * ```javascript
+	 * var cancelInterval = CKEDITOR.appendTo( 'editorSpace', {
+	 * 	delayIfDetached: true,
+	 * 	delayIfDetached_interval: 50 // Default value, you can skip that option.
+	 * } );
+	 *
+	 * cancelInterval(); // Cancel editor initialization if needed.
+	 * ```
+	 *
+	 * It's recommended to use this function to prevent potential memory leaks. Use it if you know
+	 * that the editor host element will never be attached to the DOM. As an example, execute cancel handle
+	 * in your component cleanup logic (e.g. `onDestroy` lifecycle methods in popular frontend frameworks).
+	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
+	 *
 	 * @param {Object/String} element The DOM element, its ID, or name.
 	 * @param {Object} [config] The specific configuration to apply to this
 	 * editor instance. Configuration set here will override the global CKEditor settings
 	 * (see {@link CKEDITOR.config}).
 	 * @param {String} [data] Since 3.3. Initial value for the instance.
-	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation or null.
+	 * @returns {CKEDITOR.editor/Function/null} The editor instance or function to cancel creation.
+	 * If {@glink features/delayed_creation Delayed Editor Creation} feature has not been set and
+	 * element is missing in DOM, this function will return `null`.
 	 */
 	CKEDITOR.appendTo = function( element, config, data ) {
 		return createInstance( element, config, data, CKEDITOR.ELEMENT_MODE_APPENDTO );
@@ -132,6 +156,11 @@ CKEDITOR.replaceClass = 'ckeditor';
 	 *				</script>
 	 *			</body>
 	 *		</html>
+	 *
+	 * Since 4.17 this function also supports {@glink features/delayed_creation Delayed Editor Creation} feature
+	 * allowing to postpone editor initialization.
+	 *
+	 * Read more about this feature in the {@glink features/delayed_creation documentation}.
 	 *
 	 * @param {String} [className] The `<textarea>` class name.
 	 * @param {Function} [evaluator] An evaluation function that must return `true` for a `<textarea>`

--- a/core/editor.js
+++ b/core/editor.js
@@ -1711,7 +1711,9 @@
 				}
 			}, interval );
 
-			CKEDITOR.config.delayIfDetached_cancelInterval( clearInterval( intervalId ) );
+			if ( CKEDITOR.config.delayIfDetached_cancelInterval ) {
+				CKEDITOR.config.delayIfDetached_cancelInterval( clearInterval( intervalId ) );
+			}
 		}
 	};
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -1710,6 +1710,8 @@
 					} );
 				}
 			}, interval );
+
+			CKEDITOR.config.delayIfDetached_cancelInterval( clearInterval( intervalId ) );
 		}
 	};
 
@@ -2374,6 +2376,25 @@ CKEDITOR.config.delayIfDetached = false;
  * @member CKEDITOR.config
  */
 CKEDITOR.config.delayIfDetached_callback = undefined;
+
+/**
+ * The function that allows canceling interval editor verification started during default delayed editor creation.
+ *
+ *		// Store the reference to the cancelation function.
+ *		var cancelAwaitingForEditor;
+ *
+ *		config.delayIfDetached_cancelInterval = function( cancelationFunction ) {
+ *			cancelAwaitingForEditor = cancelationFunction;
+ *		};
+ *
+ *		// Cancel awaiting by calling `cancelAwaitingForEditor()` whenever you choose (e.g. on button click).
+ *		cancelAwaitingForEditor ();
+ *
+ * @since 4.18.1
+ * @cfg {Function} [delayIfDetached_cancelInterval = undefined]
+ * @member CKEDITOR.config
+*/
+CKEDITOR.config.delayIfDetached_cancelInterval = undefined;
 
 /**
  * The amount of time (in milliseconds) between consecutive checks whether editor's target element is attached to DOM.

--- a/core/editor.js
+++ b/core/editor.js
@@ -1691,6 +1691,8 @@
 					method: 'callback'
 				} );
 			} );
+
+			return null;
 		} else {
 			var interval = config.delayIfDetached_interval === undefined ? CKEDITOR.config.delayIfDetached_interval : config.delayIfDetached_interval,
 				intervalId;
@@ -1711,9 +1713,9 @@
 				}
 			}, interval );
 
-			if ( CKEDITOR.config.delayIfDetached_cancelInterval ) {
-				CKEDITOR.config.delayIfDetached_cancelInterval( clearInterval( intervalId ) );
-			}
+			return function() {
+				clearInterval( intervalId );
+			};
 		}
 	};
 
@@ -2378,25 +2380,6 @@ CKEDITOR.config.delayIfDetached = false;
  * @member CKEDITOR.config
  */
 CKEDITOR.config.delayIfDetached_callback = undefined;
-
-/**
- * The function that allows canceling interval editor verification started during default delayed editor creation.
- *
- *		// Store the reference to the cancelation function.
- *		var cancelAwaitingForEditor;
- *
- *		config.delayIfDetached_cancelInterval = function( cancelationFunction ) {
- *			cancelAwaitingForEditor = cancelationFunction;
- *		};
- *
- *		// Cancel awaiting by calling `cancelAwaitingForEditor()` whenever you choose (e.g. on button click).
- *		cancelAwaitingForEditor ();
- *
- * @since 4.18.1
- * @cfg {Function} [delayIfDetached_cancelInterval = undefined]
- * @member CKEDITOR.config
-*/
-CKEDITOR.config.delayIfDetached_cancelInterval = undefined;
 
 /**
  * The amount of time (in milliseconds) between consecutive checks whether editor's target element is attached to DOM.

--- a/core/editor.js
+++ b/core/editor.js
@@ -1662,6 +1662,7 @@
 	 * * A callback, that should be called to create editor.
 	 *
 	 * Otherwise, it periodically (with `setInterval()` calls) checks if element is attached to DOM and creates editor automatically.
+	 * The interval can be canceled by executing a callback function (a handle) clearing the interval.
 	 *
 	 * ```js
 	 *	CKEDITOR.inline( detachedEditorElement, {
@@ -1675,8 +1676,11 @@
 	 * @static
 	 * @member CKEDITOR.editor
 	 * @param {CKEDITOR.dom.element} element The DOM element on which editor should be initialized.
-	 * @param {Object} config The specific configuration to apply to the editor instance. Configuration set here will override the global CKEditor settings.
+	 * @param {Object} config The specific configuration to apply to the editor instance.
+	 * Configuration set here will override the global CKEditor settings.
 	 * @param {String} editorCreationMethod Creator function that should be used to initialize editor (inline/replace).
+	 * @returns {Function/null} A handle allowing to cancel delayed editor initialization creation
+	 * or null if {@link CKEDITOR.config#delayIfDetached_callback} option is set.
 	 */
 	CKEDITOR.editor.initializeDelayedEditorCreation = function( element, config, editorCreationMethod ) {
 		if ( config.delayIfDetached_callback ) {
@@ -1693,30 +1697,31 @@
 			} );
 
 			return null;
-		} else {
-			var interval = config.delayIfDetached_interval === undefined ? CKEDITOR.config.delayIfDetached_interval : config.delayIfDetached_interval,
-				intervalId;
-
-			CKEDITOR.warn( 'editor-delayed-creation', {
-				method: 'interval - ' + interval + ' ms'
-			} );
-
-			intervalId = setInterval( function() {
-				if ( !element.isDetached() ) {
-					clearInterval( intervalId );
-
-					CKEDITOR[ editorCreationMethod ]( element, config );
-
-					CKEDITOR.warn( 'editor-delayed-creation-success', {
-						method: 'interval - ' + interval + ' ms'
-					} );
-				}
-			}, interval );
-
-			return function() {
-				clearInterval( intervalId );
-			};
 		}
+
+		var interval = config.delayIfDetached_interval === undefined ?
+			CKEDITOR.config.delayIfDetached_interval
+			: config.delayIfDetached_interval;
+
+		CKEDITOR.warn( 'editor-delayed-creation', {
+			method: 'interval - ' + interval + ' ms'
+		} );
+
+		var intervalId = setInterval( function() {
+			if ( !element.isDetached() ) {
+				clearInterval( intervalId );
+
+				CKEDITOR[ editorCreationMethod ]( element, config );
+
+				CKEDITOR.warn( 'editor-delayed-creation-success', {
+					method: 'interval - ' + interval + ' ms'
+				} );
+			}
+		}, interval );
+
+		return function() {
+			clearInterval( intervalId );
+		};
 	};
 
 	/**

--- a/tests/core/creators/_helpers/tools.js
+++ b/tests/core/creators/_helpers/tools.js
@@ -5,6 +5,8 @@
 var detachedTests = ( function() {
 	function appendTests( creatorFunction, tests ) {
 
+		var assertMessage = 'Creator function used: ' + creatorFunction;
+
 		return CKEDITOR.tools.extend( tests, {
 			test_editor_is_created_immediately_on_not_detached_element_even_with_delay_config: function() {
 				var editorElement = CKEDITOR.document.getById( createHtmlForEditor() ),
@@ -13,7 +15,7 @@ var detachedTests = ( function() {
 						delayIfDetached_callback: function() {}
 					} );
 
-				assert.isNotNull( editor, 'Editor should be created immediately on not detached element, even if config allows a delay. Creator function used: ' + creatorFunction );
+				assert.isNotNull( editor, 'Editor should be created immediately on not detached element, even if config allows a delay. ' + assertMessage );
 			},
 
 			test_editor_is_created_immediately_on_not_detached_element_with_delayIfDetached_config_set_as_false: function() {
@@ -22,14 +24,14 @@ var detachedTests = ( function() {
 						delayIfDetached: false
 					} );
 
-				assert.isNotNull( editor, 'Editor should be created immediately on not detached element, despite config delay option. Creator function used: ' + creatorFunction );
+				assert.isNotNull( editor, 'Editor should be created immediately on not detached element, despite config delay option. ' + assertMessage );
 			},
 
 			test_editor_without_config_is_created_immediately_on_not_detached_element: function() {
 				var editorElement = CKEDITOR.document.getById( createHtmlForEditor() ),
 					editor = CKEDITOR[ creatorFunction ]( editorElement );
 
-				assert.isNotNull( editor, 'Editor should be created immediately with default config options. Creator function used: ' + creatorFunction );
+				assert.isNotNull( editor, 'Editor should be created immediately with default config options. ' + assertMessage );
 			},
 
 			test_delay_editor_creation_if_target_element_is_detached: function() {
@@ -42,7 +44,7 @@ var detachedTests = ( function() {
 					delayIfDetached: true
 				} );
 
-				assert.isNull( editor, 'Editor should not be created on detached element, if config allows a delay. Creator function used: ' + creatorFunction );
+				assert.areSame( typeof editor, 'function', 'Editor should return function that allows to cancel creation. ' + assertMessage );
 
 				editorParent.append( editorElement );
 			},
@@ -58,7 +60,7 @@ var detachedTests = ( function() {
 					on: {
 						instanceReady: function() {
 							resume( function() {
-								assert.pass( 'Editor was created. Creator function used: ' + creatorFunction );
+								assert.pass( 'Editor was created. ' + assertMessage );
 							} );
 						}
 					}
@@ -84,7 +86,7 @@ var detachedTests = ( function() {
 					on: {
 						instanceReady: function() {
 							resume( function() {
-								assert.pass( 'Editor was created from custom callback. Creator function used: ' + creatorFunction );
+								assert.pass( 'Editor was created from custom callback. ' + assertMessage );
 							} );
 						}
 					}
@@ -120,18 +122,18 @@ var detachedTests = ( function() {
 									secondCallData = spyWarn.secondCall.args[ 0 ].data,
 									expectedMethod = 'interval - ' + CKEDITOR.config.delayIfDetached_interval + ' ms';
 
-								assert.areEqual( 'editor-delayed-creation', firstCallData.errorCode, 'First editor warn should be about creation delay with interval. Creator function used: ' + creatorFunction );
-								assert.areEqual( expectedMethod , firstCallData.additionalData.method, 'First editor warn method should be interval with time. Creator function used: ' + creatorFunction );
+								assert.areEqual( 'editor-delayed-creation', firstCallData.errorCode, 'First editor warn should be about creation delay with interval. ' + assertMessage );
+								assert.areEqual( expectedMethod , firstCallData.additionalData.method, 'First editor warn method should be interval with time. ' + assertMessage );
 
 								assert.areEqual(
 									'editor-delayed-creation-success',
 									secondCallData.errorCode,
-									'Second editor warn should be about success editor creation with interval. Creator function used: ' + creatorFunction
+									'Second editor warn should be about success editor creation with interval. ' + assertMessage
 								);
 								assert.areEqual(
 									expectedMethod,
 									secondCallData.additionalData.method,
-									'Second editor warn method should be interval with time. Creator function used: ' + creatorFunction
+									'Second editor warn method should be interval with time. ' + assertMessage
 								);
 
 								CKEDITOR.removeListener( 'log', spyWarn );
@@ -170,18 +172,18 @@ var detachedTests = ( function() {
 								var firstCallData = spyWarn.firstCall.args[ 0 ].data,
 									secondCallData = spyWarn.secondCall.args[ 0 ].data;
 
-								assert.areEqual( 'editor-delayed-creation', firstCallData.errorCode, 'First editor warn should be about creation delay with callback. Creator function used: ' + creatorFunction );
-								assert.areEqual( 'callback' , firstCallData.additionalData.method, 'First editor warn method should be \'callback\'. Creator function used: ' + creatorFunction );
+								assert.areEqual( 'editor-delayed-creation', firstCallData.errorCode, 'First editor warn should be about creation delay with callback. ' + assertMessage );
+								assert.areEqual( 'callback' , firstCallData.additionalData.method, 'First editor warn method should be \'callback\'. ' + assertMessage );
 
 								assert.areEqual(
 									'editor-delayed-creation-success',
 									secondCallData.errorCode,
-									'Second editor warn should be about success editor creation with callback. Creator function used: ' + creatorFunction
+									'Second editor warn should be about success editor creation with callback. ' + assertMessage
 								);
 								assert.areEqual(
 									'callback',
 									secondCallData.additionalData.method,
-									'Second editor warn method should be \'callback\'. Creator function used: ' + creatorFunction
+									'Second editor warn method should be \'callback\'. ' + assertMessage
 								);
 
 								CKEDITOR.removeListener( 'log', spyWarn );
@@ -214,7 +216,7 @@ var detachedTests = ( function() {
 				CKEDITOR.tools.setTimeout( function() {
 					resume( function() {
 						editorElementParent.append( editorElement );
-						assert.isTrue( spyIsDetached.callCount > 2, 'There should be at least three calls of isDetached(). Creator function used: ' + creatorFunction );
+						assert.isTrue( spyIsDetached.callCount > 2, 'There should be at least three calls of isDetached(). ' + assertMessage );
 						spyIsDetached.restore();
 					} );
 				}, 200 );

--- a/tests/core/creators/_helpers/tools.js
+++ b/tests/core/creators/_helpers/tools.js
@@ -49,6 +49,34 @@ var detachedTests = ( function() {
 				editorParent.append( editorElement );
 			},
 
+			test_delayed_editor_creation_is_cancelable: function() {
+				var editorElement = CKEDITOR.document.getById( createHtmlForEditor() ),
+					editorParent = editorElement.getParent();
+
+				editorElement.remove();
+
+				var cancelationCallback = CKEDITOR[ creatorFunction ]( editorElement, {
+					delayIfDetached: true,
+					delayIfDetached_interval: 50
+				} );
+
+				cancelationCallback();
+
+				// Attach the spy after cancelation to prevent unexpected invocations while test is waiting to fullfil.
+				var spyIsDetached = sinon.spy( editorElement, 'isDetached' );
+
+				CKEDITOR.tools.setTimeout( function() {
+					resume( function() {
+						assert.areSame( 0, spyIsDetached.callCount, 'The isDetached method should not be called after cancelation. ' + assertMessage );
+						spyIsDetached.restore();
+					} );
+				}, 150 );
+
+				editorParent.append( editorElement );
+
+				wait();
+			},
+
 			test_delay_editor_creation_with_default_interval_strategy_until_target_element_attach_to_DOM: function() {
 				var editorElement = CKEDITOR.document.getById( createHtmlForEditor() ),
 					editorParent = editorElement.getParent();

--- a/tests/core/creators/_helpers/tools.js
+++ b/tests/core/creators/_helpers/tools.js
@@ -44,7 +44,7 @@ var detachedTests = ( function() {
 					delayIfDetached: true
 				} );
 
-				assert.areSame( typeof editor, 'function', 'Editor should return function that allows to cancel creation. ' + assertMessage );
+				assert.areSame( 'function', typeof editor, 'Editor should return function that allows to cancel creation. ' + assertMessage );
 
 				editorParent.append( editorElement );
 			},

--- a/tests/core/creators/detachedinline.js
+++ b/tests/core/creators/detachedinline.js
@@ -8,7 +8,7 @@
 	'use strict';
 
 	var tests = detachedTests.appendTests( 'inline', {
-		'test CKEDITOR.inlineAll() doesnt call the shouldDelayEditorCreation() function when elements are detached': function() {
+		'test CKEDITOR.inlineAll() does not call the shouldDelayEditorCreation() function when elements are detached': function() {
 			var inlineSpy = sinon.spy( CKEDITOR.editor, 'shouldDelayEditorCreation' ),
 				editableParent = CKEDITOR.document.getById( 'inlineEditableParent' );
 

--- a/tests/core/creators/detachedreplace.js
+++ b/tests/core/creators/detachedreplace.js
@@ -8,7 +8,7 @@
 	'use strict';
 
 	var tests = detachedTests.appendTests( 'replace', {
-		'test CKEDITOR.replaceAll() doesnt call the shouldDelayEditorCreation() function when elements are detached': function() {
+		'test CKEDITOR.replaceAll() does not call the shouldDelayEditorCreation() function when elements are detached': function() {
 			var textarea = CKEDITOR.document.getById( 'ta1' ),
 				replaceSpy = sinon.spy( CKEDITOR.editor, 'shouldDelayEditorCreation' );
 

--- a/tests/core/creators/manual/detachedcancelinterval.html
+++ b/tests/core/creators/manual/detachedcancelinterval.html
@@ -3,7 +3,7 @@
 
 <div>
 	<div id="editor">
-		<p>Lorem ipsum dolor sit amet.</p>
+		<p>Do I look like an editor? If so, the test failed!</p>
 	</div>
 </div>
 

--- a/tests/core/creators/manual/detachedcancelinterval.html
+++ b/tests/core/creators/manual/detachedcancelinterval.html
@@ -1,0 +1,35 @@
+<button id="cancelButton">Cancel creation</button>
+<button id="attachButton">Attach editor to parent</button>
+
+<div>
+	<div id="editor">
+		<p>Lorem ipsum dolor sit amet.</p>
+	</div>
+</div>
+
+<script>
+	var editorElement = document.getElementById( 'editor' ),
+		attachButton = CKEDITOR.document.getById( 'attachButton' ),
+		cancelButton = CKEDITOR.document.getById( 'cancelButton' ),
+		editorParent = editorElement.parentNode,
+		cancelCreationFunction;
+
+	editorParent.removeChild( editorElement );
+
+	function storeCancelFunction( cancelCreation ) {
+		cancelCreationFunction = cancelCreation;
+	}
+
+	CKEDITOR.replace( editorElement, {
+		delayIfDetached: true,
+		delayIfDetached_cancelInterval: storeCancelFunction
+	} );
+
+	cancelButton.on( 'click', function() {
+		cancelCreationFunction();
+	} );
+
+	attachButton.on( 'click', function() {
+		editorParent.appendChild( editorElement );
+	} );
+</script>

--- a/tests/core/creators/manual/detachedcancelinterval.html
+++ b/tests/core/creators/manual/detachedcancelinterval.html
@@ -16,13 +16,8 @@
 
 	editorParent.removeChild( editorElement );
 
-	function storeCancelFunction( cancelCreation ) {
-		cancelCreationFunction = cancelCreation;
-	}
-
-	CKEDITOR.replace( editorElement, {
+	cancelCreationFunction = CKEDITOR.replace( editorElement, {
 		delayIfDetached: true,
-		delayIfDetached_cancelInterval: storeCancelFunction
 	} );
 
 	cancelButton.on( 'click', function() {

--- a/tests/core/creators/manual/detachedcancelinterval.md
+++ b/tests/core/creators/manual/detachedcancelinterval.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.18.1, feature, 4641
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, undo, clipboard, basicstyles, elementspath
+
+1. Click cancel button to cancel delayed interval creation.
+1. Click attach button to attach editor to DOM element.
+
+**Expected** Editor is not created.
+
+**Unexpected** Editor was created.

--- a/tests/core/creators/manual/detachedcancelinterval.md
+++ b/tests/core/creators/manual/detachedcancelinterval.md
@@ -2,9 +2,14 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, undo, clipboard, basicstyles, elementspath
 
-1. Click cancel button to cancel delayed interval creation.
-1. Click attach button to attach editor to DOM element.
+This manual test checks if you can cancel editor initialization.
+By clicking a cancel button, the editor initialization on attach button should be prevented.
 
-**Expected** Editor is not created.
+**Note** That clicking an attach button before canceling will result in the failed test!
 
-**Unexpected** Editor was created.
+1. Click the cancel button to cancel delayed interval creation.
+1. Click attach the button to attach the editor to the DOM.
+
+**Expected** You should see plain text indicating that the editor has not been initialized.
+
+**Unexpected** Fully functional editor.

--- a/tests/core/creators/manual/detachedcancelinterval.md
+++ b/tests/core/creators/manual/detachedcancelinterval.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, feature, 4641
+@bender-tags: 4.19.0, feature, 4641
 @bender-ui: collapsed
 @bender-ckeditor-plugins: toolbar, wysiwygarea, sourcearea, undo, clipboard, basicstyles, elementspath
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
New feature
## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): Add cancelation for delayed editor creation.
```

## What changes did you make?

*Give an overview…*

A new config function was added. It works in the same manner as the already existing [callback](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-delayIfDetached_callback). So the User pass a callback which will be invoked with cancelation function as an argument. It could be stored and invoked whenever convenient.

I don't want to introduce a new type that might be returned by editor creation. This requires changes in (probably all) integrations.

## Which issues does your PR resolve?

Closes #4641 
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
