### PR TITLE
Allow preserving line breaks at the end of inline elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New features:
 
 * [#2444](https://github.com/ckeditor/ckeditor4/issues/2444): Togglable toolbar buttons are now exposed as toggle buttons in the browser's accessibility tree.
 * [#4641](https://github.com/ckeditor/ckeditor4/issues/4641): Added an option allowing to cancel [Delayed Editor Creation](https://ckeditor.com/docs/ckeditor4/latest/features/delayed_creation.html) feature as a function handle to editor creators ([`CKEDITOR.replace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-replace), [`CKEDITOR.inline`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-inline), [`CKEDITOR.appendTo`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#method-appendTo)).
+* [#4986](https://github.com/ckeditor/ckeditor4/issues/4986): Added [`config.shiftLineBreaks`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-shiftLineBreaks) allowing to preserve inline elements formatting on shift enter.
 
 Fixed Issues:
 

--- a/core/htmlparser/fragment.js
+++ b/core/htmlparser/fragment.js
@@ -677,11 +677,11 @@ CKEDITOR.htmlParser.fragment = function() {
 	};
 
 	/**
-	 * Indicates if break lines (`br`) should be moved outside inline elements.
+	 * Indicates if line breaks (`br`) should be moved outside inline elements.
 	 *
 	 * By default, all children `br` elements, placed at the end of an inline element,
 	 * are shifted outside that element. Shifted elements are attached at the end of the parent block element.
-	 * It allows to produce more clean HTML output without abundance of
+	 * It allows producing more clean HTML output without an abundance of
 	 * orphaned styling markers. This logic can be changed by disabling shifting line breaks or providing
 	 * a custom function allowing to conditionally choose proper behavior.
 	 *

--- a/core/htmlparser/fragment.js
+++ b/core/htmlparser/fragment.js
@@ -143,6 +143,35 @@ CKEDITOR.htmlParser.fragment = function() {
 				addElement( pendingBRs.shift(), currentNode );
 		}
 
+		function shiftBRsPosition() {
+			var shiftLineBreak = CKEDITOR.config.shiftLineBreak;
+
+			if ( shiftLineBreak === true || !pendingBRs.length ) {
+				return;
+			}
+
+			if ( typeof shiftLineBreak !== 'function' ) {
+				sendPendingBRs();
+				return;
+			}
+
+			var result = shiftLineBreak( pendingBRs[ pendingBRs.length - 1 ] );
+
+			if ( result === true ) {
+				return;
+			}
+
+			sendPendingBRs();
+
+			if ( result instanceof CKEDITOR.htmlParser.text ) {
+				currentNode.add( result );
+			}
+
+			if ( result instanceof CKEDITOR.htmlParser.element ) {
+				addElement( result, currentNode );
+			}
+		}
+
 		// Rtrim empty spaces on block end boundary. (https://dev.ckeditor.com/ticket/3585)
 		function removeTailWhitespace( element ) {
 			if ( element._.isBlockLike && element.name != 'pre' && element.name != 'textarea' ) {
@@ -380,8 +409,11 @@ CKEDITOR.htmlParser.fragment = function() {
 
 				currentNode = candidate;
 
-				if ( candidate._.isBlockLike )
+				if ( candidate._.isBlockLike ) {
 					sendPendingBRs();
+				} else {
+					shiftBRsPosition();
+				}
 
 				addElement( candidate, candidate.parent );
 
@@ -643,4 +675,67 @@ CKEDITOR.htmlParser.fragment = function() {
 			return context || {};
 		}
 	};
+
+	/**
+	 * Indicates if break lines (`br`) should be moved outside inline elements.
+	 *
+	 * By default, all children `br` elements, placed at the end of an inline element,
+	 * are shifted outside that element. Shifted elements are attached at the end of the parent block element.
+	 * It allows to produce more clean HTML output without abundance of
+	 * orphaned styling markers. This logic can be changed by disabling shifting line breaks or providing
+	 * a custom function allowing to conditionally choose proper behavior.
+	 *
+	 * * `shiftLineBreak = true`
+	 *
+	 * Shift line breaks outside inline element:
+	 *
+	 * 		<p><strong>hello, world!<br><br></strong></p>
+	 *
+	 * becomes:
+	 *
+	 * 		<p><strong>hello, world!</strong><br><br></p>
+	 *
+	 * * `shiftLineBreak = false`
+	 *
+	 * Keep line breaks inside inline element:
+	 *
+	 * 		<p><strong>hello, world!<br><br></strong></p>
+	 *
+	 * * `shiftLineBreak = customFunction`
+	 *
+	 * Provide a callback function allowing to decide if break line should be shifted:
+	 *
+	 * ```javascript
+	 * CKEDITOR.config.shiftLineBreak = function() {
+	 *		if ( condition ) {
+	 * 			// Shift line break outside element.
+	 *	 		return true;
+	 * 		}
+	 *		// Keep line break inside element.
+	 * 		return false;
+	 * }
+	 * ```
+	 *
+	 * You can also decide to return {@link CKEDITOR.htmlParser.text} or {@link CKEDITOR.htmlParser.element}
+	 * node that will be attached **at the end of the last `br` node** inside inline element.
+	 *
+	 * As an example, you may want to add additional `nbsp;` filler to make sure that a user will be
+	 * able to place caret after break lines:
+	 *
+	 * ```javascript
+	 * CKEDITOR.config.shiftLineBreak = function() {
+	 * 		// Append `nbsp;` character at the end.
+	 * 		return new CKEDITOR.htmlParser.text( '&nbsp;' );
+	 * }
+	 * ```
+	 *
+	 * resulting in:
+	 *
+	 * 		<p><strong>hello, world!<br><br>&nbsp;</strong></p>
+	 *
+	 * @cfg {Boolean|Function} [shiftLineBreak=true]
+	 * @member CKEDITOR.config
+	 */
+
+	CKEDITOR.config.shiftLineBreak = true;
 } )();

--- a/core/htmlparser/fragment.js
+++ b/core/htmlparser/fragment.js
@@ -144,18 +144,18 @@ CKEDITOR.htmlParser.fragment = function() {
 		}
 
 		function shiftBRsPosition() {
-			var shiftLineBreak = CKEDITOR.config.shiftLineBreak;
+			var shiftLineBreaks = CKEDITOR.config.shiftLineBreaks;
 
-			if ( shiftLineBreak === true || !pendingBRs.length ) {
+			if ( shiftLineBreaks === true || !pendingBRs.length ) {
 				return;
 			}
 
-			if ( typeof shiftLineBreak !== 'function' ) {
+			if ( typeof shiftLineBreaks !== 'function' ) {
 				sendPendingBRs();
 				return;
 			}
 
-			var result = shiftLineBreak( pendingBRs[ pendingBRs.length - 1 ] );
+			var result = shiftLineBreaks( pendingBRs[ pendingBRs.length - 1 ] );
 
 			if ( result === true ) {
 				return;
@@ -685,7 +685,7 @@ CKEDITOR.htmlParser.fragment = function() {
 	 * orphaned styling markers. This logic can be changed by disabling shifting line breaks or providing
 	 * a custom function allowing to conditionally choose proper behavior.
 	 *
-	 * * `shiftLineBreak = true`
+	 * * `shiftLineBreaks = true`
 	 *
 	 * Shift line breaks outside inline element:
 	 *
@@ -695,18 +695,18 @@ CKEDITOR.htmlParser.fragment = function() {
 	 *
 	 * 		<p><strong>hello, world!</strong><br><br></p>
 	 *
-	 * * `shiftLineBreak = false`
+	 * * `shiftLineBreaks = false`
 	 *
 	 * Keep line breaks inside inline element:
 	 *
 	 * 		<p><strong>hello, world!<br><br></strong></p>
 	 *
-	 * * `shiftLineBreak = customFunction`
+	 * * `shiftLineBreaks = customFunction`
 	 *
 	 * Provide a callback function allowing to decide if break line should be shifted:
 	 *
 	 * ```javascript
-	 * CKEDITOR.config.shiftLineBreak = function() {
+	 * CKEDITOR.config.shiftLineBreaks = function() {
 	 *		if ( condition ) {
 	 * 			// Shift line break outside element.
 	 *	 		return true;
@@ -723,7 +723,7 @@ CKEDITOR.htmlParser.fragment = function() {
 	 * able to place caret after break lines:
 	 *
 	 * ```javascript
-	 * CKEDITOR.config.shiftLineBreak = function() {
+	 * CKEDITOR.config.shiftLineBreaks = function() {
 	 * 		// Append `nbsp;` character at the end.
 	 * 		return new CKEDITOR.htmlParser.text( '&nbsp;' );
 	 * }
@@ -733,9 +733,9 @@ CKEDITOR.htmlParser.fragment = function() {
 	 *
 	 * 		<p><strong>hello, world!<br><br>&nbsp;</strong></p>
 	 *
-	 * @cfg {Boolean|Function} [shiftLineBreak=true]
+	 * @cfg {Boolean|Function} [shiftLineBreaks=true]
 	 * @member CKEDITOR.config
 	 */
 
-	CKEDITOR.config.shiftLineBreak = true;
+	CKEDITOR.config.shiftLineBreaks = true;
 } )();

--- a/core/htmlparser/fragment.js
+++ b/core/htmlparser/fragment.js
@@ -679,6 +679,8 @@ CKEDITOR.htmlParser.fragment = function() {
 	/**
 	 * Indicates if line breaks (`br`) should be moved outside inline elements.
 	 *
+	 * **Note:** This is a global configuration that applies to all instances.
+	 *
 	 * By default, all children `br` elements, placed at the end of an inline element,
 	 * are shifted outside that element. Shifted elements are attached at the end of the parent block element.
 	 * It allows producing more clean HTML output without an abundance of

--- a/core/htmlparser/fragment.js
+++ b/core/htmlparser/fragment.js
@@ -697,13 +697,13 @@ CKEDITOR.htmlParser.fragment = function() {
 	 *
 	 * * `shiftLineBreaks = false`
 	 *
-	 * Keep line breaks inside inline element:
+	 * Keep line breaks inside an inline element:
 	 *
 	 * 		<p><strong>hello, world!<br><br></strong></p>
 	 *
 	 * * `shiftLineBreaks = customFunction`
 	 *
-	 * Provide a callback function allowing to decide if break line should be shifted:
+	 * Provide a callback function allowing to decide if a line break should be shifted:
 	 *
 	 * ```javascript
 	 * CKEDITOR.config.shiftLineBreaks = function() {
@@ -719,13 +719,13 @@ CKEDITOR.htmlParser.fragment = function() {
 	 * You can also decide to return {@link CKEDITOR.htmlParser.text} or {@link CKEDITOR.htmlParser.element}
 	 * node that will be attached **at the end of the last `br` node** inside inline element.
 	 *
-	 * As an example, you may want to add additional `nbsp;` filler to make sure that a user will be
+	 * As an example, you may want to add an additional `nbsp;` filler to make sure that a user will be
 	 * able to place caret after break lines:
 	 *
 	 * ```javascript
 	 * CKEDITOR.config.shiftLineBreaks = function() {
-	 * 		// Append `nbsp;` character at the end.
-	 * 		return new CKEDITOR.htmlParser.text( '&nbsp;' );
+	 * 	// Append `nbsp;` character at the end.
+	 * 	return new CKEDITOR.htmlParser.text( '&nbsp;' );
 	 * }
 	 * ```
 	 *
@@ -733,7 +733,7 @@ CKEDITOR.htmlParser.fragment = function() {
 	 *
 	 * 		<p><strong>hello, world!<br><br>&nbsp;</strong></p>
 	 *
-	 * @cfg {Boolean|Function} [shiftLineBreaks=true]
+	 * @cfg {Boolean/Function} [shiftLineBreaks=true]
 	 * @member CKEDITOR.config
 	 */
 

--- a/core/htmlparser/fragment.js
+++ b/core/htmlparser/fragment.js
@@ -707,12 +707,12 @@ CKEDITOR.htmlParser.fragment = function() {
 	 *
 	 * ```javascript
 	 * CKEDITOR.config.shiftLineBreaks = function() {
-	 *		if ( condition ) {
-	 * 			// Shift line break outside element.
-	 *	 		return true;
-	 * 		}
-	 *		// Keep line break inside element.
-	 * 		return false;
+	 * 	if ( condition ) {
+	 * 		// Shift line break outside element.
+	 * 		return true;
+	 * 	}
+	 * 	// Keep line break inside element.
+	 * 	return false;
 	 * }
 	 * ```
 	 *

--- a/tests/core/htmlparser/fragment/fromhtml.js
+++ b/tests/core/htmlparser/fragment/fromhtml.js
@@ -11,7 +11,7 @@ function parseHtml( raw, parent ) {
 bender.test( {
 	setUp: function() {
 		// Restore default option.
-		CKEDITOR.config.shiftLineBreak = true;
+		CKEDITOR.config.shiftLineBreaks = true;
 	},
 
 	test_parser_1: function() {
@@ -408,15 +408,15 @@ bender.test( {
 	},
 
 	// (#4986)
-	'test shiftLineBreak = false': function() {
-		CKEDITOR.config.shiftLineBreak = false;
+	'test shiftLineBreaks = false': function() {
+		CKEDITOR.config.shiftLineBreaks = false;
 		var html = '<p><strong>hello, world!<br /><br /></strong></p>';
 		assert.areSame( html, parseHtml( html ) );
 	},
 
 	// (#4986)
-	'test shiftLineBreak = callback returning false': function() {
-		CKEDITOR.config.shiftLineBreak = function() {
+	'test shiftLineBreaks = callback returning false': function() {
+		CKEDITOR.config.shiftLineBreaks = function() {
 			return false;
 		};
 		var html = '<p><strong>hello, world!<br /><br /></strong></p>';
@@ -424,8 +424,8 @@ bender.test( {
 	},
 
 	// (#4986)
-	'test shiftLineBreak = callback returning true': function() {
-		CKEDITOR.config.shiftLineBreak = function() {
+	'test shiftLineBreaks = callback returning true': function() {
+		CKEDITOR.config.shiftLineBreaks = function() {
 			return true;
 		};
 
@@ -434,8 +434,8 @@ bender.test( {
 	},
 
 	// (#4986)
-	'test shiftLineBreak = callback returning text node': function() {
-		CKEDITOR.config.shiftLineBreak = function() {
+	'test shiftLineBreaks = callback returning text node': function() {
+		CKEDITOR.config.shiftLineBreaks = function() {
 			return new CKEDITOR.htmlParser.text( '&nbsp;' );
 		};
 
@@ -444,8 +444,8 @@ bender.test( {
 	},
 
 	// (#4986)
-	'test shiftLineBreak = callback returning element node': function() {
-		CKEDITOR.config.shiftLineBreak = function() {
+	'test shiftLineBreaks = callback returning element node': function() {
+		CKEDITOR.config.shiftLineBreaks = function() {
 			return new CKEDITOR.htmlParser.element( 'br' );
 		};
 

--- a/tests/core/htmlparser/fragment/fromhtml.js
+++ b/tests/core/htmlparser/fragment/fromhtml.js
@@ -9,6 +9,11 @@ function parseHtml( raw, parent ) {
 }
 
 bender.test( {
+	setUp: function() {
+		// Restore default option.
+		CKEDITOR.config.shiftLineBreak = true;
+	},
+
 	test_parser_1: function() {
 		assert.areSame( '<p><b>2</b> Test</p><table><tr><td>1</td><td>3</td></tr></table>',
 						parseHtml( '<table><tr><td>1</td><p><b>2</b> Test</p><td>3</td></tr></table>' ) );
@@ -400,5 +405,51 @@ bender.test( {
 		fragment = CKEDITOR.htmlParser.fragment.fromHtml( '<p>A<b>B<i>C</i></b></p>' );
 		fragment.writeChildrenHtml( writer, filter, true );
 		assert.areSame( '<p x="1">A<b x="1">B<i x="1">C</i></b></p><div x="1">X</div>', writer.getHtml( true ) );
+	},
+
+	// (#4986)
+	'test shiftLineBreak = false': function() {
+		CKEDITOR.config.shiftLineBreak = false;
+		var html = '<p><strong>hello, world!<br /><br /></strong></p>';
+		assert.areSame( html, parseHtml( html ) );
+	},
+
+	// (#4986)
+	'test shiftLineBreak = callback returning false': function() {
+		CKEDITOR.config.shiftLineBreak = function() {
+			return false;
+		};
+		var html = '<p><strong>hello, world!<br /><br /></strong></p>';
+		assert.areSame( html, parseHtml( html ) );
+	},
+
+	// (#4986)
+	'test shiftLineBreak = callback returning true': function() {
+		CKEDITOR.config.shiftLineBreak = function() {
+			return true;
+		};
+
+		assert.areSame( '<p><strong>hello, world!</strong><br /><br /></p>',
+			parseHtml( '<p><strong>hello, world!<br /><br /></strong></p>' ) );
+	},
+
+	// (#4986)
+	'test shiftLineBreak = callback returning text node': function() {
+		CKEDITOR.config.shiftLineBreak = function() {
+			return new CKEDITOR.htmlParser.text( '&nbsp;' );
+		};
+
+		assert.areSame( '<p><strong>hello, world!<br /><br />&nbsp;</strong></p>',
+			parseHtml( '<p><strong>hello, world!<br /><br /></strong></p>' ) );
+	},
+
+	// (#4986)
+	'test shiftLineBreak = callback returning element node': function() {
+		CKEDITOR.config.shiftLineBreak = function() {
+			return new CKEDITOR.htmlParser.element( 'br' );
+		};
+
+		assert.areSame( '<p><strong>hello, world!<br /><br /><br /></strong></p>',
+			parseHtml( '<p><strong>hello, world!<br /><br /></strong></p>' ) );
 	}
 } );

--- a/tests/core/htmlparser/manual/preserveinlinestyling.html
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.html
@@ -13,7 +13,7 @@
 		bender.ignore();
 	}
 
-	CKEDITOR.config.shiftLineBreak = function( currentNode ) {
+	CKEDITOR.config.shiftLineBreaks = function( currentNode ) {
 		if ( currentNode.hasClass( 'filling-br') ) {
 			return;
 		}

--- a/tests/core/htmlparser/manual/preserveinlinestyling.html
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.html
@@ -1,0 +1,25 @@
+<div id="editor">
+	<p>
+		<span style="font-size: 16px"
+			><span style="font-family: Courier New, Courier, monospace"
+				>hello, world!<br /><br /><br /></span
+		></span>
+	</p>
+</div>
+
+<script>
+	CKEDITOR.config.shiftLineBreak = function( currentNode ) {
+		if ( currentNode.hasClass( 'filling-br') ) {
+			return;
+		}
+
+		var br =  new CKEDITOR.htmlParser.element( 'br' );
+
+		br.addClass( 'filling-br');
+
+		return br;
+	}
+	CKEDITOR.replace( 'editor', {
+		extraAllowedContent: 'br(filling-br)'
+	} );
+</script>

--- a/tests/core/htmlparser/manual/preserveinlinestyling.html
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.html
@@ -8,6 +8,11 @@
 </div>
 
 <script>
+	// IE allows to set cursor position exactly in BR tag.
+	if ( CKEDITOR.env.ie ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.config.shiftLineBreak = function( currentNode ) {
 		if ( currentNode.hasClass( 'filling-br') ) {
 			return;

--- a/tests/core/htmlparser/manual/preserveinlinestyling.html
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.html
@@ -14,13 +14,13 @@
 	}
 
 	CKEDITOR.config.shiftLineBreaks = function( currentNode ) {
-		if ( currentNode.hasClass( 'filling-br') ) {
+		if ( currentNode.hasClass( 'filling-br' ) ) {
 			return;
 		}
 
 		var br =  new CKEDITOR.htmlParser.element( 'br' );
 
-		br.addClass( 'filling-br');
+		br.addClass( 'filling-br' );
 
 		return br;
 	}

--- a/tests/core/htmlparser/manual/preserveinlinestyling.md
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.md
@@ -3,8 +3,8 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, sourcearea, stylescombo, font
 
 1. Toggle source area.
-2. Place cursor at the end of the editable area.
-3. Type some text.
+1. Place cursor at the end of the editable area.
+1. Type some text.
 
 ## Expected
 

--- a/tests/core/htmlparser/manual/preserveinlinestyling.md
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.19.0, feature, 4986
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, sourcearea, stylescombo, font
+
+1. Toggle source area.
+2. Place cursor at the end of the editable area.
+3. Type some text.
+
+## Expected
+
+* Typed text keeps formatting of the previous paragraph.
+* There are exactly 3 visual line breaks.
+
+## Unexpected
+
+* Typed text has no formatting.
+* There is more or less visual line breaks.

--- a/tests/core/htmlparser/manual/preserveinlinestyling.md
+++ b/tests/core/htmlparser/manual/preserveinlinestyling.md
@@ -1,17 +1,14 @@
 @bender-tags: 4.19.0, feature, 4986
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, sourcearea, stylescombo, font
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, sourcearea, stylescombo, font, elementspath
 
 1. Toggle source area.
-1. Place cursor at the end of the editable area.
-1. Type some text.
+2. Place cursor at the end of the editable area.
 
-## Expected
+**Expected** There are exactly 3 visual line breaks.
 
-* Typed text keeps formatting of the previous paragraph.
-* There are exactly 3 visual line breaks.
+3. Type some text.
 
-## Unexpected
+**Expected** Typed text keeps formatting of the previous paragraph.
 
-* Typed text has no formatting.
-* There is more or less visual line breaks.
+**Note** You can also use elementspath to see whether a selection is placed inside `span` styling elements.

--- a/tests/core/htmlparser/manual/shiftlinebreak.html
+++ b/tests/core/htmlparser/manual/shiftlinebreak.html
@@ -5,6 +5,6 @@
 </div>
 
 <script>
-	CKEDITOR.config.shiftLineBreak = false;
+	CKEDITOR.config.shiftLineBreaks = false;
 	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/core/htmlparser/manual/shiftlinebreak.html
+++ b/tests/core/htmlparser/manual/shiftlinebreak.html
@@ -1,0 +1,10 @@
+<div id="editor">
+	<p>
+		<strong>hello, world!<br><br></strong>
+	</p>
+</div>
+
+<script>
+	CKEDITOR.config.shiftLineBreak = false;
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/core/htmlparser/manual/shiftlinebreak.md
+++ b/tests/core/htmlparser/manual/shiftlinebreak.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.19.0, feature, 4986
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, sourcearea
+
+1. Click sourcearea button.
+
+## Expected
+
+`br` tags are placed inside `strong` element.
+
+## Unexpected
+
+`br` tags are placed outside `strong` element.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4986](https://github.com/ckeditor/ckeditor4/issues/4986): Added [`config.shiftLineBreaks`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-shiftLineBreaks) allowing to preserve inline elements formatting on shift enter.
```

## What changes did you make?

Added feature option allowing to manipulate how `CKEDITOR.htmlParser.fragment.fromHtml` treats line breaks inside inline elements.

## Which issues does your PR resolve?

Closes #4986
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
