### PR TITLE
Tweaks for representation of the editor in the accessibility tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,13 @@ New features:
 * [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.
 * [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): Added an option allowing to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature as a function handle to editor creators ([`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo)).
 * [#4986](https://github.com/ckeditor/ckeditor4/issues/4986): Added [`config.shiftLineBreaks`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-shiftLineBreaks) allowing to preserve inline elements formatting on shift enter.
+* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Added [`config.applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-applicationTitle) configuration option allowing to customize or disable editor's application region label. This option combined with [`config.title`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-title) gives much better control over editor's labels read by screen readers.
 
 Fixed Issues:
 
 * [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Fixed: Toolbar buttons toggle state is not correctly announced by screen readers lacking information if a feature is on/off.
 * [#4052](https://github.com/ckeditor/ckeditor4/issues/4052): Fixed: Editor labels are read incorrectly by screen readers due to invalid editor control type for [Iframe Editing Area](https://ckeditor.com/cke4/addon/wysiwygarea) editors.
 * [#1904](https://github.com/ckeditor/ckeditor4/issues/1904): Fixed: Screen readers are not announcing read-only editor state due to missing proper aria-labels.
-* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Fixed: The same editor's label is read several times by screen readers when focusing an editor.
 * [#4904](https://github.com/ckeditor/ckeditor4/issues/4904): Fixed: Selection in table via keyboard is broken after adding new table row.
 * [#3394](https://github.com/ckeditor/ckeditor4/issues/3394): Fixed: [Enhanced image](https://ckeditor.com/cke4/addon/image2) plugin dialog is not supporting URL with query string parameters. Thanks to [Simon Urli](https://github.com/surli)!
 * [#5049](https://github.com/ckeditor/ckeditor4/issues/5049): Fixed: Editor fails in strict mode.
@@ -25,7 +25,7 @@ API changes:
 
 * [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): [`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo) functions are now returning a handle function allowing to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature.
 * [#5095](https://github.com/ckeditor/ckeditor4/issues/5095): Added [CKEDITOR.plugins.clipboard.addFileMatcher](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard.html#method-addFileMatcher) function allowing to define supported file formats by the [clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin. Unsupported file format will result in notification that a file cannot be dropped or pasted into the editor.
-* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Added [`config.applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-applicationTitle) alongside [`CKEDITOR.editor#applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-title) to allow customizing editor's application region label.
+* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Added [`config.applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-applicationTitle) alongside [`CKEDITOR.editor#applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-applicationTitle) to allow customizing editor's application region label.
 
 ## CKEditor 4.18.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,12 @@ New features:
 
 Fixed Issues:
 
-* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Fixed: Toolbar buttons toggle state is not correctly announced by screen readers.
-* [#3394](https://github.com/ckeditor/ckeditor4/issues/3394): Fixed: [Enhanced image](https://ckeditor.com/cke4/addon/image2) plugin dialog is not supporting URL with query string parameters. Thanks to [Simon Urli](https://github.com/surli)!
+* [#4543](https://github.com/ckeditor/ckeditor4/issues/4543): Fixed: Toolbar buttons toggle state is not correctly announced by screen readers lacking information if a feature is on/off.
+* [#4052](https://github.com/ckeditor/ckeditor4/issues/4052): Fixed: Editor labels are read incorrectly by screen readers due to invalid editor control type for [Iframe Editing Area](https://ckeditor.com/cke4/addon/wysiwygarea) editors.
+* [#1904](https://github.com/ckeditor/ckeditor4/issues/1904): Fixed: Screen readers are not announcing read-only editor state due to missing proper aria-labels.
+* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Fixed: The same editor's label is read several times by screen readers when focusing an editor.
 * [#4904](https://github.com/ckeditor/ckeditor4/issues/4904): Fixed: Selection in table via keyboard is broken after adding new table row.
+* [#3394](https://github.com/ckeditor/ckeditor4/issues/3394): Fixed: [Enhanced image](https://ckeditor.com/cke4/addon/image2) plugin dialog is not supporting URL with query string parameters. Thanks to [Simon Urli](https://github.com/surli)!
 * [#5049](https://github.com/ckeditor/ckeditor4/issues/5049): Fixed: Editor fails in strict mode.
 * [#5095](https://github.com/ckeditor/ckeditor4/issues/5095): Fixed: The [clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin shows notification about unsupported file format when a file type is different than `jpg`, `gif`, `png`, not respecting [supported types](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_fileTools_uploadWidgetDefinition.html#property-supportedTypes) by the [Upload Widget](https://ckeditor.com/cke4/addon/uploadwidget) plugin.
 * [#4855](https://github.com/ckeditor/ckeditor4/issues/4855): [iOS] Fixed: Focusing toolbar buttons with an enabled VoiceOver screen reader causes moving browser focus into an editable area and interrupts button functionality.
@@ -22,6 +25,7 @@ API changes:
 
 * [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): [`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo) functions are now returning a handle function allowing to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature.
 * [#5095](https://github.com/ckeditor/ckeditor4/issues/5095): Added [CKEDITOR.plugins.clipboard.addFileMatcher](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_clipboard.html#method-addFileMatcher) function allowing to define supported file formats by the [clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin. Unsupported file format will result in notification that a file cannot be dropped or pasted into the editor.
+* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Added [`config.applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-applicationTitle) alongside [`CKEDITOR.editor#applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-title) to allow customizing editor's application region label.
 
 ## CKEditor 4.18.0
 

--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -480,9 +480,9 @@ CKEDITOR.replaceClass = 'ckeditor';
 				' dir="{langDir}"' +
 				' lang="{langCode}"' +
 				' role="application"' +
-				( editor.title ? ' aria-labelledby="cke_{name}_arialbl"' : '' ) +
+				( editor.applicationTitle ? ' aria-labelledby="cke_{name}_arialbl"' : '' ) +
 				'>' +
-				( editor.title ? '<span id="cke_{name}_arialbl" class="cke_voice_label">{voiceLabel}</span>' : '' ) +
+				( editor.applicationTitle ? '<span id="cke_{name}_arialbl" class="cke_voice_label">{voiceLabel}</span>' : '' ) +
 				'<{outerEl} class="cke_inner cke_reset" role="presentation">' +
 					'{topHtml}' +
 					'<{outerEl} id="{contentId}" class="cke_contents cke_reset" role="presentation"></{outerEl}>' +
@@ -495,7 +495,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 			name: name,
 			langDir: editor.lang.dir,
 			langCode: editor.langCode,
-			voiceLabel: editor.title,
+			voiceLabel: editor.applicationTitle,
 			topHtml: topHtml ? '<span id="' + editor.ui.spaceId( 'top' ) + '" class="cke_top cke_reset_all" role="presentation" style="height:auto">' + topHtml + '</span>' : '',
 			contentId: editor.ui.spaceId( 'contents' ),
 			bottomHtml: bottomHtml ? '<span id="' + editor.ui.spaceId( 'bottom' ) + '" class="cke_bottom cke_reset_all" role="presentation">' + bottomHtml + '</span>' : '',

--- a/core/editable.js
+++ b/core/editable.js
@@ -533,6 +533,9 @@
 			 */
 			setReadOnly: function( isReadOnly ) {
 				this.setAttribute( 'contenteditable', !isReadOnly );
+
+				// Update also aria-readonly attribute (#1904).
+				this.setAttribute( 'aria-readonly', String( isReadOnly ) );
 			},
 
 			/**

--- a/core/editable.js
+++ b/core/editable.js
@@ -1400,7 +1400,10 @@
 
 				editable.changeAttr( 'role', 'textbox' );
 				editable.changeAttr( 'aria-multiline', 'true' ); // (#1034)
-				editable.changeAttr( 'aria-label', ariaLabel );
+
+				if ( ariaLabel ) {
+					editable.changeAttr( 'aria-label', ariaLabel );
+				}
 
 				if ( ariaLabel )
 					editable.changeAttr( 'title', ariaLabel );

--- a/core/editable.js
+++ b/core/editable.js
@@ -532,7 +532,7 @@
 			 * @param {Boolean} isReadOnly
 			 */
 			setReadOnly: function( isReadOnly ) {
-				this.setAttribute( 'contenteditable', !isReadOnly );
+				this.setAttribute( 'contenteditable', String( !isReadOnly ) );
 
 				// Update also aria-readonly attribute (#1904).
 				this.setAttribute( 'aria-readonly', String( isReadOnly ) );

--- a/core/editor.js
+++ b/core/editor.js
@@ -1895,8 +1895,8 @@ CKEDITOR.ELEMENT_MODE_INLINE = 3;
 
 /**
  * Customizes the {@link CKEDITOR.editor#applicationTtle human-readable title} of the application for this
- * editor. This title is used as a label for the whole website's region containing editor with its toolbars and other
- * UI parts. This title impacts various
+ * editor. This title is used as a label for the whole website's region containing the editor with its toolbars and other
+ * UI parts. Application title impacts various
  * [accessibility aspects](#!/guide/dev_a11y-section-announcing-the-editor-on-the-page),
  * e.g. it is commonly used by screen readers for distinguishing editor instances and for navigation.
  * Accepted values are a string or `false`.

--- a/core/editor.js
+++ b/core/editor.js
@@ -424,7 +424,8 @@
 
 	function loadLang( editor ) {
 		CKEDITOR.lang.load( editor.config.language, editor.config.defaultLanguage, function( languageCode, lang ) {
-			var configTitle = editor.config.title;
+			var configTitle = editor.config.title,
+				configApplicationTitle = editor.config.applicationTitle;
 
 			/**
 			 * The code for the language resources that have been loaded
@@ -462,6 +463,21 @@
 			 * @property {String/Boolean}
 			 */
 			editor.title = typeof configTitle == 'string' || configTitle === false ? configTitle : [ editor.lang.editor, editor.name ].join( ', ' );
+
+			/**
+			 * Indicates the human-readable title of this editor's application (the website's region
+			 * that contains the editor and its whole UI). Although this is a read-only property,
+			 * it can be initialized with {@link CKEDITOR.config#applicationTitle}.
+			 *
+			 * **Note:** Please do not confuse this property with {@link CKEDITOR.editor#name editor.name}
+			 * which identifies the instance in the {@link CKEDITOR#instances} literal.
+			 *
+			 * @since 4.19.0
+			 * @readonly
+			 * @property {String/Boolean}
+			 */
+			editor.applicationTitle = typeof configApplicationTitle == 'string' || configApplicationTitle === false ?
+				configApplicationTitle : [ editor.lang.application, editor.name ].join( ', ' );
 
 			if ( !editor.config.contentsLangDirection ) {
 				// Fallback to either the editable element direction or editor UI direction depending on creators.
@@ -1867,12 +1883,50 @@ CKEDITOR.ELEMENT_MODE_INLINE = 3;
  *		config.title = false;
  *
  * See also:
- *
- * * CKEDITOR.editor#name
  * * CKEDITOR.editor#title
+ * * CKEDITOR.editor#name
+ * * CKEDITOR.editor#applicationTitle
+ * * CKEDITOR.config#applicationTitle
  *
  * @since 4.2.0
  * @cfg {String/Boolean} [title=based on editor.name]
+ * @member CKEDITOR.config
+ */
+
+/**
+ * Customizes the {@link CKEDITOR.editor#applicationTtle human-readable title} of the application for this
+ * editor. This title is used as a label for the whole website's region containing editor with its toolbars and other
+ * UI parts. This title impacts various
+ * [accessibility aspects](#!/guide/dev_a11y-section-announcing-the-editor-on-the-page),
+ * e.g. it is commonly used by screen readers for distinguishing editor instances and for navigation.
+ * Accepted values are a string or `false`.
+ *
+ * **Note:** When `config.applicationTitle` is set globally, the same value will be applied to all editor instances
+ * loaded with this config. This may adversely affect accessibility as screen reader users will be unable
+ * to distinguish particular editor instances and navigate between them.
+ *
+ * **Note:** Setting `config.title = false` may also impair accessibility in a similar way.
+ *
+ * **Note:** Please do not confuse this property with {@link CKEDITOR.editor#name}
+ * which identifies the instance in the {@link CKEDITOR#instances} literal.
+ *
+ *		// Sets the application title to 'My WYSIWYG'. The original title of the element (if it exists)
+ *		// will be restored once the editor instance is destroyed.
+ *		config.title = 'My WYSIWYG';
+ *
+ *		// Do not touch the title. If the element already has a title, it remains unchanged.
+ *		// Also if no `title` attribute exists, nothing new will be added.
+ *		config.title = false;
+ *
+ * See also:
+ *
+ * * CKEDITOR.editor#applicationTitle
+ * * CKEDITOR.editor#name
+ * * CKEDITOR.editor#title
+ * * CKEDITOR.config#title
+ *
+ * @since 4.19.0
+ * @cfg {String/Boolean} [applicationTitle=based on editor.name]
  * @member CKEDITOR.config
  */
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -1905,18 +1905,16 @@ CKEDITOR.ELEMENT_MODE_INLINE = 3;
  * loaded with this config. This may adversely affect accessibility as screen reader users will be unable
  * to distinguish particular editor instances and navigate between them.
  *
- * **Note:** Setting `config.title = false` may also impair accessibility in a similar way.
+ * **Note:** Setting `config.applicationTitle = false` may also impair accessibility in a similar way.
  *
  * **Note:** Please do not confuse this property with {@link CKEDITOR.editor#name}
  * which identifies the instance in the {@link CKEDITOR#instances} literal.
  *
- *		// Sets the application title to 'My WYSIWYG'. The original title of the element (if it exists)
- *		// will be restored once the editor instance is destroyed.
- *		config.title = 'My WYSIWYG';
+ *		// Sets the application title to 'My WYSIWYG'.
+ *		config.applicationTitle = 'My WYSIWYG';
  *
- *		// Do not touch the title. If the element already has a title, it remains unchanged.
- *		// Also if no `title` attribute exists, nothing new will be added.
- *		config.title = false;
+ *		// Do not add the application title.
+ *		config.applicationTitle = false;
  *
  * See also:
  *

--- a/lang/af.js
+++ b/lang/af.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'af' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Woordverwerker',
 	editorPanel: 'Woordverwerkerpaneel',
 

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ar' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'محرر النص الغني',
 	editorPanel: 'لائحة محرر النص المنسق',
 

--- a/lang/az.js
+++ b/lang/az.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'az' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Mətn Redaktoru',
 	editorPanel: 'Mətn Redaktorun Paneli',
 

--- a/lang/bg.js
+++ b/lang/bg.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'bg' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Редактор за форматиран текст',
 	editorPanel: 'Панел на текстовия редактор',
 

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'bn' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/bs.js
+++ b/lang/bs.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'bs' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ca' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de text enriquit',
 	editorPanel: 'Panell de l\'editor de text enriquit',
 

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'cs' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Textový editor',
 	editorPanel: 'Panel textového editoru',
 

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'cy' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Golygydd Testun Cyfoethog',
 	editorPanel: 'Panel Golygydd Testun Cyfoethog',
 

--- a/lang/da.js
+++ b/lang/da.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'da' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text Editor',
 	editorPanel: 'Rich Text Editor panel',
 

--- a/lang/de-ch.js
+++ b/lang/de-ch.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'de-ch' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'WYSIWYG-Editor',
 	editorPanel: 'WYSIWYG-Editor-Leiste',
 

--- a/lang/de.js
+++ b/lang/de.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'de' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'WYSIWYG-Editor',
 	editorPanel: 'WYSIWYG-Editor-Leiste',
 

--- a/lang/el.js
+++ b/lang/el.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'el' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Επεξεργαστής Πλούσιου Κειμένου',
 	editorPanel: 'Πίνακας Επεξεργαστή Πλούσιου Κειμένου',
 

--- a/lang/en-au.js
+++ b/lang/en-au.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'en-au' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text Editor',
 	editorPanel: 'Rich Text Editor panel',
 

--- a/lang/en-ca.js
+++ b/lang/en-ca.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'en-ca' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'en-gb' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text Editor',
 	editorPanel: 'Rich Text Editor panel',
 

--- a/lang/en.js
+++ b/lang/en.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'en' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor',
+	application: 'Rich Text Editor',
+	editor: 'Editor',
 	editorPanel: 'Rich Text Editor panel',
 
 	// Common messages and labels.

--- a/lang/eo.js
+++ b/lang/eo.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'eo' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'RiĉTeksta Redaktilo',
 	editorPanel: 'Panelo de la RiĉTeksta Redaktilo',
 

--- a/lang/es-mx.js
+++ b/lang/es-mx.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'es-mx' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de texto enriquecido',
 	editorPanel: 'Panel del editor de texto',
 

--- a/lang/es.js
+++ b/lang/es.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'es' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de Texto Enriquecido',
 	editorPanel: 'Panel del Editor de Texto Enriquecido',
 

--- a/lang/et.js
+++ b/lang/et.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'et' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rikkalik tekstiredaktor',
 	editorPanel: 'Rikkaliku tekstiredaktori paneel',
 

--- a/lang/eu.js
+++ b/lang/eu.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'eu' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Testu aberastuaren editorea',
 	editorPanel: 'Testu aberastuaren editorearen panela',
 

--- a/lang/fa.js
+++ b/lang/fa.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'fa' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'ویرایش‌گر متن غنی',
 	editorPanel: 'پنل ویرایشگر متن غنی',
 

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'fi' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rikastekstieditori',
 	editorPanel: 'Rikastekstieditoripaneeli',
 

--- a/lang/fo.js
+++ b/lang/fo.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'fo' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text Editor',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/fr-ca.js
+++ b/lang/fr-ca.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'fr-ca' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Éditeur de texte enrichi',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'fr' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Éditeur de texte enrichi',
 	editorPanel: 'Tableau de bord de l\'éditeur de texte enrichi',
 

--- a/lang/gl.js
+++ b/lang/gl.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'gl' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de texto mellorado',
 	editorPanel: 'Panel do editor de texto mellorado',
 

--- a/lang/gu.js
+++ b/lang/gu.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'gu' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'રીચ ટેક્ષ્ત્ એડીટર',
 	editorPanel: 'વધુ વિકલ્પ વાળુ એડિટર',
 

--- a/lang/he.js
+++ b/lang/he.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'he' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'עורך טקסט עשיר',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'hi' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'रिच टेक्स्ट एडिटर',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/hr.js
+++ b/lang/hr.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'hr' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Bogati uređivač teksta, %1',
 	editorPanel: 'Ploča Bogatog Uređivača Teksta',
 

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'hu' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'HTML szerkesztő',
 	editorPanel: 'HTML szerkesztő panel',
 

--- a/lang/id.js
+++ b/lang/id.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'id' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text Editor',
 	editorPanel: 'Panel Rich Text Editor',
 

--- a/lang/is.js
+++ b/lang/is.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'is' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/it.js
+++ b/lang/it.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'it' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text Editor',
 	editorPanel: 'Pannello Rich Text Editor',
 

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ja' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'リッチテキストエディタ',
 	editorPanel: 'リッチテキストエディタパネル',
 

--- a/lang/ka.js
+++ b/lang/ka.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ka' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'ტექსტის რედაქტორი',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/km.js
+++ b/lang/km.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'km' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'ឧបករណ៍​សរសេរ​អត្ថបទ​សម្បូរ​បែប',
 	editorPanel: 'ផ្ទាំង​ឧបករណ៍​សរសេរ​អត្ថបទ​សម្បូរ​បែប',
 

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ko' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: '리치 텍스트 편집기',
 	editorPanel: '리치 텍스트 편집기 패널',
 

--- a/lang/ku.js
+++ b/lang/ku.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'ku' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'سەرنووسەی دەقی تەواو',
 	editorPanel: 'بڕگەی سەرنووسەی دەقی تەواو',
 

--- a/lang/lt.js
+++ b/lang/lt.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'lt' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Pilnas redaktorius',
 	editorPanel: 'Pilno redagtoriaus skydelis',
 

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'lv' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Bagātinātā teksta redaktors',
 	editorPanel: 'Bagātinātā teksta redaktora panelis',
 

--- a/lang/mk.js
+++ b/lang/mk.js
@@ -18,7 +18,8 @@
  */
 CKEDITOR.lang[ 'mk' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/mn.js
+++ b/lang/mn.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'mn' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Хэлбэрт бичвэр боловсруулагч',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/ms.js
+++ b/lang/ms.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'ms' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/nb.js
+++ b/lang/nb.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'nb' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rikteksteditor',
 	editorPanel: 'Panel for rikteksteditor',
 

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'nl' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Tekstverwerker',
 	editorPanel: 'Tekstverwerker beheerpaneel',
 

--- a/lang/no.js
+++ b/lang/no.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'no' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rikteksteditor',
 	editorPanel: 'Panel for rikteksteditor',
 

--- a/lang/oc.js
+++ b/lang/oc.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'oc' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de tèxte enriquit',
 	editorPanel: 'Tablèu de bòrd de l\'editor de tèxte enriquit',
 

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'pl' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Edytor tekstu sformatowanego',
 	editorPanel: 'Panel edytora tekstu sformatowanego',
 

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'pt-br' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de Rich Text',
 	editorPanel: 'Painel do editor de Rich Text',
 

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'pt' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de texto enriquecido',
 	editorPanel: 'Painel do editor de texto enriquecido',
 

--- a/lang/ro.js
+++ b/lang/ro.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ro' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor de text îmbogățit',
 	editorPanel: 'Panoul editorului de text îmbogățit',
 

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'ru' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Визуальный текстовый редактор',
 	editorPanel: 'Визуальный редактор текста',
 

--- a/lang/si.js
+++ b/lang/si.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'si' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'පොහොසත් වචන සංස්කරණ',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'sk' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Editor formátovaného textu',
 	editorPanel: 'Panel editora formátovaného textu',
 

--- a/lang/sl.js
+++ b/lang/sl.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'sl' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Urejevalnik obogatenega besedila',
 	editorPanel: 'Plošča urejevalnika obogatenega besedila',
 

--- a/lang/sq.js
+++ b/lang/sq.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'sq' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Redaktues i Pasur Teksti',
 	editorPanel: 'Paneli i redaktuesit të tekstit të plotë',
 

--- a/lang/sr-latn.js
+++ b/lang/sr-latn.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'sr-latn' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Bogati uređivač teksta',
 	editorPanel: 'Bogati uređivač panel',
 

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'sr' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'ХТМЛ уређивач текста',
 	editorPanel: 'ХТМЛ уређивач панел',
 

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'sv' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Rich Text-editor',
 	editorPanel: 'Panel till Rich Text-editor',
 

--- a/lang/th.js
+++ b/lang/th.js
@@ -19,7 +19,8 @@
  */
 CKEDITOR.lang[ 'th' ] = {
 	// ARIA description.
-	editor: 'Rich Text Editor', // MISSING
+	application: 'Rich Text Editor', // MISSING
+	editor: 'Editor', // MISSING
 	editorPanel: 'Rich Text Editor panel', // MISSING
 
 	// Common messages and labels.

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'tr' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Zengin Metin Editörü',
 	editorPanel: 'Zengin Metin Editör Paneli',
 

--- a/lang/tt.js
+++ b/lang/tt.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'tt' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Форматлаулы текст өлкәсе',
 	editorPanel: 'Rich Text Editor panel', // MISSING
 

--- a/lang/ug.js
+++ b/lang/ug.js
@@ -18,6 +18,7 @@
  */
 CKEDITOR.lang[ 'ug' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'تەھرىرلىگۈچ',
 	editorPanel: 'مول تېكست تەھرىرلىگۈچ تاختىسى',
 

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'uk' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Текстовий редактор',
 	editorPanel: 'Панель розширеного текстового редактора',
 

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'vi' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'Bộ soạn thảo văn bản có định dạng',
 	editorPanel: 'Bảng điều khiển Rich Text Editor',
 

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'zh-cn' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: '所见即所得编辑器',
 	editorPanel: '所见即所得编辑器面板',
 

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -19,6 +19,7 @@
  */
 CKEDITOR.lang[ 'zh' ] = {
 	// ARIA description.
+	application: 'Rich Text Editor', // MISSING
 	editor: 'RTF 編輯器',
 	editorPanel: 'RTF 編輯器面板',
 

--- a/plugins/floatingspace/plugin.js
+++ b/plugins/floatingspace/plugin.js
@@ -275,9 +275,9 @@
 					' lang="{langCode}"' +
 					' role="application"' +
 					' style="{style}"' +
-					( editor.title ? ' aria-labelledby="cke_{name}_arialbl"' : ' ' ) +
+					( editor.applicationTitle ? ' aria-labelledby="cke_{name}_arialbl"' : ' ' ) +
 					'>' +
-					( editor.title ? '<span id="cke_{name}_arialbl" class="cke_voice_label">{voiceLabel}</span>' : ' ' ) +
+					( editor.applicationTitle ? '<span id="cke_{name}_arialbl" class="cke_voice_label">{voiceLabel}</span>' : ' ' ) +
 					'<div class="cke_inner">' +
 						'<div id="{topId}" class="cke_top" role="presentation">{content}</div>' +
 					'</div>' +
@@ -290,7 +290,7 @@
 					name: editor.name,
 					style: 'display:none;z-index:' + ( config.baseFloatZIndex - 1 ),
 					topId: editor.ui.spaceId( 'top' ),
-					voiceLabel: editor.title
+					voiceLabel: editor.applicationTitle
 				} ) ) ),
 
 				// Use event buffers to reduce CPU load when tons of events are fired.

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -609,11 +609,12 @@
 
 					// Remove ARIA attributes during getting data for full-page editing (#1904, #4052).
 					if ( fullPage ) {
-						data = data.
-							replace( /<body(.*?)role="textbox"/, '<body$1' ).
-							replace( /<body(.*?)aria-multiline="true"/, '<body$1' ).
-							replace( /<body(.*?)tabindex="0"/, '<body$1' ).
-							replace( /<body(.*?)aria-readonly="(?:true|false)"/, '<body$1' );
+						data = data
+							.replace( /<body(.*?)role="textbox"/, '<body$1' )
+							.replace( /<body(.*?)aria-multiline="true"/, '<body$1' )
+							.replace( /<body(.*?)tabindex="0"/, '<body$1' )
+							.replace( /<body(.*?)aria-label="(.+?)"/, '<body$1' )
+							.replace( /<body(.*?)aria-readonly="(?:true|false)"/, '<body$1' );
 					}
 
 					data = editor.dataProcessor.toDataFormat( data );

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -521,6 +521,9 @@
 							data = data.replace( /<body[^>]*>/, '$&<!-- cke-content-start -->'  );
 					}
 
+					// Add ARIA attributes (#4052).
+					data = data.replace( /<body/, '<body role="textbox" aria-multiline="true" ' );
+
 					// The script that launches the bootstrap logic on 'domReady', so the document
 					// is fully editable even before the editing iframe is fully loaded (https://dev.ckeditor.com/ticket/4455).
 					var bootstrapCode =

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -522,7 +522,11 @@
 					}
 
 					// Add ARIA attributes (#4052).
-					data = data.replace( /<body/, '<body role="textbox" aria-multiline="true" ' );
+					data = data.replace( /<body/, '<body role="textbox" aria-multiline="true"' );
+
+					if ( editor.title ) {
+						data = data.replace( /<body/, '<body aria-label="' + editor.title + '"' );
+					}
 
 					// Add [tabindex=0] for the editor (#1904).
 					// Can't do it in Firefox due to https://bugzilla.mozilla.org/show_bug.cgi?id=1483828.

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -525,7 +525,8 @@
 					data = data.replace( /<body/, '<body role="textbox" aria-multiline="true"' );
 
 					if ( editor.title ) {
-						data = data.replace( /<body/, '<body aria-label="' + editor.title + '"' );
+						data = data.replace( /<body/, '<body aria-label="' +
+							CKEDITOR.tools.htmlEncodeAttr( editor.title ) + '"' );
 					}
 
 					// Add [tabindex=0] for the editor (#1904).

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -597,6 +597,11 @@
 					if ( CKEDITOR.env.gecko && config.enterMode != CKEDITOR.ENTER_BR )
 						data = data.replace( /<br>(?=\s*(:?$|<\/body>))/, '' );
 
+					// Remove ARIA attributes during getting data for full-page editing (#4052).
+					if ( fullPage ) {
+						data = data.replace( '<body role="textbox" aria-multiline="true"', '<body ' );
+					}
+
 					data = editor.dataProcessor.toDataFormat( data );
 
 					if ( xmlDeclaration )

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -603,9 +603,13 @@
 					if ( CKEDITOR.env.gecko && config.enterMode != CKEDITOR.ENTER_BR )
 						data = data.replace( /<br>(?=\s*(:?$|<\/body>))/, '' );
 
-					// Remove ARIA attributes during getting data for full-page editing (#4052).
+					// Remove ARIA attributes during getting data for full-page editing (#1904, #4052).
 					if ( fullPage ) {
-						data = data.replace( '<body role="textbox" aria-multiline="true"', '<body ' );
+						data = data.
+							replace( /<body(.*?)role="textbox"/, '<body$1' ).
+							replace( /<body(.*?)aria-multiline="true"/, '<body$1' ).
+							replace( /<body(.*?)tabindex="0"/, '<body$1' ).
+							replace( /<body(.*?)aria-readonly="(?:true|false)"/, '<body$1' );
 					}
 
 					data = editor.dataProcessor.toDataFormat( data );

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -524,6 +524,12 @@
 					// Add ARIA attributes (#4052).
 					data = data.replace( /<body/, '<body role="textbox" aria-multiline="true" ' );
 
+					// Add [tabindex=0] for the editor (#1904).
+					// Can't do it in Firefox due to https://bugzilla.mozilla.org/show_bug.cgi?id=1483828.
+					if ( !CKEDITOR.env.gecko ) {
+						data = data.replace( '<body', '<body tabindex="0" ' );
+					}
+
 					// The script that launches the bootstrap logic on 'domReady', so the document
 					// is fully editable even before the editing iframe is fully loaded (https://dev.ckeditor.com/ticket/4455).
 					var bootstrapCode =

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -416,7 +416,7 @@
 				CKEDITOR.tools.setTimeout( onDomReady, 0, this, win );
 			}, this );
 
-			this._.docTitle = this.getWindow().getFrame().getAttribute( 'title' );
+			this._.docTitle = this.getWindow().getFrame().getAttribute( 'title' ) || '&nbsp;';
 		},
 
 		base: CKEDITOR.editable,

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -3,6 +3,8 @@
 ( function() {
 	'use strict';
 
+	var labelWithSpecialCharacters = '"><!';
+
 	bender.test( {
 		'test labels (inline)': function() {
 			bender.editorBot.create( {
@@ -68,6 +70,64 @@
 				assert.areSame( expectedApplicationLabel, actualApplicationLabel, 'Application label is incorrect' );
 				assert.areSame( expectedEditorLabel, actualEditorLabel, 'Editor label is incorrect' );
 				assert.areSame( expectedEditorLabel, actualBodyLabel, 'Editor\'s body label is incorrect' );
+			} );
+		},
+
+		'test label with special characters (inline)': function() {
+			bender.editorBot.create( {
+				creator: 'inline',
+				name: 'inline-special',
+				config: {
+					title: labelWithSpecialCharacters,
+					// They are needed for the floating toolbar to appear.
+					plugins: 'floatingspace,toolbar',
+					language: 'en'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					actualEditorLabel = container.getAttribute( 'aria-label' );
+
+				assert.areSame( labelWithSpecialCharacters, actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		},
+
+		'test label with special characters (divarea)': function() {
+			bender.editorBot.create( {
+				creator: 'replace',
+				name: 'divarea-special',
+				config: {
+					title: labelWithSpecialCharacters,
+					plugins: 'divarea',
+					language: 'en'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					actualEditorLabel = container.findOne( '.cke_editable' ).getAttribute( 'aria-label' );
+
+				assert.areSame( labelWithSpecialCharacters, actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		},
+
+		'test label with special characters (wysiwygarea)': function() {
+			bender.editorBot.create( {
+				creator: 'replace',
+				name: 'wysiwygarea-special',
+				config: {
+					title: labelWithSpecialCharacters,
+					plugins: 'wysiwygarea',
+					language: 'en'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					frame = container.findOne( 'iframe' ),
+					actualEditorLabel = frame.getAttribute( 'title' ),
+					actualBodyLabel = frame.getFrameDocument().findOne( 'body' ).getAttribute( 'aria-label' );
+
+				assert.areSame( labelWithSpecialCharacters, actualEditorLabel, 'Editor label is incorrect' );
+				assert.areSame( labelWithSpecialCharacters, actualBodyLabel, 'Editor\'s body label is incorrect' );
 			} );
 		}
 	} );

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -58,13 +58,16 @@
 			}, function( bot ) {
 				var editor = bot.editor,
 					container = editor.container,
+					frame = container.findOne( 'iframe' ),
 					expectedApplicationLabel = createApplicationLabel( editor ),
 					actualApplicationLabel = container.findOne( '#cke_wysiwygarea_arialbl' ).getHtml(),
 					expectedEditorLabel = createEditorLabel( editor ),
-					actualEditorLabel = container.findOne( 'iframe' ).getAttribute( 'title' );
+					actualEditorLabel = frame.getAttribute( 'title' ),
+					actualBodyLabel = frame.getFrameDocument().findOne( 'body' ).getAttribute( 'aria-label' );
 
 				assert.areSame( expectedApplicationLabel, actualApplicationLabel, 'Application label is incorrect' );
 				assert.areSame( expectedEditorLabel, actualEditorLabel, 'Editor label is incorrect' );
+				assert.areSame( expectedEditorLabel, actualBodyLabel, 'Editor\'s body label is incorrect' );
 			} );
 		}
 	} );

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -1,0 +1,85 @@
+/* bender-tags: editor */
+
+( function() {
+	'use strict';
+
+	bender.test( {
+		'test labels (inline)': function() {
+			bender.editorBot.create( {
+				creator: 'inline',
+				name: 'inline',
+				config: {
+					// They are needed for the floating toolbar to appear.
+					plugins: 'floatingspace,toolbar',
+					language: 'en'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					expectedApplicationLabel = createApplicationLabel( editor ),
+					actualApplicationLabel = CKEDITOR.document.findOne( '#cke_inline_arialbl' ).getHtml(),
+					expectedEditorLabel = createEditorLabel( editor ),
+					actualEditorLabel = container.getAttribute( 'aria-label' );
+
+				assert.areSame( expectedApplicationLabel, actualApplicationLabel, 'Application label is incorrect' );
+				assert.areSame( expectedEditorLabel, actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		},
+
+		'test labels (divarea)': function() {
+			bender.editorBot.create( {
+				creator: 'replace',
+				name: 'divarea',
+				config: {
+					plugins: 'divarea',
+					language: 'en'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					expectedApplicationLabel = createApplicationLabel( editor ),
+					actualApplicationLabel = container.findOne( '#cke_divarea_arialbl' ).getHtml(),
+					expectedEditorLabel = createEditorLabel( editor ),
+					actualEditorLabel = container.findOne( '.cke_editable' ).getAttribute( 'aria-label' );
+
+				assert.areSame( expectedApplicationLabel, actualApplicationLabel, 'Application label is incorrect' );
+				assert.areSame( expectedEditorLabel, actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		},
+
+		'test labels (wysiwygarea)': function() {
+			bender.editorBot.create( {
+				creator: 'replace',
+				name: 'wysiwygarea',
+				config: {
+					plugins: 'wysiwygarea',
+					language: 'en'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					expectedApplicationLabel = createApplicationLabel( editor ),
+					actualApplicationLabel = container.findOne( '#cke_wysiwygarea_arialbl' ).getHtml(),
+					expectedEditorLabel = createEditorLabel( editor ),
+					actualEditorLabel = container.findOne( 'iframe' ).getAttribute( 'title' );
+
+				assert.areSame( expectedApplicationLabel, actualApplicationLabel, 'Application label is incorrect' );
+				assert.areSame( expectedEditorLabel, actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		}
+	} );
+
+	function createApplicationLabel( editor ) {
+		var lang = CKEDITOR.lang.en,
+			applicationLabel = lang.application;
+
+		return applicationLabel + ', ' + editor.name;
+	}
+
+	function createEditorLabel( editor ) {
+		var lang = CKEDITOR.lang.en,
+			editorLabel = lang.editor;
+
+		return editorLabel + ', ' + editor.name;
+	}
+} )();

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -129,6 +129,74 @@
 				assert.areSame( labelWithSpecialCharacters, actualEditorLabel, 'Editor label is incorrect' );
 				assert.areSame( labelWithSpecialCharacters, actualBodyLabel, 'Editor\'s body label is incorrect' );
 			} );
+		},
+
+		'test labels disabled (inline)': function() {
+			bender.editorBot.create( {
+				creator: 'inline',
+				name: 'inline-disabled',
+				config: {
+					// They are needed for the floating toolbar to appear.
+					plugins: 'floatingspace,toolbar',
+					language: 'en',
+					title: false,
+					applicationTitle: false
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					actualApplicationLabel = CKEDITOR.document.findOne( '#cke_inline-disabled' ).
+						getAttribute( 'aria-labelledby' ),
+					actualEditorLabel = container.getAttribute( 'aria-label' );
+
+				assert.isNull( actualApplicationLabel, 'Application label is incorrect' );
+				assert.isNull( actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		},
+
+		'test labels disabled (divarea)': function() {
+			bender.editorBot.create( {
+				creator: 'replace',
+				name: 'divarea-disabled',
+				config: {
+					plugins: 'divarea',
+					language: 'en',
+					title: false,
+					applicationTitle: false
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					actualApplicationLabel = container.getAttribute( 'aria-labelledby' ),
+					actualEditorLabel = container.findOne( '.cke_editable' ).getAttribute( 'aria-label' );
+
+				assert.isNull( actualApplicationLabel, 'Application label is incorrect' );
+				assert.isNull( actualEditorLabel, 'Editor label is incorrect' );
+			} );
+		},
+
+		'test labels disabled (wysiwygarea)': function() {
+			bender.editorBot.create( {
+				creator: 'replace',
+				name: 'wysiwygarea-disabled',
+				config: {
+					plugins: 'wysiwygarea',
+					language: 'en',
+					title: false,
+					applicationTitle: false
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					container = editor.container,
+					frame = container.findOne( 'iframe' ),
+					actualApplicationLabel = container.getAttribute( 'aria-labelledby' ),
+					actualEditorLabel = frame.getAttribute( 'title' ),
+					actualBodyLabel = frame.getFrameDocument().findOne( 'body' ).getAttribute( 'aria-label' );
+
+				assert.isNull( actualApplicationLabel, 'Application label is incorrect' );
+				assert.isNull( actualEditorLabel, 'Editor label is incorrect' );
+				assert.isNull( actualBodyLabel, 'Editor\'s body label is incorrect' );
+			} );
 		}
 	} );
 

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -61,15 +61,18 @@
 				var editor = bot.editor,
 					container = editor.container,
 					frame = container.findOne( 'iframe' ),
+					frameDocument = frame.getFrameDocument(),
 					expectedApplicationLabel = createApplicationLabel( editor ),
 					actualApplicationLabel = container.findOne( '#cke_wysiwygarea_arialbl' ).getHtml(),
 					expectedEditorLabel = createEditorLabel( editor ),
 					actualEditorLabel = frame.getAttribute( 'title' ),
-					actualBodyLabel = frame.getFrameDocument().findOne( 'body' ).getAttribute( 'aria-label' );
+					actualBodyLabel = frameDocument.findOne( 'body' ).getAttribute( 'aria-label' ),
+					actualTitleLabel = frameDocument.findOne( 'title' ).getHtml();
 
 				assert.areSame( expectedApplicationLabel, actualApplicationLabel, 'Application label is incorrect' );
 				assert.areSame( expectedEditorLabel, actualEditorLabel, 'Editor label is incorrect' );
 				assert.areSame( expectedEditorLabel, actualBodyLabel, 'Editor\'s body label is incorrect' );
+				assert.areSame( expectedEditorLabel, actualTitleLabel, 'Editor\'s title label is incorrect' );
 			} );
 		},
 
@@ -189,13 +192,16 @@
 				var editor = bot.editor,
 					container = editor.container,
 					frame = container.findOne( 'iframe' ),
+					frameDocument = frame.getFrameDocument(),
 					actualApplicationLabel = container.getAttribute( 'aria-labelledby' ),
 					actualEditorLabel = frame.getAttribute( 'title' ),
-					actualBodyLabel = frame.getFrameDocument().findOne( 'body' ).getAttribute( 'aria-label' );
+					actualBodyLabel = frameDocument.findOne( 'body' ).getAttribute( 'aria-label' ),
+					actualTitleLabel = frameDocument.findOne( 'title' ).getHtml();
 
 				assert.isNull( actualApplicationLabel, 'Application label is incorrect' );
 				assert.isNull( actualEditorLabel, 'Editor label is incorrect' );
 				assert.isNull( actualBodyLabel, 'Editor\'s body label is incorrect' );
+				assert.areSame( '&nbsp;', actualTitleLabel, 'Editor\'s title label is incorrect' );
 			} );
 		}
 	} );

--- a/tests/core/creators/manual/inlinecustomlabels.html
+++ b/tests/core/creators/manual/inlinecustomlabels.html
@@ -1,0 +1,11 @@
+<div id="foo" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.inline( 'foo', {
+		language: 'en',
+		title: 'Horse',
+		applicationTitle: 'Mouse'
+	} );
+</script>

--- a/tests/core/creators/manual/inlinecustomlabels.md
+++ b/tests/core/creators/manual/inlinecustomlabels.md
@@ -1,0 +1,16 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced ("Horse").
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+1. Press <kbd>Alt</kbd>+<kbd>F10</kbd> to focus the toolbar.
+
+	**Expected** The toolbar is correctly announced (first button info followed by "Mouse").
+
+	**Unexpected** The info about the editor is not included in the announcement.

--- a/tests/core/creators/manual/inlinedisabledapplicationlabels.html
+++ b/tests/core/creators/manual/inlinedisabledapplicationlabels.html
@@ -1,0 +1,10 @@
+<div id="foo" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.inline( 'foo', {
+		language: 'en',
+		applicationTitle: false
+	} );
+</script>

--- a/tests/core/creators/manual/inlinedisabledapplicationlabels.md
+++ b/tests/core/creators/manual/inlinedisabledapplicationlabels.md
@@ -1,0 +1,16 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced ("Editor foo").
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+1. Press <kbd>Alt</kbd>+<kbd>F10</kbd> to focus the toolbar.
+
+	**Expected** The toolbar and the first button are announced.
+
+	**Unexpected** The info about the editor is included in the announcement ("Rich Text Editor foo").

--- a/tests/core/creators/manual/inlinedisablededitorlabels.html
+++ b/tests/core/creators/manual/inlinedisablededitorlabels.html
@@ -1,0 +1,10 @@
+<div id="foo" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.inline( 'foo', {
+		language: 'en',
+		title: false
+	} );
+</script>

--- a/tests/core/creators/manual/inlinedisablededitorlabels.md
+++ b/tests/core/creators/manual/inlinedisablededitorlabels.md
@@ -1,0 +1,16 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is announced as the generic text input.
+
+	**Unexpected** The editor's name is announced ("Editor foo").
+1. Press <kbd>Alt</kbd>+<kbd>F10</kbd> to focus the toolbar.
+
+	**Expected** The toolbar is correctly announced (first button info followed by "Rich Text Editor foo").
+
+	**Unexpected** The info about the editor is not included in the announcement.

--- a/tests/core/creators/manual/inlinelabels.html
+++ b/tests/core/creators/manual/inlinelabels.html
@@ -1,0 +1,9 @@
+<div id="hublabubla" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.inline( 'hublabubla', {
+		language: 'en'
+	} );
+</script>

--- a/tests/core/creators/manual/inlinelabels.html
+++ b/tests/core/creators/manual/inlinelabels.html
@@ -1,9 +1,9 @@
-<div id="hublabubla" contenteditable="true">
+<div id="foo" contenteditable="true">
 	<p>Lorem ipsum dolor sit amet</p>
 </div>
 
 <script>
-	CKEDITOR.inline( 'hublabubla', {
+	CKEDITOR.inline( 'foo', {
 		language: 'en'
 	} );
 </script>

--- a/tests/core/creators/manual/inlinelabels.md
+++ b/tests/core/creators/manual/inlinelabels.md
@@ -1,0 +1,16 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced ("Editor hublabubla").
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+1. Press <kbd>Alt</kbd>+<kbd>F10</kbd> to focus the toolbar.
+
+	**Expected** The toolbar is correctly announced (first button info followed by "Rich Text Editor hublabubla").
+
+	**Unexpected** The info about the editor is not included in the announcement.

--- a/tests/core/creators/manual/inlinelabels.md
+++ b/tests/core/creators/manual/inlinelabels.md
@@ -6,11 +6,11 @@
 
 1. Focus the editor.
 
-	**Expected** The editor is correctly announced ("Editor hublabubla").
+	**Expected** The editor is correctly announced ("Editor foo").
 
 	**Unexpected** The editor is incorrectly announced or not announced at all.
 1. Press <kbd>Alt</kbd>+<kbd>F10</kbd> to focus the toolbar.
 
-	**Expected** The toolbar is correctly announced (first button info followed by "Rich Text Editor hublabubla").
+	**Expected** The toolbar is correctly announced (first button info followed by "Rich Text Editor foo").
 
 	**Unexpected** The info about the editor is not included in the announcement.

--- a/tests/core/creators/manual/themeduicustomlabels.html
+++ b/tests/core/creators/manual/themeduicustomlabels.html
@@ -1,0 +1,23 @@
+<h2><code>Iframe</code>-based</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<h2><code>Div</code>-based</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'wysiwygarea', {
+		language: 'en',
+		title: 'Horse',
+		applicationTitle: 'Mouse'
+	} );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		language: 'en',
+		title: 'Donkey',
+		applicationTitle: 'Snake'
+	} );
+</script>

--- a/tests/core/creators/manual/themeduicustomlabels.md
+++ b/tests/core/creators/manual/themeduicustomlabels.md
@@ -1,0 +1,23 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced.
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+
+Sample announcements for the `iframe`-based editor:
+
+* VoiceOver+Chrome: "Horse edit text, &lt;content and selection info&gt;. Horse, group"
+* NVDA+Firefox: "Mouse, Horse frame, Horse document editable"
+* JAWS+Firefox: "Mouse, Horse frame, Horse edit &lt;content&gt; type and text"
+
+Sample announcements for the `div`-based editor:
+
+* VoiceOver+Chrome: "Donkey edit text &lt;content&gt;. Snake, application."
+* NVDA+Firefox: "Snake, Donkey edit multi line"
+* JAWS+Firefox: "Snake, Donkey edit, contains text, type and text"

--- a/tests/core/creators/manual/themeduidisabledapplicationlabels.html
+++ b/tests/core/creators/manual/themeduidisabledapplicationlabels.html
@@ -1,0 +1,21 @@
+<h2><code>Iframe</code>-based</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<h2><code>Div</code>-based</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'wysiwygarea', {
+		language: 'en',
+		applicationTitle: false
+	} );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		language: 'en',
+		applicationTitle: false
+	} );
+</script>

--- a/tests/core/creators/manual/themeduidisabledapplicationlabels.md
+++ b/tests/core/creators/manual/themeduidisabledapplicationlabels.md
@@ -1,0 +1,23 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced.
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+
+Sample announcements for the `iframe`-based editor:
+
+* VoiceOver+Chrome: "Editor, wysiwygarea edit text, &lt;content and selection info&gt;. Editor, wysiwygarea, group"
+* NVDA+Firefox: "application, Editor, wysiwygarea frame, Editor, wysiwygarea document editable"
+* JAWS+Firefox: "Editor, wysiwygarea frame, editor, wysiwygarea edit &lt;content&gt; type and text"
+
+Sample announcements for the `div`-based editor:
+
+* VoiceOver+Chrome: "Editor, divarea edit text &lt;content&gt;. Application."
+* NVDA+Firefox: "application, Editor, divarea edit multi line"
+* JAWS+Firefox: "Editor, divarea edit, contains text, type and text"

--- a/tests/core/creators/manual/themeduidisablededitorlabels.html
+++ b/tests/core/creators/manual/themeduidisablededitorlabels.html
@@ -1,0 +1,21 @@
+<h2><code>Iframe</code>-based</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<h2><code>Div</code>-based</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'wysiwygarea', {
+		language: 'en',
+		title: false
+	} );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		language: 'en',
+		title: false
+	} );
+</script>

--- a/tests/core/creators/manual/themeduidisablededitorlabels.md
+++ b/tests/core/creators/manual/themeduidisablededitorlabels.md
@@ -1,0 +1,23 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced.
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+
+Sample announcements for the `iframe`-based editor:
+
+* VoiceOver+Chrome: "Frame. edit text. &lt;content and selection info&gt;"
+* NVDA+Firefox: "Rich Text Editor, wysiwygarea, null document editable"
+* JAWS+Firefox: "Rich Text Editor, wysiwygarea, frame, null edit &lt;content&gt; type and text"
+
+Sample announcements for the `div`-based editor:
+
+* VoiceOver+Chrome: "edit text &lt;content&gt;. Rich Text Editor, divarea, application."
+* NVDA+Firefox: "Rich Text Editor, divarea, edit multi line"
+* JAWS+Firefox: "Rich Text Editor, divarea, edit, contains text, type and text"

--- a/tests/core/creators/manual/themeduidisablededitorlabels.md
+++ b/tests/core/creators/manual/themeduidisablededitorlabels.md
@@ -13,8 +13,8 @@
 Sample announcements for the `iframe`-based editor:
 
 * VoiceOver+Chrome: "Frame. edit text. &lt;content and selection info&gt;"
-* NVDA+Firefox: "Rich Text Editor, wysiwygarea, null document editable"
-* JAWS+Firefox: "Rich Text Editor, wysiwygarea, frame, null edit &lt;content&gt; type and text"
+* NVDA+Firefox: "Rich Text Editor, wysiwygarea, document editable"
+* JAWS+Firefox: "Rich Text Editor, wysiwygarea, frame, edit &lt;content&gt; type and text"
 
 Sample announcements for the `div`-based editor:
 

--- a/tests/core/creators/manual/themeduilabels.html
+++ b/tests/core/creators/manual/themeduilabels.html
@@ -1,0 +1,19 @@
+<h2><code>Iframe</code>-based</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<h2><code>Div</code>-based</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'wysiwygarea', {
+		language: 'en'
+	} );
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		language: 'en'
+	} );
+</script>

--- a/tests/core/creators/manual/themeduilabels.md
+++ b/tests/core/creators/manual/themeduilabels.md
@@ -1,0 +1,23 @@
+@bender-tags: bug, 4.19.0, 2445
+@bender-ui: collapsed
+@bender-ckeditor-plugins: toolbar, wysiwygarea, basicstyles, floatingspace
+
+**Note** This test is intended to be used with a screen reader.
+
+1. Focus the editor.
+
+	**Expected** The editor is correctly announced ("Editor hublabubla").
+
+	**Unexpected** The editor is incorrectly announced or not announced at all.
+
+Sample announcements for the `iframe`-based editor:
+
+* VoiceOver: "edit text, &lt;content and selection info&gt;. Editor, wysiwygarea, group"
+* NVDA: "Rich Text Editor, wysiwygarea, Editor, wysiwygarea frame, Editor, wysiwygarea document editable"
+* JAWS: "Editor, wysiwygarea frame, editor, wysiwygarea edit &lt;content&gt; type and text"
+
+Sample announcements for the `div`-based editor:
+
+* VoiceOver: "Editor, divarea edit text &lt;content&gt;. Rich Text Editor, divarea, application."
+* NVDA: "Rich Text Editor, divarea, Editor, divarea edit multi line"
+* JAWS: "Editor, divarea edit, contains text, type and text"

--- a/tests/core/creators/manual/themeduilabels.md
+++ b/tests/core/creators/manual/themeduilabels.md
@@ -6,18 +6,18 @@
 
 1. Focus the editor.
 
-	**Expected** The editor is correctly announced ("Editor hublabubla").
+	**Expected** The editor is correctly announced.
 
 	**Unexpected** The editor is incorrectly announced or not announced at all.
 
 Sample announcements for the `iframe`-based editor:
 
-* VoiceOver: "edit text, &lt;content and selection info&gt;. Editor, wysiwygarea, group"
-* NVDA: "Rich Text Editor, wysiwygarea, Editor, wysiwygarea frame, Editor, wysiwygarea document editable"
-* JAWS: "Editor, wysiwygarea frame, editor, wysiwygarea edit &lt;content&gt; type and text"
+* VoiceOver+Chrome: "Editor, wysiwygarea edit text, &lt;content and selection info&gt;. Editor, wysiwygarea, group"
+* NVDA+Firefox: "Rich Text Editor, wysiwygarea, Editor, wysiwygarea frame, Editor, wysiwygarea document editable"
+* JAWS+Firefox: "Editor, wysiwygarea frame, editor, wysiwygarea edit &lt;content&gt; type and text"
 
 Sample announcements for the `div`-based editor:
 
-* VoiceOver: "Editor, divarea edit text &lt;content&gt;. Rich Text Editor, divarea, application."
-* NVDA: "Rich Text Editor, divarea, Editor, divarea edit multi line"
-* JAWS: "Editor, divarea edit, contains text, type and text"
+* VoiceOver+Chrome: "Editor, divarea edit text &lt;content&gt;. Rich Text Editor, divarea, application."
+* NVDA+Firefox: "Rich Text Editor, divarea, Editor, divarea edit multi line"
+* JAWS+Firefox: "Editor, divarea edit, contains text, type and text"

--- a/tests/core/editable/manual/ariareadonlyscreenreader.html
+++ b/tests/core/editable/manual/ariareadonlyscreenreader.html
@@ -1,0 +1,25 @@
+<h2>Divarea</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline (via config)</h2>
+<div id="inline-config" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline (via attribute)</h2>
+<div id="inline-attribute" contenteditable="false">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'divarea', {
+		extraPlugins: 'divarea',
+		readOnly: true
+	} );
+	CKEDITOR.inline( 'inline-config', {
+		readOnly: true
+	}  );
+	CKEDITOR.inline( 'inline-attribute' );
+</script>

--- a/tests/core/editable/manual/ariareadonlyscreenreader.html
+++ b/tests/core/editable/manual/ariareadonlyscreenreader.html
@@ -15,11 +15,15 @@
 
 <script>
 	CKEDITOR.replace( 'divarea', {
+		langauge: 'en',
 		extraPlugins: 'divarea',
 		readOnly: true
 	} );
 	CKEDITOR.inline( 'inline-config', {
+		langauge: 'en',
 		readOnly: true
 	}  );
-	CKEDITOR.inline( 'inline-attribute' );
+	CKEDITOR.inline( 'inline-attribute', {
+		langauge: 'en'
+	} );
 </script>

--- a/tests/core/editable/manual/ariareadonlyscreenreader.md
+++ b/tests/core/editable/manual/ariareadonlyscreenreader.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.18.1, feature, 1904
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar
+
+**Note:** This test is intended for screen readers.
+
+1. Focus the first editor.
+
+	**Expected** The screen reader announces the editor is readonly.
+1. Repeat the test for other editors.
+
+Sample screen readers' outputs (essential part bolded):
+
+* VoiceOver: "&lt;editor's name&gt; **clickable, text**. &lt;editor's content&gt;"
+* JAWS: "&lt;editor's name&gt; **readonly** edit/type and text"
+* NVDA: "&lt;application name&gt;, &lt;editor's name&gt; **edit readonly**"

--- a/tests/core/editable/manual/ariareadonlyscreenreader.md
+++ b/tests/core/editable/manual/ariareadonlyscreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, feature, 1904
+@bender-tags: 4.18.1, bug, 1904
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 

--- a/tests/core/editable/manual/ariareadonlyscreenreader.md
+++ b/tests/core/editable/manual/ariareadonlyscreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, bug, 1904
+@bender-tags: 4.19.0, bug, 1904
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 

--- a/tests/core/editable/readonly.js
+++ b/tests/core/editable/readonly.js
@@ -6,6 +6,8 @@
 	CKEDITOR.disableAutoInline = true;
 	CKEDITOR.config.plugins = 'basicstyles,toolbar';
 
+	var ARIA_ATTRIBUTE = 'aria-readonly';
+
 	bender.editors = {
 		framed: {
 			name: 'framed'
@@ -38,6 +40,14 @@
 			config: {
 				extraPlugins: 'divarea'
 			}
+		},
+
+		divareaStartReadOnly: {
+			name: 'divareaStartReadOnly',
+			config: {
+				extraPlugins: 'divarea',
+				readOnly: true
+			}
 		}
 	};
 
@@ -64,6 +74,28 @@
 				bender.editors[ name ].dataProcessor.writer.sortAttributes = true;
 			}
 		},
+
+		// These tests need to be first as other ones modifies the read-only state of editors.
+		// (#1904)
+		'test startup aria-readonly value (framed)': createAriaReadonlyInitialTest( 'framed', 'false' ),
+
+		// (#1904)
+		'test startup aria-readonly value (framedStartReadOnly)': createAriaReadonlyInitialTest( 'framedStartReadOnly', 'true' ),
+
+		// (#1904)
+		'test startup aria-readonly value (divarea)': createAriaReadonlyInitialTest( 'divarea', 'false' ),
+
+		// (#1904)
+		'test startup aria-readonly value (divareaStartReadOnly)': createAriaReadonlyInitialTest( 'divareaStartReadOnly', 'true' ),
+
+		// (#1904)
+		'test startup aria-readonly value (inline)': createAriaReadonlyInitialTest( 'inline', 'false' ),
+
+		// (#1904)
+		'test startup aria-readonly value (inlineNoCE)': createAriaReadonlyInitialTest( 'inlineNoCE', 'true' ),
+
+		// (#1904)
+		'test startup aria-readonly value (inlineStartReadOnly)': createAriaReadonlyInitialTest( 'inlineStartReadOnly', 'true' ),
 
 		'test BACKSPACE in read-only mode: framed': function() {
 			var editor = this.editors.framed,
@@ -132,6 +164,40 @@
 
 			editor.setReadOnly( false );
 			t.assertKeyBlocked( 8, 0 );
-		}
+		},
+
+		// (#1904)
+		'test updating aria-readonly attribute (framed)': createAriaReadonlySwitchingTest( 'framed' ),
+
+		// (#1904)
+		'test updating aria-readonly attribute (divarea)': createAriaReadonlySwitchingTest( 'divarea' ),
+
+		// (#1904)
+		'test updating aria-readonly attribute (inline)': createAriaReadonlySwitchingTest( 'inline' )
 	} );
+
+	function createAriaReadonlyInitialTest( editorName, expectedValue ) {
+		return function() {
+			var editor = bender.editors[ editorName ],
+				editable = editor.editable();
+
+			assert.areSame( expectedValue, editable.getAttribute( ARIA_ATTRIBUTE ) );
+		};
+	}
+
+	function createAriaReadonlySwitchingTest( editorName ) {
+		return function() {
+			var editor = bender.editors[ editorName ],
+				editable = editor.editable(),
+				attributeAfterSettingReadOnly;
+
+			assert.areSame( 'false', editable.getAttribute( ARIA_ATTRIBUTE ), 'aria-readonly for writable editor' );
+
+			editor.setReadOnly( true );
+			attributeAfterSettingReadOnly = editable.getAttribute( ARIA_ATTRIBUTE );
+			editor.setReadOnly( false );
+
+			assert.areSame( 'true', attributeAfterSettingReadOnly, 'aria-readonly for readonly editor' );
+		};
+	}
 } )();

--- a/tests/core/editor/applicationtitle.js
+++ b/tests/core/editor/applicationtitle.js
@@ -1,0 +1,172 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: wysiwygarea,floatingspace,toolbar */
+
+( function() {
+	'use strict';
+
+	CKEDITOR.disableAutoInline = true;
+
+	bender.editors = {
+		editor1: {
+			name: 'editor1',
+			config: { applicationTitle: 'foo' }
+		},
+		editor2: {
+			name: 'editor2',
+			config: { applicationTitle: 'bar' }
+		},
+		editor3: {
+			name: 'editor3',
+			creator: 'inline',
+			config: { applicationTitle: 'boom' }
+		},
+		editor4: {
+			name: 'editor4',
+			creator: 'inline',
+			config: { applicationTitle: 'bang' }
+		},
+
+		// applicationTitle attribute "inherited".
+		inherited1: {
+			name: 'inherited1',
+			config: {}
+		},
+		inherited2: {
+			name: 'inherited2',
+			creator: 'inline',
+			config: {}
+		},
+
+		// applicationTitle attribute disabled on purpose.
+		disabled1: {
+			name: 'disabled1',
+			config: { applicationTitle: false }
+		},
+		disabled2: {
+			name: 'disabled2',
+			creator: 'inline',
+			config: { applicationTitle: false }
+		},
+
+		// Empty string
+		disabled3: {
+			name: 'disabled3',
+			config: { applicationTitle: '' }
+		},
+
+		// Invalid applicationTitles, inline.
+		invalid1: {
+			name: 'invalid1',
+			creator: 'inline',
+			config: { applicationTitle: true }
+		},
+		invalid2: {
+			name: 'invalid2',
+			creator: 'inline',
+			config: { applicationTitle: null }
+		},
+		invalid3: {
+			name: 'invalid3',
+			creator: 'inline',
+			config: { applicationTitle: 42 }
+		},
+
+		// Invalid applicationTitles, framed.
+		invalid4: {
+			name: 'invalid4',
+			config: { applicationTitle: true }
+		},
+		invalid5: {
+			name: 'invalid5',
+			config: { applicationTitle: null }
+		},
+		invalid6: {
+			name: 'invalid6',
+			config: { applicationTitle: 42 }
+		}
+	};
+
+	for ( var name in bender.editors ) {
+		// Save startup title for further comparison.
+		var element = CKEDITOR.document.getById( name );
+
+		if ( element )
+			element.data( 'startup-title', element.getAttribute( 'title' ) || '' );
+	}
+
+	bender.test( {
+		'init': function() {
+			var initialDelay = CKEDITOR.focusManager._.blurDelay;
+
+			// Due to asynchronous nature of editor's blurring,
+			// blur handler is called after switching focus to the next editor.
+			// In case of inline editors in Chrome it causes to clear the selection
+			// and breaks the editor.
+			CKEDITOR.focusManager._.blurDelay = 0;
+
+			for ( var name in bender.editors ) {
+				bender.editors[ name ].insertText( name );
+			}
+
+			CKEDITOR.focusManager._.blurDelay = initialDelay;
+		},
+
+		'test config.applicationTitle implies editor.applicationTitle': function() {
+			assertApplicationTitle( 'foo', 'editor1' );
+			assertApplicationTitle( 'bar', 'editor2' );
+			assertApplicationTitle( 'boom',	'editor3' );
+			assertApplicationTitle( 'bang',	'editor4' );
+
+			assertApplicationTitle( false, 'disabled1' );
+			assertApplicationTitle( false, 'disabled2' );
+			assertApplicationTitle( '', 'disabled3' );
+		},
+
+		'test editor.name implies editor.applicationTitle': function() {
+			// config.title not set, using editor.name
+			assertApplicationTitleInherited( 'inherited1' );
+			assertApplicationTitleInherited( 'inherited2' );
+
+			// Invalid config.title, also "inherit" editor.name
+			assertApplicationTitleInherited( 'invalid4' );
+			assertApplicationTitleInherited( 'invalid5' );
+			assertApplicationTitleInherited( 'invalid6' );
+			assertApplicationTitleInherited( 'invalid1' );
+			assertApplicationTitleInherited( 'invalid2' );
+			assertApplicationTitleInherited( 'invalid3' );
+		},
+
+		'test voice label have properly set application title': function() {
+			for ( var i in this.editors ) {
+				assertVoiceLabelIsBasedOnApplicationTitle( this.editors[ i ] );
+			}
+		}
+	} );
+
+	function assertApplicationTitle( expected, editor, msg ) {
+		assert.areSame(
+			expected,
+			bender.editors[ editor ].applicationTitle,
+			msg || 'editor.applicationTitle of ' + bender.editors[ editor ].name + ' based on editor.config' );
+	}
+
+	function assertApplicationTitleInherited( editor ) {
+		assert.isTrue( !!~bender.editors[ editor ].applicationTitle.indexOf( bender.editors[ editor ].name ),
+			'editor.applicationTitle of ' + editor.name + ' based on editor.name' );
+	}
+
+	function assertVoiceLabelIsBasedOnApplicationTitle( editor ) {
+		var element = getVoiceLabel( editor );
+
+		if ( !editor.applicationTitle ) {
+			assert.isNull( element, 'editor: ' + editor.name );
+		} else {
+			assert.isNotNull( element, 'editor: ' + editor.name + ' - element' );
+			assert.areSame( editor.applicationTitle, element.getText(), 'editor: ' + editor.name + ' - value' );
+		}
+	}
+
+	function getVoiceLabel( editor ) {
+		return CKEDITOR.document.getById( 'cke_' + editor.name + '_arialbl' );
+	}
+} )();

--- a/tests/core/editor/title.js
+++ b/tests/core/editor/title.js
@@ -12,10 +12,6 @@
 		return editable.isInline() ? editable : editor.window.getFrame();
 	}
 
-	function getVoiceLabel( editor ) {
-		return CKEDITOR.document.getById( 'cke_' + editor.name + '_arialbl' );
-	}
-
 	function assertTitle( expected, editor, msg ) {
 		assert.areSame(
 			expected,
@@ -38,17 +34,6 @@
 				assert.isFalse( element.hasAttribute( 'title' ), 'Title attribute set on editable of ' + editor.name );
 		} else {
 			assert.isTrue( !!~element.getAttribute( 'title' ).indexOf( editor.title ), 'editor.title used as an attribute of editable of ' + editor.name );
-		}
-	}
-
-	function assertVoiceLabelIsBasedOnTitle( editor ) {
-		var element = getVoiceLabel( editor );
-
-		if ( !editor.title ) {
-			assert.isNull( element, 'editor: ' + editor.name );
-		} else {
-			assert.isNotNull( element, 'editor: ' + editor.name + ' - element' );
-			assert.areSame( editor.title, element.getText(), 'editor: ' + editor.name + ' - value' );
 		}
 	}
 
@@ -210,12 +195,6 @@
 		'test editor.title transferred to editable element': function() {
 			for ( var i in this.editors )
 				assertTitleSetOnEditable( this.editors[ i ] );
-		},
-
-		'test voice label have properly set title': function() {
-			for ( var i in this.editors ) {
-				assertVoiceLabelIsBasedOnTitle( this.editors[ i ] );
-			}
 		},
 
 		'test restore title after instance is destroyed': function() {

--- a/tests/plugins/wysiwygarea/aria.js
+++ b/tests/plugins/wysiwygarea/aria.js
@@ -60,6 +60,7 @@
 			} );
 		},
 
+		// (#4052)
 		'test editor has correct role and multiline attributes': function() {
 			bender.editorBot.create( {
 				name: 'editor-role-multiline',
@@ -68,15 +69,16 @@
 				}
 			}, function( bot ) {
 				var editor = bot.editor,
-					body = editor.document.findOne( 'body' ),
-					roleAttribute = body.getAttribute( 'role' ),
-					multineAttribute = body.getAttribute( 'aria-multiline' );
+					editable = editor.editable(),
+					roleAttribute = editable.getAttribute( 'role' ),
+					multineAttribute = editable.getAttribute( 'aria-multiline' );
 
 				assert.areSame( 'textbox', roleAttribute );
 				assert.areSame( 'true', multineAttribute );
 			} );
 		},
 
+		// (#4052)
 		'test editor has correct role and multiline attributes (full-page editing)': function() {
 			bender.editorBot.create( {
 				name: 'editor-role-multiline-fullpage',
@@ -86,12 +88,29 @@
 				}
 			}, function( bot ) {
 				var editor = bot.editor,
-					body = editor.document.findOne( 'body' ),
-					roleAttribute = body.getAttribute( 'role' ),
-					multineAttribute = body.getAttribute( 'aria-multiline' );
+					editable = editor.editable(),
+					roleAttribute = editable.getAttribute( 'role' ),
+					multineAttribute = editable.getAttribute( 'aria-multiline' );
 
 				assert.areSame( 'textbox', roleAttribute );
 				assert.areSame( 'true', multineAttribute );
+			} );
+		},
+
+		'test editor has correct [tabindex] attribute value': function() {
+			bender.editorBot.create( {
+				name: 'editor-tabindex',
+				config: {
+					plugins: 'wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					editable = editor.editable(),
+					tabindexAttribute = editable.getAttribute( 'tabindex' ),
+					// Firefox should not have this attribute (https://bugzilla.mozilla.org/show_bug.cgi?id=1483828).
+					expectedValue = CKEDITOR.env.gecko ? null : '0';
+
+				assert.areSame( expectedValue, tabindexAttribute );
 			} );
 		}
 	} );

--- a/tests/plugins/wysiwygarea/aria.js
+++ b/tests/plugins/wysiwygarea/aria.js
@@ -58,6 +58,21 @@
 				assert.areSame( 1, fired, 'event was fired once' );
 				assert.isNull( describedBy, 'iframe does not have aria-describedby attribute' );
 			} );
+		},
+
+		'test editor has correct role and multiline attributes': function() {
+			bender.editorBot.create( {
+				name: 'editor-role-multiline',
+				plugins: 'wysiwygarea'
+			}, function( bot ) {
+				var editor = bot.editor,
+					body = editor.document.findOne( 'body' ),
+					roleAttribute = body.getAttribute( 'role' ),
+					multineAttribute = body.getAttribute( 'aria-multiline' );
+
+				assert.areSame( 'textbox', roleAttribute );
+				assert.areSame( 'true', multineAttribute );
+			} );
 		}
 	} );
 } )();

--- a/tests/plugins/wysiwygarea/aria.js
+++ b/tests/plugins/wysiwygarea/aria.js
@@ -63,7 +63,27 @@
 		'test editor has correct role and multiline attributes': function() {
 			bender.editorBot.create( {
 				name: 'editor-role-multiline',
-				plugins: 'wysiwygarea'
+				config: {
+					plugins: 'wysiwygarea'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					body = editor.document.findOne( 'body' ),
+					roleAttribute = body.getAttribute( 'role' ),
+					multineAttribute = body.getAttribute( 'aria-multiline' );
+
+				assert.areSame( 'textbox', roleAttribute );
+				assert.areSame( 'true', multineAttribute );
+			} );
+		},
+
+		'test editor has correct role and multiline attributes (full-page editing)': function() {
+			bender.editorBot.create( {
+				name: 'editor-role-multiline-fullpage',
+				config: {
+					plugins: 'wysiwygarea',
+					fullPage: true
+				}
 			}, function( bot ) {
 				var editor = bot.editor,
 					body = editor.document.findOne( 'body' ),

--- a/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.html
+++ b/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.html
@@ -14,10 +14,12 @@
 	}
 
 	CKEDITOR.replace( 'classic', {
+		language: 'en',
 		readOnly: true
 	} );
 
 	CKEDITOR.replace( 'fullpage', {
+		language: 'en',
 		readOnly: true,
 		fullPage: true
 	} );

--- a/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.html
+++ b/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.html
@@ -1,0 +1,24 @@
+<h2>Classic</h2>
+<div id="classic">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Full-page</h2>
+<div id="fullpage">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'classic', {
+		readOnly: true
+	} );
+
+	CKEDITOR.replace( 'fullpage', {
+		readOnly: true,
+		fullPage: true
+	} );
+</script>

--- a/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.md
+++ b/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.18.1, feature, 1904
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar
+
+**Note:** This test is intended for screen readers.
+
+1. Focus the first editor.
+
+	**Expected** The screen reader announces the editor is readonly.
+1. Repeat the test for the second editor.
+
+Sample screen readers' outputs (essential part bolded):
+
+* VoiceOver: "&lt;editor's name&gt; **clickable, text**. &lt;editor's content&gt;"
+* JAWS: "&lt;editor's name&gt; **readonly** edit/type and text"
+* NVDA: "&lt;application name&gt;, &lt;editor's name&gt; **edit readonly**"

--- a/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.md
+++ b/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, feature, 1904
+@bender-tags: 4.18.1, bug, 1904
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 

--- a/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.md
+++ b/tests/plugins/wysiwygarea/manual/ariareadonlyscreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, bug, 1904
+@bender-tags: 4.19.0, bug, 1904
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 

--- a/tests/plugins/wysiwygarea/manual/ariarolescreenreader.html
+++ b/tests/plugins/wysiwygarea/manual/ariarolescreenreader.html
@@ -1,7 +1,16 @@
+<h2>Classic</h2>
 <div id="editor">
 	<p>Lorem ipsum dolor sit amet.</p>
 </div>
 
+<h2>Full page</h2>
+<div id="fullpage">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
 <script>
-CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'fullpage', {
+		fullPage: true
+	} );
 </script>

--- a/tests/plugins/wysiwygarea/manual/ariarolescreenreader.html
+++ b/tests/plugins/wysiwygarea/manual/ariarolescreenreader.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>
+CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/wysiwygarea/manual/ariarolescreenreader.md
+++ b/tests/plugins/wysiwygarea/manual/ariarolescreenreader.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, feature, 4052
+@bender-tags: 4.18.1, bug, 4052
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 

--- a/tests/plugins/wysiwygarea/manual/ariarolescreenreader.md
+++ b/tests/plugins/wysiwygarea/manual/ariarolescreenreader.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.18.1, feature, 4052
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar
+
+**Note:** This test is intended for screen readers.
+
+1. Focus the editor.
+
+	**Expected** The screen reader announces that the user is inside an editable field.
+
+Sample screen readers' outputs (essential part bolded):
+
+* VoiceOver: "&lt;editor's name&gt; **edit text**. &lt;editor's content&gt;"
+* JAWS: "&lt;frame's name&gt; frame, &lt;editor's name&gt; **edit, type and text**"
+* NVDA: "&lt;application name&gt;, &lt;frame name&gt;, &lt;editor's name&gt; **document editable**"

--- a/tests/plugins/wysiwygarea/manual/ariarolescreenreader.md
+++ b/tests/plugins/wysiwygarea/manual/ariarolescreenreader.md
@@ -4,9 +4,10 @@
 
 **Note:** This test is intended for screen readers.
 
-1. Focus the editor.
+1. Focus the first editor.
 
 	**Expected** The screen reader announces that the user is inside an editable field.
+1. Repeat the test for the second editor.
 
 Sample screen readers' outputs (essential part bolded):
 

--- a/tests/plugins/wysiwygarea/manual/tabindex.html
+++ b/tests/plugins/wysiwygarea/manual/tabindex.html
@@ -1,0 +1,24 @@
+<h2>Editable</h2>
+<div id="editable">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<p>
+	<button>Behold as I am the button!</button>
+</p>
+
+<h2>Read-only</h2>
+<div id="readonly">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<p>
+	<button>Behold as I am the button!</button>
+</p>
+
+<script>
+	CKEDITOR.replace( 'editable' );
+	CKEDITOR.replace( 'readonly', {
+		readOnly: true
+	} );
+</script>

--- a/tests/plugins/wysiwygarea/manual/tabindex.md
+++ b/tests/plugins/wysiwygarea/manual/tabindex.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.18.1, feature, 1904
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea,toolbar
+
+1. Focus the first editor.
+1. Press the <kbd>Tab</kbd> key.
+
+	**Expected** The focus is moved to the button after the editor.
+
+	**Unexpected** The focus is still in the editor.
+1. Repeat the procedure for the second editor.

--- a/tests/plugins/wysiwygarea/manual/tabindex.md
+++ b/tests/plugins/wysiwygarea/manual/tabindex.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, feature, 1904
+@bender-tags: 4.18.1, bug, 1904
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 

--- a/tests/plugins/wysiwygarea/manual/tabindex.md
+++ b/tests/plugins/wysiwygarea/manual/tabindex.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.18.1, bug, 1904
+@bender-tags: 4.19.0, bug, 1904
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea,toolbar
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
Fixed Issues:

* [#4052](https://github.com/ckeditor/ckeditor4/issues/4052): Fixed: Editor labels are read incorrectly by screen readers due to invalid editor control type for [Iframe Editing Area](https://ckeditor.com/cke4/addon/wysiwygarea) editors.
* [#1904](https://github.com/ckeditor/ckeditor4/issues/1904): Fixed: Screen readers are not announcing read-only editor state due to missing proper aria-labels.
* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Fixed: The same editor's label is read several times by screen readers when focusing an editor.

API Changes:

* [#2445](https://github.com/ckeditor/ckeditor4/issues/2445): Added [`config.applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-applicationTitle) alongside [`CKEDITOR.editor#applicationTitle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-title) to allow customizing editor's application region label.
```

## What changes did you make?

I've added missing `[role=textbox]` and `[aria-multiline]` attributes for `wysiwygarea` editors. I've also added `[aria-readonly]` attribute to editors to indicate the status of the "readonliness" of the editor. However, for iframe-based editors it required adding also the `[tabindex=0]` attribute to be actually read by screen readers. This change was implemented for all browsers except Firefox which has a [bug connected with this attribute and `iframe`s](https://bugzilla.mozilla.org/show_bug.cgi?id=1483828). It also means that marking read-only `iframe`s does not work in Firefox.

I didn't touch #2445 because I have no idea how to differentiate labels for applications and editables. But the changes introduced for read-only editors indicate such a need (NVDA now reads the same label _thrice_ – probably due to it being the label of the application, the label of the editor, and the title of the editor's `iframe`). Probably it's something that we need to discuss further.

Proposed changes should also fix #2499 but it needs further verification.

## Which issues does your PR resolve?

Closes #4052.
Closes #1904.
Closes #2445.
