### PR TITLE
Add keystroke handlings for `elementspath` and `toolbar` plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixed Issues:
 * [#5184](https://github.com/ckeditor/ckeditor4/issues/5184): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/wysiwygarea) plugin degredates typing performance.
 * [#5158](https://github.com/ckeditor/ckeditor4/issues/5158): Fixed: [`CKEDITOR.tools#convertToPx()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-convertToPx) gives invalid results in case helper calculator element was deleted from the DOM.
 * [#5234](https://github.com/ckeditor/ckeditor4/issues/5234): Fixed: [Easy Image](https://ckeditor.com/cke4/addon/easyimage) Upload file by using toolbar easyimage button was impossible.
+* [#438](https://github.com/ckeditor/ckeditor4/issues/438): Fixed: It is impossible to navigate to the [elementspath](https://ckeditor.com/cke4/addon/elementspath) from the [toolbar](https://ckeditor.com/cke4/addon/toolbar) by keyboard and vice versa.
 
 API changes:
 

--- a/plugins/elementspath/plugin.js
+++ b/plugins/elementspath/plugin.js
@@ -151,6 +151,9 @@
 					case 32: // SPACE
 						onClick( elementIndex );
 						return false;
+					case CKEDITOR.ALT + 121: // ALT + F10 (#438).
+						editor.execCommand( 'toolbarFocus' );
+						return false;
 				}
 				return true;
 			} );

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -154,6 +154,9 @@
 						case 32: // SPACE
 							item.execute();
 							return false;
+						case CKEDITOR.ALT + 122: // ALT + F11 (#438).
+							editor.execCommand( 'elementsPathFocus' );
+							return false;
 					}
 					return true;
 				};

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1278,6 +1278,32 @@
 				mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
 				element.dispatchEvent( mouseEvent );
 			}
+		},
+
+		/**
+		 * Fires element event handler attribute e.g.
+		 * ```html <button onkeydown="return customFn( event )">x</button>```
+		 *
+		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
+		 * @param {String} eventName Event handler attribute name.
+		 * @param {Object} evt Event payload.
+		*/
+		fireElementEventHandler: function( element, eventName, evt ) {
+			if ( element.$ ) {
+				element = element.$;
+			}
+
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
+				var nativeEvent = CKEDITOR.document.$.createEventObject();
+
+				for ( var key in evt ) {
+					nativeEvent[ key ] = evt[ key ];
+				}
+
+				element.fireEvent( eventName, nativeEvent );
+			} else {
+				element[ eventName ]( evt );
+			}
 		}
 	};
 

--- a/tests/_benderjs/ckeditor/static/tools.js
+++ b/tests/_benderjs/ckeditor/static/tools.js
@@ -1278,32 +1278,6 @@
 				mouseEvent.initMouseEvent( type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, button, null );
 				element.dispatchEvent( mouseEvent );
 			}
-		},
-
-		/**
-		 * Fires element event handler attribute e.g.
-		 * ```html <button onkeydown="return customFn( event )">x</button>```
-		 *
-		 * @param {CKEDITOR.dom.element/HTMLElement} element Element with attached event handler attribute.
-		 * @param {String} eventName Event handler attribute name.
-		 * @param {Object} evt Event payload.
-		*/
-		fireElementEventHandler: function( element, eventName, evt ) {
-			if ( element.$ ) {
-				element = element.$;
-			}
-
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 ) {
-				var nativeEvent = CKEDITOR.document.$.createEventObject();
-
-				for ( var key in evt ) {
-					nativeEvent[ key ] = evt[ key ];
-				}
-
-				element.fireEvent( eventName, nativeEvent );
-			} else {
-				element[ eventName ]( evt );
-			}
 		}
 	};
 

--- a/tests/plugins/elementspath/elementspath.js
+++ b/tests/plugins/elementspath/elementspath.js
@@ -54,10 +54,11 @@
 			this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
 			var pathUIPart = editor.ui.space( 'path' ).getFirst();
 
-			bender.tools.fireElementEventHandler( pathUIPart, 'onkeydown', {
+			pathUIPart.fireEventHandler( 'keydown', {
 				keyCode: F10,
 				altKey: true
 			} );
+
 			commandSpy.restore();
 			assert.isTrue( commandSpy.calledWith( 'toolbarFocus' ) );
 		},
@@ -70,7 +71,9 @@
 			this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
 			var pathUIPart = editor.ui.space( 'path' ).getFirst();
 
-			bender.tools.fireElementEventHandler( pathUIPart, 'onkeydown', { keyCode: ESC } );
+			pathUIPart.fireEventHandler( 'keydown', {
+				keyCode: ESC
+			} );
 
 			focusSpy.restore();
 			assert.isTrue( focusSpy.calledOnce );

--- a/tests/plugins/elementspath/elementspath.js
+++ b/tests/plugins/elementspath/elementspath.js
@@ -1,9 +1,12 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: elementspath */
+/* bender-ckeditor-plugins: elementspath, toolbar, basicstyles */
 /* global elementspathTestsTools */
 
 ( function() {
 	'use strict';
+
+	var F10 = 121,
+		ESC = 27;
 
 	// Elements path feature is only available in themed UI creators.
 	bender.editor = { creator: 'replace' };
@@ -41,6 +44,36 @@
 				assert.areEqual( 'false', element.getAttribute( 'draggable' ), 'Element draggable attribute value.' );
 				assert.areEqual( 'return false;', element.getAttribute( 'ondragstart' ), 'Element ondragstart attribute value.' );
 			} );
+		},
+
+		// (#438)
+		'test focusing toolbar': function() {
+			var editor = this.editor,
+				commandSpy = sinon.spy( editor, 'execCommand' );
+
+			this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
+			var pathUIPart = editor.ui.space( 'path' ).getFirst();
+
+			bender.tools.fireElementEventHandler( pathUIPart, 'onkeydown', {
+				keyCode: F10,
+				altKey: true
+			} );
+			commandSpy.restore();
+			assert.isTrue( commandSpy.calledWith( 'toolbarFocus' ) );
+		},
+
+		// (#438)
+		'test focusing editor': function() {
+			var editor = this.editor,
+				focusSpy = sinon.spy( editor, 'focus' );
+
+			this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
+			var pathUIPart = editor.ui.space( 'path' ).getFirst();
+
+			bender.tools.fireElementEventHandler( pathUIPart, 'onkeydown', { keyCode: ESC } );
+
+			focusSpy.restore();
+			assert.isTrue( focusSpy.calledOnce );
 		}
 	} );
 } )();

--- a/tests/plugins/elementspath/manual/focus.html
+++ b/tests/plugins/elementspath/manual/focus.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Click here to focus the editor.</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/elementspath/manual/focus.md
+++ b/tests/plugins/elementspath/manual/focus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.1, 438, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, elementspath
+
+1. Focus the editor.
+2. Focus elements path by pressing `ALT + F11`.
+
+**Expected:** Elementspath is focused.
+
+**Unexpected:** Elementspath is not focused.
+
+3. Press `ALT + F10`.
+
+**Expected:** Toolbar is focused.
+
+**Unexpected:** Toolbar is not focused.

--- a/tests/plugins/toolbar/basic.js
+++ b/tests/plugins/toolbar/basic.js
@@ -33,6 +33,9 @@ bender.editor = {
 	}
 };
 
+var F11 = 122,
+	ESC = 27;
+
 bender.test( {
 	'test toolbar': function() {
 		assert.isNotNull( this.editor.ui.space( 'toolbox' ) );
@@ -123,5 +126,39 @@ bender.test( {
 				assert.areSame( resizeData[ 0 ].outerHeight, resizeData[ 2 ].outerHeight, 'Height should properly restore to same value.' );
 			}
 		);
+	},
+
+	// (#438)
+	'test focusing elements path': function() {
+		var editor = this.editor,
+			commandSpy = sinon.spy( editor, 'execCommand' ),
+			toolboxUIPart = editor.ui.space( 'toolbox' ).findOne( '.cke_button' );
+
+		this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
+
+		// ALT + F11
+		bender.tools.fireElementEventHandler( toolboxUIPart, 'onkeydown', {
+			keyCode: F11,
+			altKey: true
+		} );
+
+		commandSpy.restore();
+		assert.isTrue( commandSpy.calledWith( 'elementsPathFocus' ) );
+	},
+
+	// (#438)
+	'test focusing editor': function() {
+		var editor = this.editor,
+			focusSpy = sinon.spy( editor, 'focus' ),
+			toolboxUIPart = editor.ui.space( 'toolbox' ).findOne( '.cke_button' );
+
+		this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
+
+		bender.tools.fireElementEventHandler( toolboxUIPart, 'onkeydown', {
+			keyCode: ESC
+		} );
+
+		focusSpy.restore();
+		assert.isTrue( focusSpy.calledOnce );
 	}
 } );

--- a/tests/plugins/toolbar/basic.js
+++ b/tests/plugins/toolbar/basic.js
@@ -137,7 +137,7 @@ bender.test( {
 		this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
 
 		// ALT + F11
-		bender.tools.fireElementEventHandler( toolboxUIPart, 'onkeydown', {
+		toolboxUIPart.fireEventHandler( 'keydown', {
 			keyCode: F11,
 			altKey: true
 		} );
@@ -154,7 +154,7 @@ bender.test( {
 
 		this.editorBot.setHtmlWithSelection( '<b>f^oo</b>' );
 
-		bender.tools.fireElementEventHandler( toolboxUIPart, 'onkeydown', {
+		toolboxUIPart.fireEventHandler( 'keydown', {
 			keyCode: ESC
 		} );
 

--- a/tests/plugins/toolbar/manual/focus.html
+++ b/tests/plugins/toolbar/manual/focus.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Click here to focus the editor.</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/toolbar/manual/focus.md
+++ b/tests/plugins/toolbar/manual/focus.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.19.1, 438, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, elementspath
+
+1. Focus the editor.
+2.  Focus toolbar by pressing `ALT + F10`.
+
+**Expected:** Toolbar is focused.
+
+**Unexpected:** Toolbar is not focused.
+
+3. Press `ALT + F11`.
+
+**Expected:** Elementspath is focused.
+
+**Unexpected:** Elementspath is not focused.

--- a/tests/plugins/toolbar/manual/focus.md
+++ b/tests/plugins/toolbar/manual/focus.md
@@ -3,7 +3,7 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, elementspath
 
 1. Focus the editor.
-2.  Focus toolbar by pressing `ALT + F10`.
+2. Focus toolbar by pressing `ALT + F10`.
 
 **Expected:** Toolbar is focused.
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#438](https://github.com/ckeditor/ckeditor4/issues/438): Fixed: There was impossible to navigate to the [elementspath](https://ckeditor.com/cke4/addon/elementspath) from the [toolbar](https://ckeditor.com/cke4/addon/toolbar) by keyboard and vice versa.  
```

## What changes did you make?

The solution was taken from: https://github.com/ckeditor/ckeditor4/pull/2412 PR.
I just extracted the helper function to `bender` tools and adjusted a little the manual tests.

## Which issues does your PR resolve?

Closes #438.
