### PR TITLE
Prevent removal body element with widget

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -608,11 +608,6 @@
 				// Allow removal of empty paragraphs (#1572).
 				startElement = sel.getStartElement();
 
-				// Prevent removal of the body element. (#5125)
-				if ( startElement.getName() === 'body' || isWidget( startElement.getFirst() ) ) {
-					return;
-				}
-
 				if ( isEmptyBlock( startElement ) && isDeleteAction( keystroke ) ) {
 					startElement.remove();
 
@@ -633,7 +628,8 @@
 		function isEmptyElement( element ) {
 			var text = element.$.textContent === undefined ? element.$.innerText : element.$.textContent;
 
-			return text === '';
+			// Check if the element does not contain a widget to prevent removal of the body element. (#5125)
+			return text === '' && !isWidget( element.getFirst() );
 		}
 
 		function isEmptyBlock( block ) {

--- a/core/selection.js
+++ b/core/selection.js
@@ -608,6 +608,11 @@
 				// Allow removal of empty paragraphs (#1572).
 				startElement = sel.getStartElement();
 
+				// Prevent removal of the body element. (#5125)
+				if ( startElement.getName() === 'body' || isWidget( startElement.getFirst() ) ) {
+					return;
+				}
+
 				if ( isEmptyBlock( startElement ) && isDeleteAction( keystroke ) ) {
 					startElement.remove();
 

--- a/tests/core/selection/manual/removewidget.html
+++ b/tests/core/selection/manual/removewidget.html
@@ -1,0 +1,29 @@
+<div id="editor1">
+	<img src="data:,"/>deleteme
+</div>
+
+<h2>Inline editor</h2>
+
+<div id="editor2" contenteditable="true" style="border: 1px solid">
+	<img src="data:,"/>deleteme
+</div>
+
+<script>
+	CKEDITOR.plugins.add( 'simple-image-widget', {
+		init: function( editor ) {
+			editor.widgets.add( 'simple-image-widget', {
+				upcast: function( element, data ) {
+					return element.name.toLowerCase() === 'img';
+				}
+			} );
+		}
+	} );
+
+	CKEDITOR.replace( 'editor1', {
+		extraPlugins: 'simple-image-widget'
+	} );
+
+	CKEDITOR.inline( 'editor2', {
+		extraPlugins: 'simple-image-widget, floatingspace'
+	} );
+</script>

--- a/tests/core/selection/manual/removewidget.md
+++ b/tests/core/selection/manual/removewidget.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, bug, 5125
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, floatingspace, image, widget, elementspath, sourcearea
+
+1. Put caret at the end of the `deleteme`.
+2. Remove everything by pressing <kbd>Backspace</kbd> key.
+
+**Expected**
+
+Caret is visible and the editor is usable.
+
+**Unexpected**
+
+Caret is not visible and the editor is not usable anymore.
+
+3. Repeat the above steps for the inline editor.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5125](https://github.com/ckeditor/ckeditor4/issues/5125): Fixed: Deleting a widget with the keyboard removes the whole body.
```

## What changes did you make?

There was an issue with `isEmptyElement` method which only checked if an element contain text. In the fix, I just extended the condition to check if the item doesn't also contain a widget.

## Which issues does your PR resolve?

Closes #5125.
