### PR TITLE
Remove `tableselection` plugin from `tests/plugins/tab/manual/focusafteraddednewrownative`

### DIFF
--- a/tests/plugins/tab/manual/focusafteraddednewrownative.html
+++ b/tests/plugins/tab/manual/focusafteraddednewrownative.html
@@ -38,8 +38,11 @@
 
 	bender.tools.ignoreUnsupportedEnvironment( 'tableselection' );
 
-	CKEDITOR.replace( 'editor1' );
+	CKEDITOR.replace( 'editor1', {
+		removePlugins: 'tableselection'
+	} );
 	CKEDITOR.inline( 'editor2', {
-		extraPlugins: 'floatingspace'
+		extraPlugins: 'floatingspace',
+		removePlugins: 'tableselection'
 	} );
 </script>


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix for failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

N/A

## What changes did you make?

I've forced the removal of the `tableselection` plugin so the test would use the native selection inside the table.

## Which issues does your PR resolve?

Closes #5198.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
