### PR TITLE
Fix incorrect stripping of ARIA attributes in full-page mode in IE8

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -613,11 +613,11 @@
 					// Remove ARIA attributes during getting data for full-page editing (#1904, #4052).
 					if ( fullPage ) {
 						data = data
-							.replace( /<body(.*?)role="textbox"/, '<body$1' )
-							.replace( /<body(.*?)aria-multiline="true"/, '<body$1' )
-							.replace( /<body(.*?)tabindex="0"/, '<body$1' )
-							.replace( /<body(.*?)aria-label="(.+?)"/, '<body$1' )
-							.replace( /<body(.*?)aria-readonly="(?:true|false)"/, '<body$1' );
+							.replace( /<body(.*?)role="?textbox"?/i, '<body$1' )
+							.replace( /<body(.*?)aria-multiline="?true"?/i, '<body$1' )
+							.replace( /<body(.*?)tabindex="?0"?/i, '<body$1' )
+							.replace( /<body(.*?)aria-label="(.+?)"/i, '<body$1' )
+							.replace( /<body(.*?)aria-readonly="?(?:true|false)"?/i, '<body$1' );
 					}
 
 					data = editor.dataProcessor.toDataFormat( data );

--- a/tests/plugins/wysiwygarea/fullpage.js
+++ b/tests/plugins/wysiwygarea/fullpage.js
@@ -41,6 +41,17 @@
 				baseHref: '/foo/bar/404/',
 				allowedContent: true
 			}
+		},
+		editor_customLabel: {
+			name: 'editor-customLabel',
+			creator: 'replace',
+			config: {
+				docType: '',
+				contentsLangDirection: 'ltr',
+				fullPage: true,
+				contentsCss: [],
+				title: 'custom'
+			}
 		}
 	};
 
@@ -91,6 +102,17 @@
 					// Common problem - ACF :P
 					assert.isTrue( base.getParent().hasAttribute( 'foo' ), 'attribute was not lost' );
 				}
+			} );
+		},
+
+		// (#5190)
+		'test get data from full-page editor with custom one word label': function() {
+			var bot = this.editorBots.editor_customLabel;
+			bender.tools.testInputOut( 'fullpage1', function( source, expected ) {
+				bot.setData( source, function() {
+					assert.areSame( bender.tools.compatHtml( expected ),
+						bot.getData( true ).replace( removeStyle, '' ) );	// remove styles from data
+				} );
 			} );
 		}
 	} );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

N/A

## What changes did you make?

I've updated the regex for stripping ARIA attributes to accommodate IE8's oddities – as it uses uppercase for elements' names and sometimes it skips quotes for attributes' values (probably when they are boolean or numerical; but just to be sure I've added a unit test for one-word editor label).

## Which issues does your PR resolve?

Closes #5190.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
