### PR TITLE
dialogui - make .setValue() chainable for checkboxes and radio buttons - follow up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ CKEditor 4 Changelog
 Fixed Issues:
 
 * [#5125](https://github.com/ckeditor/ckeditor4/issues/5125): Fixed: Deleting a widget with disabled [autoParagraph](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-autoParagraph) by the keyboard `backspace` key removes editor editable area and crash it.
+* [#5135](https://github.com/ckeditor/ckeditor4/issues/5135): Fixed: [`checkbox.setValue`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_dialog_checkbox.html#method-setValue) and [`radio.setValue`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_dialog_radio.html#method-setValue) methods are not chainable as stated in documentation. Thanks to [Jordan Bradford](https://github.com/LordPachelbel)!
+
 
 ## CKEditor 4.19.0
 

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -1201,6 +1201,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 			setValue: function( checked, noChangeEvent ) {
 				this.getInputElement().$.checked = checked;
 				!noChangeEvent && this.fire( 'change', { value: checked } );
+				return this;
 			},
 
 			/**
@@ -1261,6 +1262,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 				( i < children.length ) && ( item = children[ i ] ); i++ )
 					item.getElement().$.checked = ( item.getValue() == value );
 				!noChangeEvent && this.fire( 'change', { value: value } );
+				return this;
 			},
 
 			/**

--- a/tests/plugins/dialogui/api.js
+++ b/tests/plugins/dialogui/api.js
@@ -1,0 +1,69 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: dialog */
+
+bender.editor = true;
+
+bender.test( {
+	setUp: function() {
+		this.editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog' ) );
+		CKEDITOR.dialog.add( 'testDialog', function() {
+			return {
+				title: 'Test Dialog',
+				contents: [
+					{
+						id: 'info',
+						elements: [
+							{
+								id: 'customRadio',
+								type: 'radio',
+								label: 'radio',
+								items: [
+									[ 'Test0', 'Test0', 'Test0' ],
+									[ 'Test1', 'Test1', 'Test1' ],
+									[ 'Test2', 'Test2', 'Test2' ]
+								]
+							},
+							{
+								id: 'customCheckbox',
+								type: 'checkbox',
+								label: 'checkbox'
+							}
+						]
+					}
+				]
+			};
+		} );
+	},
+
+	// (#5135)
+	'test radio#setValue should be chainable': function() {
+		var bot = this.editorBot;
+
+		bot.dialog( 'testDialog', function( dialog ) {
+			var field = dialog.getContentElement( 'info', 'customRadio' );
+
+			field.setValue( 'Test1' ).setValue( 'Test2' );
+
+			assert.areEqual( 'Test2', field.getValue() );
+
+			// Close dialog.
+			dialog.getButton( 'ok' ).click();
+		} );
+	},
+
+	// (#5135)
+	'test checkbox#setValue should be chainable': function() {
+		var bot = this.editorBot;
+
+		bot.dialog( 'testDialog', function( dialog ) {
+			var field = dialog.getContentElement( 'info', 'customCheckbox' );
+
+			field.setValue( true ).setValue( false );
+
+			assert.isFalse( field.getValue() );
+
+			// Close dialog.
+			dialog.getButton( 'ok' ).click();
+		} );
+	}
+} );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5135](https://github.com/ckeditor/ckeditor4/issues/5135): dialogui - make .setValue() chainable for checkboxes and radio buttons

```

## What changes did you make?

That's a follow-up PR to https://github.com/ckeditor/ckeditor4/pull/5239 with required test coverage.

## Which issues does your PR resolve?

Closes #5135
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
