### PR TITLE
Fix #5158 - assure that calculator element is always attached to DOM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Fixed Issues:
 * [#5085](https://github.com/ckeditor/ckeditor4/issues/5085): Fixed: [Language](https://ckeditor.com/cke4/addon/language) plugin removes the element marking the text in foreign language if this element does not have an information about text direction.
 * [#4284](https://github.com/ckeditor/ckeditor4/issues/4284): Fixed: [Tableselection](https://ckeditor.com/cke4/addon/tableselection) Merging cells with a rowspan was throwing error and did not create undo step.
 * [#5184](https://github.com/ckeditor/ckeditor4/issues/5184): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/wysiwygarea) plugin degredates typing performance.
+* [#5158](https://github.com/ckeditor/ckeditor4/issues/5158): Fixed: [tools.convertToPx()](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-convertToPx) gives invalid results in case of DOM manipulations that deleted helper calculator element.
 
 API changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Fixed Issues:
 * [#5085](https://github.com/ckeditor/ckeditor4/issues/5085): Fixed: [Language](https://ckeditor.com/cke4/addon/language) plugin removes the element marking the text in foreign language if this element does not have an information about text direction.
 * [#4284](https://github.com/ckeditor/ckeditor4/issues/4284): Fixed: [Tableselection](https://ckeditor.com/cke4/addon/tableselection) Merging cells with a rowspan was throwing error and did not create undo step.
 * [#5184](https://github.com/ckeditor/ckeditor4/issues/5184): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/wysiwygarea) plugin degredates typing performance.
-* [#5158](https://github.com/ckeditor/ckeditor4/issues/5158): Fixed: [tools.convertToPx()](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-convertToPx) gives invalid results in case of DOM manipulations that deleted helper calculator element.
+* [#5158](https://github.com/ckeditor/ckeditor4/issues/5158): Fixed: [tools.convertToPx()](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-convertToPx) gives invalid results in case helper calculator element was deleted from the DOM.
 
 API changes:
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1002,14 +1002,12 @@
 				boundingClientRect;
 
 			return function( cssLength ) {
-				if ( !calculator ) {
+				// Recreate calculator whenever it was externally manipulated (#5158).
+				if ( !calculator || calculator.isDetached() ) {
 					calculator = CKEDITOR.dom.element.createFromHtml( '<div style="position:absolute;left:-9999px;' +
 						'top:-9999px;margin:0px;padding:0px;border:0px;"' +
 						'></div>', CKEDITOR.document );
-				}
 
-				// (#5158)
-				if ( calculator.isDetached() ) {
 					CKEDITOR.document.getBody().append( calculator );
 				}
 

--- a/core/tools.js
+++ b/core/tools.js
@@ -1006,6 +1006,10 @@
 					calculator = CKEDITOR.dom.element.createFromHtml( '<div style="position:absolute;left:-9999px;' +
 						'top:-9999px;margin:0px;padding:0px;border:0px;"' +
 						'></div>', CKEDITOR.document );
+				}
+
+				// (#5158)
+				if ( calculator.isDetached() ) {
 					CKEDITOR.document.getBody().append( calculator );
 				}
 

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -1113,7 +1113,9 @@
 
 		// (#5158)
 		'test convertToPx works after calculator element was removed': function() {
-			var firstResult = CKEDITOR.tools.convertToPx( '10px' );
+			// Attach calculator element to the DOM.
+			CKEDITOR.tools.convertToPx( '10px' );
+
 			// Based on convertToPx implementation
 			// calculator is the last element under `body` after `convertToPx` invocation.
 			var bodyChildren = CKEDITOR.document.getBody().getChildren(),
@@ -1122,8 +1124,7 @@
 			calculator.remove();
 
 			var result = CKEDITOR.tools.convertToPx( '10px' );
-			assert.areSame( firstResult, result, 'convertToPx() returns different values when helper calculator was removed.' );
-			assert.areSame( result, 10, 'calculator was not properly attached to DOM.' );
+			assert.areEqual( 10, result );
 		},
 
 		'test bind without context and without arguments': function() {

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -1,4 +1,4 @@
-﻿/* bender-tags: editor */
+/* bender-tags: editor */
 
 ( function() {
 	'use strict';
@@ -1122,7 +1122,8 @@
 			calculator.remove();
 
 			var result = CKEDITOR.tools.convertToPx( '10px' );
-			assert.areSame( firstResult, result, 'convertToPx returns different values when helper calculator was removed' );
+			assert.areSame( firstResult, result, 'convertToPx() returns different values when helper calculator was removed.' );
+			assert.areSame( result, 10, 'calculator was not properly attached to DOM.' );
 		},
 
 		'test bind without context and without arguments': function() {

--- a/tests/core/tools.js
+++ b/tests/core/tools.js
@@ -1111,6 +1111,20 @@
 			} );
 		},
 
+		// (#5158)
+		'test convertToPx works after calculator element was removed': function() {
+			var firstResult = CKEDITOR.tools.convertToPx( '10px' );
+			// Based on convertToPx implementation
+			// calculator is the last element under `body` after `convertToPx` invocation.
+			var bodyChildren = CKEDITOR.document.getBody().getChildren(),
+				calculator = bodyChildren.getItem( bodyChildren.count() - 1 );
+
+			calculator.remove();
+
+			var result = CKEDITOR.tools.convertToPx( '10px' );
+			assert.areSame( firstResult, result, 'convertToPx returns different values when helper calculator was removed' );
+		},
+
 		'test bind without context and without arguments': function() {
 			var testSpy = sinon.spy(),
 				bindedFn = CKEDITOR.tools.bind( testSpy );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5158](https://github.com/ckeditor/ckeditor4/issues/5158): Fixed: [tools.convertToPx()](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-convertToPx) keeps returning valid results despite DOM manipulations which might delete helper calculator object.
```

## What changes did you make?

I used our API [method](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html#method-isDetached) to detect whether calculator is really under the DOM. If not: it is reattached.

The only thing I'm worried ☝️ about is there a valid use case that might entirely destroy the underlying object - so we rather should recreate the entire element instead of just reattaching?

Added an automatic test that corresponds to the issue description (https://github.com/ckeditor/ckeditor4/pull/5238/commits/90f916d906a5a193bbced65a275b460e404087f8) - it is failing as expected( without the fix).

And then the fix makes it work. Also added assertion if the conversion is correct. Because if sth goes wrong inside the method because of the introduced attaching the first and second results in test case might be equal (the first assertion passed) - but they will be equal to `0` which is not a correct result. That is why the second assertion was added.

## Which issues does your PR resolve?

Closes #5158.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
