### PR TITLE
Add focus indicator to the editor

### DIFF
--- a/skins/kama/mainui.css
+++ b/skins/kama/mainui.css
@@ -200,3 +200,13 @@ Special outer level classes used in this file:
 
 	box-sizing: border-box;
 }
+
+/* Slightly move the outline away from the text in inline editables (#5145). */
+.cke_focus.cke_editable {
+	outline-offset: 5px;
+}
+
+/* Add focus indicator (#5145). */
+.cke_focus .cke_contents, .cke_focus.cke_editable {
+	outline: 2px #000 solid;
+}

--- a/skins/moono-lisa/mainui.css
+++ b/skins/moono-lisa/mainui.css
@@ -194,3 +194,18 @@ Special outer level classes used in this file:
 
 	box-sizing: border-box;
 }
+
+/* Add focus indicator (#5145). */
+.cke_focus .cke_contents, .cke_focus.cke_editable {
+	outline: 2px #000 solid;
+}
+
+/* Slightly move the outline away from the text in inline editables (#5145). */
+.cke_focus.cke_editable {
+	outline-offset: 5px;
+}
+
+/* Brutal hack to ensure that outline is correctly visible on bottom of the editable (#5145). */
+.cke_bottom {
+	top: 2px;
+}

--- a/skins/moono/mainui.css
+++ b/skins/moono/mainui.css
@@ -212,3 +212,18 @@ Special outer level classes used in this file:
 
 	box-sizing: border-box;
 }
+
+/* Add focus indicator (#5145). */
+.cke_focus .cke_contents, .cke_focus.cke_editable {
+	outline: 2px #000 solid;
+}
+
+/* Slightly move the outline away from the text in inline editables (#5145). */
+.cke_focus.cke_editable {
+	outline-offset: 5px;
+}
+
+/* Brutal hack to ensure that outline is correctly visible on bottom of the editable (#5145). */
+.cke_bottom {
+	top: 2px;
+}

--- a/tests/core/skin/manual/kamafocus.html
+++ b/tests/core/skin/manual/kamafocus.html
@@ -1,0 +1,30 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>( function() {
+	CKEDITOR.replace( 'wysiwygarea', {
+		skin: 'kama'
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		skin: 'kama',
+		extraPlugins: 'divarea'
+	} );
+
+	CKEDITOR.inline( 'inline', {
+		skin: 'kama'
+	} );
+} )();
+</script>

--- a/tests/core/skin/manual/kamafocus.md
+++ b/tests/core/skin/manual/kamafocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, feature, 5145
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
+@bender-ui: collapsed
+
+1. Focus the editor.
+
+	**Expected** There is visible outline around the editable area.
+
+	**Unexpected** There is no visible outline around the editable area.
+1. Press the <kbd>Alt</kbd>+<kbd>F10</kbd> shortcut to focus the toolbar.
+
+	**Expected** The outline is still visible.
+1. Blur the editor.
+
+	**Expected** The outline disappears.
+1. Repeat the procedure for all editors.

--- a/tests/core/skin/manual/kamareadonlyfocus.html
+++ b/tests/core/skin/manual/kamareadonlyfocus.html
@@ -1,0 +1,33 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>( function() {
+	CKEDITOR.replace( 'wysiwygarea', {
+		skin: 'kama',
+		readOnly: true
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		skin: 'kama',
+		extraPlugins: 'divarea',
+		readOnly: true
+	} );
+
+	CKEDITOR.inline( 'inline', {
+		skin: 'kama',
+		readOnly: true
+	} );
+} )();
+</script>

--- a/tests/core/skin/manual/kamareadonlyfocus.md
+++ b/tests/core/skin/manual/kamareadonlyfocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, feature, 5145
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
+@bender-ui: collapsed
+
+1. Focus the editor.
+
+	**Expected** There is visible outline around the editable area.
+
+	**Unexpected** There is no visible outline around the editable area.
+1. Press the <kbd>Alt</kbd>+<kbd>F10</kbd> shortcut to focus the toolbar.
+
+	**Expected** The outline is still visible.
+1. Blur the editor.
+
+	**Expected** The outline disappears.
+1. Repeat the procedure for all editors.

--- a/tests/core/skin/manual/kamareadonlyfocus.md
+++ b/tests/core/skin/manual/kamareadonlyfocus.md
@@ -2,6 +2,8 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
 @bender-ui: collapsed
 
+Note: focus indicator in the `iframe`-based editor is not visible in Firefox due to [its bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1483828).
+
 1. Focus the editor.
 
 	**Expected** There is visible outline around the editable area.

--- a/tests/core/skin/manual/moonofocus.html
+++ b/tests/core/skin/manual/moonofocus.html
@@ -1,0 +1,30 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>( function() {
+	CKEDITOR.replace( 'wysiwygarea', {
+		skin: 'moono'
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		skin: 'moono',
+		extraPlugins: 'divarea'
+	} );
+
+	CKEDITOR.inline( 'inline', {
+		skin: 'moono'
+	} );
+} )();
+</script>

--- a/tests/core/skin/manual/moonofocus.md
+++ b/tests/core/skin/manual/moonofocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, feature, 5145
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
+@bender-ui: collapsed
+
+1. Focus the editor.
+
+	**Expected** There is visible outline around the editable area.
+
+	**Unexpected** There is no visible outline around the editable area.
+1. Press the <kbd>Alt</kbd>+<kbd>F10</kbd> shortcut to focus the toolbar.
+
+	**Expected** The outline is still visible.
+1. Blur the editor.
+
+	**Expected** The outline disappears.
+1. Repeat the procedure for all editors.

--- a/tests/core/skin/manual/moonolisafocus.html
+++ b/tests/core/skin/manual/moonolisafocus.html
@@ -1,0 +1,30 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>( function() {
+	CKEDITOR.replace( 'wysiwygarea', {
+		skin: 'moono-lisa'
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		skin: 'moono-lisa',
+		extraPlugins: 'divarea'
+	} );
+
+	CKEDITOR.inline( 'inline', {
+		skin: 'moono-lisa'
+	} );
+} )();
+</script>

--- a/tests/core/skin/manual/moonolisafocus.md
+++ b/tests/core/skin/manual/moonolisafocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, feature, 5145
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
+@bender-ui: collapsed
+
+1. Focus the editor.
+
+	**Expected** There is visible outline around the editable area.
+
+	**Unexpected** There is no visible outline around the editable area.
+1. Press the <kbd>Alt</kbd>+<kbd>F10</kbd> shortcut to focus the toolbar.
+
+	**Expected** The outline is still visible.
+1. Blur the editor.
+
+	**Expected** The outline disappears.
+1. Repeat the procedure for all editors.

--- a/tests/core/skin/manual/moonolisareadonlyfocus.html
+++ b/tests/core/skin/manual/moonolisareadonlyfocus.html
@@ -1,0 +1,33 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>( function() {
+	CKEDITOR.replace( 'wysiwygarea', {
+		skin: 'moono-lisa',
+		readOnly: true
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		skin: 'moono-lisa',
+		extraPlugins: 'divarea',
+		readOnly: true
+	} );
+
+	CKEDITOR.inline( 'inline', {
+		skin: 'moono-lisa',
+		readOnly: true
+	} );
+} )();
+</script>

--- a/tests/core/skin/manual/moonolisareadonlyfocus.md
+++ b/tests/core/skin/manual/moonolisareadonlyfocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, feature, 5145
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
+@bender-ui: collapsed
+
+1. Focus the editor.
+
+	**Expected** There is visible outline around the editable area.
+
+	**Unexpected** There is no visible outline around the editable area.
+1. Press the <kbd>Alt</kbd>+<kbd>F10</kbd> shortcut to focus the toolbar.
+
+	**Expected** The outline is still visible.
+1. Blur the editor.
+
+	**Expected** The outline disappears.
+1. Repeat the procedure for all editors.

--- a/tests/core/skin/manual/moonolisareadonlyfocus.md
+++ b/tests/core/skin/manual/moonolisareadonlyfocus.md
@@ -2,6 +2,8 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
 @bender-ui: collapsed
 
+Note: focus indicator in the `iframe`-based editor is not visible in Firefox due to [its bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1483828).
+
 1. Focus the editor.
 
 	**Expected** There is visible outline around the editable area.

--- a/tests/core/skin/manual/moonoreadonlyfocus.html
+++ b/tests/core/skin/manual/moonoreadonlyfocus.html
@@ -1,0 +1,33 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="wysiwygarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="divarea">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<p>Lorem ipsum dolor sit amet.</p>
+</div>
+
+<script>( function() {
+	CKEDITOR.replace( 'wysiwygarea', {
+		skin: 'moono',
+		readOnly: true
+	} );
+
+	CKEDITOR.replace( 'divarea', {
+		skin: 'moono',
+		extraPlugins: 'divarea',
+		readOnly: true
+	} );
+
+	CKEDITOR.inline( 'inline', {
+		skin: 'moono',
+		readOnly: true
+	} );
+} )();
+</script>

--- a/tests/core/skin/manual/moonoreadonlyfocus.md
+++ b/tests/core/skin/manual/moonoreadonlyfocus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.0, feature, 5145
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
+@bender-ui: collapsed
+
+1. Focus the editor.
+
+	**Expected** There is visible outline around the editable area.
+
+	**Unexpected** There is no visible outline around the editable area.
+1. Press the <kbd>Alt</kbd>+<kbd>F10</kbd> shortcut to focus the toolbar.
+
+	**Expected** The outline is still visible.
+1. Blur the editor.
+
+	**Expected** The outline disappears.
+1. Repeat the procedure for all editors.

--- a/tests/core/skin/manual/moonoreadonlyfocus.md
+++ b/tests/core/skin/manual/moonoreadonlyfocus.md
@@ -2,6 +2,8 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, floatingspace, elementspath
 @bender-ui: collapsed
 
+Note: focus indicator in the `iframe`-based editor is not visible in Firefox due to [its bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1483828).
+
 1. Focus the editor.
 
 	**Expected** There is visible outline around the editable area.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5145](https://github.com/ckeditor/ckeditor4/issues/5145): Added a focus indicator to the editor's UI.
```

## What changes did you make?

We already have a mechanism that adds the `.cke_focus` class to the focused editor. I used it to add a 2px black outline to the editable.

I've also ensured that the outline for the inline editor is moved away from the text to make it more readable.

The focus indicator in read-only mode is not present for the `iframe`-based editor unless #5146 is already merged (as it fixes the focusability of such editors).

## Which issues does your PR resolve?

Closes #5145.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
