### PR TITLE
Fix editor failing in strict mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ New features:
 
 Fixed Issues:
 
-* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Toolbar buttons toggle state is not correctly announced by screen readers.
+* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Fixed: Toolbar buttons toggle state is not correctly announced by screen readers.
 * [#3394](https://github.com/ckeditor/ckeditor4/issues/3394): Fixed: [Enhanced image](https://ckeditor.com/cke4/addon/image2) plugin dialog is not supporting URL with query string parameters. Thanks to [Simon Urli](https://github.com/surli)!
 * [#4904](https://github.com/ckeditor/ckeditor4/issues/4904): Fixed: Selection in table via keyboard is broken after adding new table row.
 * [#5049](https://github.com/ckeditor/ckeditor4/issues/5049): Fixed: Editor fails in strict mode.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Fixed Issues:
 * [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Toolbar buttons toggle state is not correctly announced by screen readers.
 * [#3394](https://github.com/ckeditor/ckeditor4/issues/3394): Fixed: [Enhanced image](https://ckeditor.com/cke4/addon/image2) plugin dialog is not supporting URL with query string parameters. Thanks to [Simon Urli](https://github.com/surli)!
 * [#4904](https://github.com/ckeditor/ckeditor4/issues/4904): Fixed: Selection in table via keyboard is broken after adding new table row.
+* [#5049](https://github.com/ckeditor/ckeditor4/issues/5049): Fixed: Editor fails in strict mode.
 
 ## CKEditor 4.18.0
 

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+'use strict';
+
 /**
  * Represents a delimited piece of content in a DOM Document.
  * It is contiguous in the sense that it can be characterized as selecting all
@@ -176,7 +178,6 @@ CKEDITOR.dom.range = function( root ) {
 	//   param (see range.deleteContents or range.extractContents).
 	//   See comments in mergeAndUpdate because this is lots of fun too.
 	function execContentsAction( range, action, docFrag, mergeThen, cloneId ) {
-		'use strict';
 
 		range.optimizeBookmark();
 
@@ -2910,7 +2911,6 @@ CKEDITOR.dom.range = function( root ) {
 		 * @returns {CKEDITOR.dom.rect[]}
 		 */
 		getClientRects: ( function() {
-			'use strict';
 			if ( document.getSelection !== undefined ) {
 				return function( isAbsolute ) {
 					// We need to create native range so we can call native getClientRects.

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2910,6 +2910,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * @returns {CKEDITOR.dom.rect[]}
 		 */
 		getClientRects: ( function() {
+			'use strict';
 			if ( document.getSelection !== undefined ) {
 				return function( isAbsolute ) {
 					// We need to create native range so we can call native getClientRects.

--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2910,7 +2910,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * @returns {CKEDITOR.dom.rect[]}
 		 */
 		getClientRects: ( function() {
-			if ( this.document.getSelection !== undefined ) {
+			if ( document.getSelection !== undefined ) {
 				return function( isAbsolute ) {
 					// We need to create native range so we can call native getClientRects.
 					var range = this.root.getDocument().$.createRange(),

--- a/tests/core/ckeditor/manual/strictmode.html
+++ b/tests/core/ckeditor/manual/strictmode.html
@@ -1,0 +1,17 @@
+<div id="editor"></div>
+<button id="createEditorBtn">Create editor</button>
+
+<script>
+	( function() {
+		if ( bender.tools.env.mobile ) {
+			return bender.ignore();
+		}
+
+		var createEditorBtn = document.getElementById( 'createEditorBtn' );
+
+		createEditorBtn.addEventListener( 'click', function() {
+			CKEDITOR.replace( 'editor' );
+			createEditorBtn.setAttribute( 'disabled', true );
+		} )
+	} )();
+</script>

--- a/tests/core/ckeditor/manual/strictmode.html
+++ b/tests/core/ckeditor/manual/strictmode.html
@@ -1,5 +1,4 @@
 <div id="editor"></div>
-<button id="createEditorBtn">Create editor</button>
 
 <script>
 	( function() {
@@ -7,11 +6,6 @@
 			return bender.ignore();
 		}
 
-		var createEditorBtn = document.getElementById( 'createEditorBtn' );
-
-		createEditorBtn.addEventListener( 'click', function() {
-			CKEDITOR.replace( 'editor' );
-			createEditorBtn.setAttribute( 'disabled', true );
-		} )
+		CKEDITOR.replace( 'editor' );
 	} )();
 </script>

--- a/tests/core/ckeditor/manual/strictmode.md
+++ b/tests/core/ckeditor/manual/strictmode.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 4.18.1, 5049
+@bender-tags: bug, 4.19.0, 5049
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles
 

--- a/tests/core/ckeditor/manual/strictmode.md
+++ b/tests/core/ckeditor/manual/strictmode.md
@@ -1,0 +1,11 @@
+@bender-tags: bug, 4.18.1, 5049
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles
+
+1. Open dev console.
+2. Click "Create editor" button.
+3. Wait until editor initialize.
+
+**Expected** There are no errors in the console.
+
+**Unexpected** There is error in the console.

--- a/tests/core/ckeditor/manual/strictmode.md
+++ b/tests/core/ckeditor/manual/strictmode.md
@@ -3,8 +3,6 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, basicstyles
 
 1. Open dev console.
-2. Click "Create editor" button.
-3. Wait until editor initialize.
 
 **Expected** There are no errors in the console.
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [X] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5049](https://github.com/ckeditor/ckeditor4/issues/5049): Fix editor fails in strict mode.
```

## What changes did you make?

*Give an overview…*

Removed `this` from IIFE in getClientRects. Without strict mode, it refers to a global `window`. In strict mode it is `undefined` - but actually, we need the global `document` in this place - so the problematic `this` could be removed.

## Which issues does your PR resolve?

Closes #5049 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
