### PR TITLE
Fix failing test: Ignores test on safari

### DIFF
--- a/tests/plugins/pastefromword/generated/tickets1.js
+++ b/tests/plugins/pastefromword/generated/tickets1.js
@@ -61,6 +61,7 @@
 		customFilters: [
 			pfwTools.filters.span
 		],
-		ignoreAll: ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 ) || bender.tools.env.mobile
+		// Ignores safari due to #5113.
+		ignoreAll: CKEDITOR.env.safari || bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 )
 	} ) );
 } )();

--- a/tests/plugins/pastefromword/generated/tickets2.js
+++ b/tests/plugins/pastefromword/generated/tickets2.js
@@ -57,6 +57,7 @@
 		customFilters: [
 			pfwTools.filters.span
 		],
-		ignoreAll: ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 ) || bender.tools.env.mobile
+		// Ignores safari due to #5113.
+		ignoreAll: CKEDITOR.env.safari || bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 )
 	} ) );
 } )();


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
skip
```

## What changes did you make?

Added `CKEDITOR.env.safari` to be ignored in two tests suites:
- tests/plugins/pastefromword/generated/tickets1
- tests/plugins/pastefromword/generated/tickets2

Also added a proper comment according to: https://github.com/ckeditor/ckeditor4/issues/5113#issuecomment-1148472094

## Which issues does your PR resolve?

Closes #5113 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
