### PR TITLE
dialogui - make .setValue() chainable for checkboxes and radio buttons

### DIFF
--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -1201,6 +1201,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 			setValue: function( checked, noChangeEvent ) {
 				this.getInputElement().$.checked = checked;
 				!noChangeEvent && this.fire( 'change', { value: checked } );
+				return this;
 			},
 
 			/**
@@ -1261,6 +1262,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 				( i < children.length ) && ( item = children[ i ] ); i++ )
 					item.getElement().$.checked = ( item.getValue() == value );
 				!noChangeEvent && this.fire( 'change', { value: value } );
+				return this;
 			},
 
 			/**


### PR DESCRIPTION
## What is the purpose of this pull request?

To make `.setValue()` chainable for checkboxes and radio buttons in the `dialogui` plugin

## Does your PR contain necessary tests?

I don't know how to write a test for something like this.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

I think so…

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5135](https://github.com/ckeditor/ckeditor4/issues/5135): dialogui - make .setValue() chainable for checkboxes and radio buttons
```

## What changes did you make?

I finally got around to making a pull request to make these methods chainable, per https://github.com/ckeditor/ckeditor4/issues/5135#issuecomment-1080024930

## Which issues does your PR resolve?

Closes #5135.