### PR TITLE
Use raw non-breaking space for an empty `iframe`'s `title`

### DIFF
--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -417,6 +417,7 @@
 			}, this );
 
 			// In case of lack of the title attribute, use non-breaking space.
+			// It needs to be as a raw character because HTML entity can cause issues in IE.
 			this._.docTitle = this.getWindow().getFrame().getAttribute( 'title' ) || '\xa0';
 		},
 

--- a/plugins/wysiwygarea/plugin.js
+++ b/plugins/wysiwygarea/plugin.js
@@ -416,7 +416,8 @@
 				CKEDITOR.tools.setTimeout( onDomReady, 0, this, win );
 			}, this );
 
-			this._.docTitle = this.getWindow().getFrame().getAttribute( 'title' ) || '&nbsp;';
+			// In case of lack of the title attribute, use non-breaking space.
+			this._.docTitle = this.getWindow().getFrame().getAttribute( 'title' ) || '\xa0';
 		},
 
 		base: CKEDITOR.editable,

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -205,7 +205,7 @@
 				try {
 					assert.areSame( '&nbsp;', actualTitleLabel, 'Editor\'s title label is incorrect' );
 				} catch ( e ) {
-					// Some browsers (I'm looking at you, IE8…) can represent the title as a raw character.
+					// IE8 can represent the title as a raw character.
 					assert.areSame( '\xa0', actualTitleLabel, 'Editor\'s title label is incorrect' );
 				}
 			} );

--- a/tests/core/creators/aria.js
+++ b/tests/core/creators/aria.js
@@ -201,7 +201,13 @@
 				assert.isNull( actualApplicationLabel, 'Application label is incorrect' );
 				assert.isNull( actualEditorLabel, 'Editor label is incorrect' );
 				assert.isNull( actualBodyLabel, 'Editor\'s body label is incorrect' );
-				assert.areSame( '&nbsp;', actualTitleLabel, 'Editor\'s title label is incorrect' );
+
+				try {
+					assert.areSame( '&nbsp;', actualTitleLabel, 'Editor\'s title label is incorrect' );
+				} catch ( e ) {
+					// Some browsers (I'm looking at you, IE8…) can represent the title as a raw character.
+					assert.areSame( '\xa0', actualTitleLabel, 'Editor\'s title label is incorrect' );
+				}
 			} );
 		}
 	} );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

N/A

## What changes did you make?

Instead of using `&nbsp;` entity I've used a raw character for setting `iframe`'s `title` when there is no editor label.

## Which issues does your PR resolve?

Closes #5189.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
