### PR TITLE
Revert "Fix failing test: Ignores test on safari"

### DIFF
--- a/tests/plugins/pastefromword/generated/tickets1.js
+++ b/tests/plugins/pastefromword/generated/tickets1.js
@@ -61,7 +61,6 @@
 		customFilters: [
 			pfwTools.filters.span
 		],
-		// Ignores safari due to #5113.
-		ignoreAll: CKEDITOR.env.safari || bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 )
+		ignoreAll: ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 ) || bender.tools.env.mobile
 	} ) );
 } )();

--- a/tests/plugins/pastefromword/generated/tickets2.js
+++ b/tests/plugins/pastefromword/generated/tickets2.js
@@ -57,7 +57,6 @@
 		customFilters: [
 			pfwTools.filters.span
 		],
-		// Ignores safari due to #5113.
-		ignoreAll: CKEDITOR.env.safari || bender.tools.env.mobile || ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 )
+		ignoreAll: ( CKEDITOR.env.ie && CKEDITOR.env.version <= 11 ) || bender.tools.env.mobile
 	} ) );
 } )();


### PR DESCRIPTION
I mislook the original issue. We didn't intend to disable these tests on Safari but accommodate iPad for testing purposes.

Reverts ckeditor/ckeditor4#5235