### PR TITLE
Fix: dialog validators  accept value only from inner getValue method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,14 +16,13 @@ Fixed Issues:
 * [#5234](https://github.com/ckeditor/ckeditor4/issues/5234): Fixed: [Easy Image](https://ckeditor.com/cke4/addon/easyimage) can't be uploaded using toolbar button.
 * [#438](https://github.com/ckeditor/ckeditor4/issues/438): Fixed: It is impossible to navigate to the [elementspath](https://ckeditor.com/cke4/addon/elementspath) from the [toolbar](https://ckeditor.com/cke4/addon/toolbar) by keyboard and vice versa.
 * [#4449](https://github.com/ckeditor/ckeditor4/issues/4449): Fixed: [`dialog.validate#functions`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions) incorrectly composes functions that returns an optional error message, like e.g. [`dialog.validate.number`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-number) due to unnecessary return type coercion.
-* [#4473](https://github.com/ckeditor/ckeditor4/issues/4473): Fix: [dialog.validate methods](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html) does not accept parameter value. Affected validators:
-	* [equals](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-equals)
-	* [notEqual](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-notEqual)
-	* [cssLength](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-cssLength)
-	* [htmlLength](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-htmlLength)
-	* [inlineStyle](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-inlineStyle)
-The issue originated in [dialog.validate.functions](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions) method that didn't properly propagate parameter value to validator and has been also patched.
-
+* [#4473](https://github.com/ckeditor/ckeditor4/issues/4473): Fixed: [dialog.validate](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html) methods does not accept parameter value. The issue originated in [dialog.validate.functions](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions) method that did not properly propagate parameter value to validator. Affected validators:
+	* [`functions`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions)
+	* [`equals`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-equals)
+	* [`notEqual`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-notEqual)
+	* [`cssLength`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-cssLength)
+	* [`htmlLength`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-htmlLength)
+	* [`inlineStyle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-inlineStyle)
 
 API changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,11 +11,18 @@ Fixed Issues:
 * [#5135](https://github.com/ckeditor/ckeditor4/issues/5135): Fixed: [`checkbox.setValue`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_dialog_checkbox.html#method-setValue) and [`radio.setValue`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_dialog_radio.html#method-setValue) methods are not chainable as stated in documentation. Thanks to [Jordan Bradford](https://github.com/LordPachelbel)!
 * [#5085](https://github.com/ckeditor/ckeditor4/issues/5085): Fixed: [Language](https://ckeditor.com/cke4/addon/language) plugin removes the element marking the text in foreign language if this element does not have an information about text direction.
 * [#4284](https://github.com/ckeditor/ckeditor4/issues/4284): Fixed: [Tableselection](https://ckeditor.com/cke4/addon/tableselection) Merging cells with a rowspan throws unexpected error and does not create undo step.
-* [#5184](https://github.com/ckeditor/ckeditor4/issues/5184): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/wysiwygarea) plugin degredates typing performance.
+* [#5184](https://github.com/ckeditor/ckeditor4/issues/5184): Fixed: [Editor Placeholder](https://ckeditor.com/cke4/addon/wysiwygarea) plugin degradates typing performance.
 * [#5158](https://github.com/ckeditor/ckeditor4/issues/5158): Fixed: [`CKEDITOR.tools#convertToPx()`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_tools.html#method-convertToPx) gives invalid results in case helper calculator element was deleted from the DOM.
 * [#5234](https://github.com/ckeditor/ckeditor4/issues/5234): Fixed: [Easy Image](https://ckeditor.com/cke4/addon/easyimage) can't be uploaded using toolbar button.
 * [#438](https://github.com/ckeditor/ckeditor4/issues/438): Fixed: It is impossible to navigate to the [elementspath](https://ckeditor.com/cke4/addon/elementspath) from the [toolbar](https://ckeditor.com/cke4/addon/toolbar) by keyboard and vice versa.
 * [#4449](https://github.com/ckeditor/ckeditor4/issues/4449): Fixed: [`dialog.validate#functions`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions) incorrectly composes functions that returns an optional error message, like e.g. [`dialog.validate.number`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-number) due to unnecessary return type coercion.
+* [#4473](https://github.com/ckeditor/ckeditor4/issues/4473): Fix: [dialog.validate methods](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html) does not accept parameter value. Affected validators:
+	* [equals](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-equals)
+	* [notEqual](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-notEqual)
+	* [cssLength](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-cssLength)
+	* [htmlLength](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-htmlLength)
+	* [inlineStyle](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-inlineStyle)
+The issue originated in [dialog.validate.functions](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions) method that didn't properly propagate parameter value to validator and has been also patched.
 
 
 API changes:

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3292,7 +3292,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			 */
 			regex: function( regex, msg ) {
 				return this.functions( function( val ) {
-					return !regex.test( val ) ? msg : true;
+					return regex.test( val );
 				}, msg );
 			},
 
@@ -3312,7 +3312,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					var trimCharacters = '\\u0020\\u00a0\\u1680\\u202f\\u205f\\u3000\\u2000-\\u200a\\s',
 						trimRegex = new RegExp( '^[' + trimCharacters + ']+|[' + trimCharacters + ']+$', 'g' );
 
-					return val.replace( trimRegex, '' ).length > 0 || msg;
+					return val.replace( trimRegex, '' ).length > 0;
 				}, msg );
 			},
 

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3279,7 +3279,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			 * Checks if a dialog UI element value meets the regex condition.
 			 *
 			 * ```javascript
-			 * CKEDITOR.dialog.validate.regex( 'error!', /^\d*$/ )( '123' ) // true
+			 * CKEDITOR.dialog.validate.regex( /^\d*$/, 'error!' )( '123' ) // true
 			 * CKEDITOR.dialog.validate.regex( 'error!' )( '123.321' ) // error!
 			 * ```
 			 *

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3291,14 +3291,9 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			 * @returns {Function} Validation function.
 			 */
 			regex: function( regex, msg ) {
-				/*
-				 * Can be greatly shortened by deriving from functions validator if code size
-				 * turns out to be more important than performance.
-				 */
-				return function() {
-					var value = this && this.getValue ? this.getValue() : arguments[ 0 ];
-					return !regex.test( value ) ? msg : true;
-				};
+				return this.functions( function( val ) {
+					return !regex.test( val ) ? msg : true;
+				}, msg );
 			},
 
 			/**
@@ -3313,14 +3308,12 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			 * @returns {Function} Validation function.
 			 */
 			notEmpty: function( msg ) {
-				var trimCharacters = '\\u0020\\u00a0\\u1680\\u202f\\u205f\\u3000\\u2000-\\u200a\\s',
-					trimRegex = new RegExp( '^[' + trimCharacters + ']+|[' + trimCharacters + ']+$', 'g' );
+				return this.functions( function( val ) {
+					var trimCharacters = '\\u0020\\u00a0\\u1680\\u202f\\u205f\\u3000\\u2000-\\u200a\\s',
+						trimRegex = new RegExp( '^[' + trimCharacters + ']+|[' + trimCharacters + ']+$', 'g' );
 
-				return function() {
-					var value = this && this.getValue ? this.getValue() : arguments[ 0 ];
-
-					return value.replace( trimRegex, '' ).length > 0 || msg;
-				};
+					return val.replace( trimRegex, '' ).length > 0 || msg;
+				}, msg );
 			},
 
 			/**

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3224,12 +3224,14 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			 */
 			functions: function() {
 				var args = arguments;
-				return function() {
+				return function( value ) {
 					// It's important for validate functions to be able to accept the value
 					// as argument in addition to this.getValue(), so that it is possible to
 					// combine validate functions together to make more sophisticated
 					// validators.
-					var value = this && this.getValue ? this.getValue() : arguments[ 0 ];
+					if ( this && this.getValue ) {
+						value = this.getValue();
+					}
 
 					var msg,
 						relation = CKEDITOR.VALIDATE_AND,

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3229,7 +3229,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 					// as argument in addition to this.getValue(), so that it is possible to
 					// combine validate functions together to make more sophisticated
 					// validators.
-					var value = this && this.getValue ? this.getValue() : args[ 0 ];
+					var value = this && this.getValue ? this.getValue() : arguments[ 0 ];
 
 					var msg,
 						relation = CKEDITOR.VALIDATE_AND,

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3280,7 +3280,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			 *
 			 * ```javascript
 			 * CKEDITOR.dialog.validate.regex( /^\d*$/, 'error!' )( '123' ) // true
-			 * CKEDITOR.dialog.validate.regex( 'error!' )( '123.321' ) // error!
+			 * CKEDITOR.dialog.validate.regex( /^\d*$/, 'error!' )( '123.321' ) // error!
 			 * ```
 			 *
 			 * @param {RegExp} regex Regular expression used to validate the value.

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -3239,10 +3239,11 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 						i;
 
 					for ( i = 0; i < args.length; i++ ) {
-						if ( typeof args[ i ] == 'function' )
+						if ( typeof args[ i ] == 'function' ) {
 							functions.push( args[ i ] );
-						else
+						} else {
 							break;
+						}
 					}
 
 					if ( i < args.length && typeof args[ i ] == 'string' ) {

--- a/tests/plugins/dialog/functions.js
+++ b/tests/plugins/dialog/functions.js
@@ -6,11 +6,11 @@ bender.test( {
 		var testValue = 'value',
 			stubValidator = sinon.stub().returns( true );
 
-		validateFunctions( testValue, [
+		CKEDITOR.dialog.validate.functions(
 			stubValidator,
 			stubValidator,
 			stubValidator
-		] );
+		)( testValue );
 
 		assert.areSame( stubValidator.callCount, 3, 'Validator should be called 3 times.' );
 		assert.isTrue( stubValidator.calledWith( testValue ), 'Validator should be called with "' + testValue + '".' );
@@ -19,11 +19,11 @@ bender.test( {
 	'test functions returns true if all inner validators returns true - joined with default VALIDATE_AND': function() {
 		var stubValidator = sinon.stub().returns( true );
 
-		var result = validateFunctions( 'any value', [
+		var result = CKEDITOR.dialog.validate.functions(
 			stubValidator,
 			stubValidator,
 			stubValidator
-		] );
+		)( 'any value' );
 
 		assert.isTrue( result );
 	},
@@ -34,11 +34,11 @@ bender.test( {
 			stubFalseValidator = sinon.stub().returns( 'error message' ),
 			errorMsg = 'error!';
 
-		var result = validateFunctions( 'any value', [
+		var result = CKEDITOR.dialog.validate.functions(
 			stubTrueValidator,
 			stubFalseValidator,
 			errorMsg
-		] );
+		)( 'any value' );
 
 		assert.areSame( errorMsg, result );
 	},
@@ -47,12 +47,12 @@ bender.test( {
 		var stubTrueValidator = sinon.stub().returns( true ),
 			stubFalseValidator = sinon.stub().returns( false );
 
-		var result = validateFunctions( 'any value', [
+		var result = CKEDITOR.dialog.validate.functions(
 			stubTrueValidator,
 			stubFalseValidator,
 			'error message',
 			CKEDITOR.VALIDATE_OR
-		] );
+		)( 'any value' );
 
 		assert.isTrue( result );
 	},
@@ -61,26 +61,27 @@ bender.test( {
 		var stubFalseValidator = sinon.stub().returns( 'error message' ),
 			errorMsg = 'error!';
 
-		var result = validateFunctions( 'any value', [
+		var result = CKEDITOR.dialog.validate.functions(
 			stubFalseValidator,
 			stubFalseValidator,
 			errorMsg,
 			CKEDITOR.VALIDATE_OR
-		] );
+		)( 'any value' );
 
 		assert.areSame( errorMsg, result );
+	},
+
+	'test functions favor getValue context method instead of value parameter': function() {
+		var stubValidator = sinon.stub().returns( true ),
+			context = {
+				getValue: function() {
+					return 'getValue';
+				}
+			};
+
+		CKEDITOR.dialog.validate.functions( stubValidator ).call( context, 'value' );
+
+		assert.areSame( stubValidator.callCount, 1, 'Validator should be called once.' );
+		assert.isTrue( stubValidator.calledWith( 'getValue' ), 'Validator should use "getValue" value.' );
 	}
 } );
-
-function validateFunctions( value, functions ) {
-	// Use that validator context to stub `getValue` method.
-	var context = {
-		getValue: function() {
-			return value;
-		}
-	};
-
-	var validator = CKEDITOR.dialog.validate.functions.apply( null, functions );
-
-	return validator.apply( context );
-}

--- a/tests/plugins/dialog/validatorinlinestyle.js
+++ b/tests/plugins/dialog/validatorinlinestyle.js
@@ -8,85 +8,67 @@ bender.test( {
 
 	tearDown: function() {
 		this.inlineStyleValidator = null;
-		this.getValue = null;
 	},
 
 	'test empty styles validates to true': function() {
-		setupValueGetter( '', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator( '' ) );
 	},
 
 	'test valid styles validates to true': function() {
-		setupValueGetter( 'height: 10px; width: 20px;', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator( 'height: 10px; width: 20px;' ) );
 	},
 
 	'test valid styles (no spacing) validates to true': function() {
-		setupValueGetter( 'height:10px;width:20px;', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator( 'height:10px;width:20px;' ) );
 	},
 
 	'test valid styles (additional spacing, missing ; at the end) validates to true': function() {
-		setupValueGetter( '  height:     10px; width:         20px', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator( '  height:     10px; width:         20px' ) );
 	},
 
 	'test valid styles (long version) validates to true': function() {
-		setupValueGetter( 'font-family: \'Arial\', \'Helvetica\', sans-serif; font-size: 14px; position: absolute; top: 0; right: 0;' +
-			'width: 100%; list-style-type: none; margin: 0; padding: 56px 0 0; z-index: 1000; text-shadow: none;', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator(
+			'font-family: \'Arial\', \'Helvetica\', sans-serif; font-size: 14px; position: absolute; top: 0; right: 0;' +
+			'width: 100%; list-style-type: none; margin: 0; padding: 56px 0 0; z-index: 1000; text-shadow: none;'
+		) );
 	},
 
 	'test valid styles (long version with no \' escaping) validates to true': function() {
-		setupValueGetter( "font-family: 'Arial', 'Helvetica', sans-serif; font-size: 14px; position: absolute; top: 0; right: 0;" +
-			'width: 100%; list-style-type: none; margin: 0; padding: 56px 0 0; z-index: 1000; text-shadow: none;', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator(
+			"font-family: 'Arial', 'Helvetica', sans-serif; font-size: 14px; position: absolute; top: 0; right: 0;" +
+			'width: 100%; list-style-type: none; margin: 0; padding: 56px 0 0; z-index: 1000; text-shadow: none;'
+		) );
 	},
 
 	'test valid styles validates to true (edge case #1)': function() {
-		setupValueGetter( '\\9: bar;', this );
-		assert.isTrue( this.inlineStyleValidator() );
+		assert.isTrue( this.inlineStyleValidator( '\\9: bar;' ) );
 	},
 
 	'test invalid styles returns error message': function() {
-		setupValueGetter( 'test', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( 'test' ), 'Invalid inline styles!' );
 	},
 
 	'test valid styles but with duplicated ; returns error message': function() {
-		setupValueGetter( 'height: 10px;; width: 20px;', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( 'height: 10px;; width: 20px;' ), 'Invalid inline styles!' );
 	},
 
 	'test valid styles but with duplicated : returns error message': function() {
-		setupValueGetter( 'height:: 10px;', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( 'height:: 10px;' ), 'Invalid inline styles!' );
 	},
 
 	'test invalid styles returns error message (edge case #1)': function() {
-		setupValueGetter( '-: foo;', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( '-: foo;' ), 'Invalid inline styles!' );
 	},
 
 	'test invalid styles returns error message (edge case #2)': function() {
-		setupValueGetter( '9: bar;', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( '9: bar;' ), 'Invalid inline styles!' );
 	},
 
 	'test invalid styles returns error message (edge case #3)': function() {
-		setupValueGetter( 'foo: ;', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( 'foo: ;' ), 'Invalid inline styles!' );
 	},
 
 	'test invalid styles returns error message (edge case #4)': function() {
-		setupValueGetter( 'foo: ', this );
-		assert.areEqual( this.inlineStyleValidator(), 'Invalid inline styles!' );
+		assert.areEqual( this.inlineStyleValidator( 'foo' ), 'Invalid inline styles!' );
 	}
 } );
-
-// Setup `getValue()` method for the current context due to #4473.
-function setupValueGetter( value, context ) {
-	context.getValue = function() {
-		return value;
-	};
-}

--- a/tests/plugins/dialog/validators.js
+++ b/tests/plugins/dialog/validators.js
@@ -77,7 +77,7 @@ bender.test( {
 
 	'test validator regex should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.regex( /^\d*$/, errorMsg )( '123' );
-		var negativeResult = CKEDITOR.dialog.validate.regex( errorMsg )( '123.321' );
+		var negativeResult = CKEDITOR.dialog.validate.regex( /^\d*$/, errorMsg )( '123.321' );
 
 		assert.isTrue( result );
 		assert.areSame( errorMsg, negativeResult );

--- a/tests/plugins/dialog/validators.js
+++ b/tests/plugins/dialog/validators.js
@@ -1,0 +1,87 @@
+/* bender-tags: editor, dialog, 4473 */
+/* bender-ckeditor-plugins: dialog */
+
+var errorMsg = errorMsg;
+
+bender.test( {
+	// (#4473)
+	'test validator cssLength should accept passed argument': function () {
+		var positiveResult = CKEDITOR.dialog.validate.cssLength( errorMsg )( '10pt' );
+		var negativeResult = CKEDITOR.dialog.validate.cssLength( errorMsg )( 'solid' );
+
+		assert.isTrue( positiveResult );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	// (#4473)
+	'test validator htmlLength should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.htmlLength( errorMsg )( '10px' );
+		var negativeResult = CKEDITOR.dialog.validate.htmlLength( errorMsg )( 'solid' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	// (#4473)
+	'test validator equals should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.equals( 'foo', errorMsg )( 'foo' );
+		var negativeResult = CKEDITOR.dialog.validate.equals( 'foo', errorMsg )( 'baz' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	// (#4473)
+	'test validator notEqual should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.notEqual( 'foo', errorMsg )( 'baz' );
+		var negativeResult = CKEDITOR.dialog.validate.notEqual( 'foo', errorMsg )( 'foo' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	// (#4473)
+	'test validator inlineStyle should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.inlineStyle( errorMsg )( 'height: 10px; width: 20px;' );
+		var resultFromEmpty = CKEDITOR.dialog.validate.inlineStyle( errorMsg )( '' );
+		var negativeResult = CKEDITOR.dialog.validate.inlineStyle( errorMsg )( 'test' );
+
+		assert.isTrue( result );
+		assert.isTrue( resultFromEmpty );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	'test validator integer should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.integer( errorMsg )( '123' );
+		var negativeResult = CKEDITOR.dialog.validate.integer( errorMsg )( '123.321' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	'test validator notEmpty should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.notEmpty( errorMsg )( 'test' );
+		var negativeResult = CKEDITOR.dialog.validate.notEmpty( errorMsg )( '  ' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	'test validator number should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.number( errorMsg )( '123' );
+		var negativeResult = CKEDITOR.dialog.validate.number( errorMsg )( 'test' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	},
+
+	'test validator regex should accept passed argument': function () {
+		var result = CKEDITOR.dialog.validate.regex( /^\d*$/, errorMsg )( '123' );
+		var negativeResult = CKEDITOR.dialog.validate.regex( errorMsg )( '123.321' );
+
+		assert.isTrue( result );
+		assert.areSame( errorMsg, negativeResult );
+	}
+} );
+
+

--- a/tests/plugins/dialog/validators.js
+++ b/tests/plugins/dialog/validators.js
@@ -1,11 +1,11 @@
 /* bender-tags: editor, dialog, 4473 */
 /* bender-ckeditor-plugins: dialog */
 
-var errorMsg = errorMsg;
+var errorMsg = 'error!';
 
 bender.test( {
 	// (#4473)
-	'test validator cssLength should accept passed argument': function () {
+	'test validator cssLength should accept passed argument': function() {
 		var positiveResult = CKEDITOR.dialog.validate.cssLength( errorMsg )( '10pt' );
 		var negativeResult = CKEDITOR.dialog.validate.cssLength( errorMsg )( 'solid' );
 
@@ -14,7 +14,7 @@ bender.test( {
 	},
 
 	// (#4473)
-	'test validator htmlLength should accept passed argument': function () {
+	'test validator htmlLength should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.htmlLength( errorMsg )( '10px' );
 		var negativeResult = CKEDITOR.dialog.validate.htmlLength( errorMsg )( 'solid' );
 
@@ -23,7 +23,7 @@ bender.test( {
 	},
 
 	// (#4473)
-	'test validator equals should accept passed argument': function () {
+	'test validator equals should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.equals( 'foo', errorMsg )( 'foo' );
 		var negativeResult = CKEDITOR.dialog.validate.equals( 'foo', errorMsg )( 'baz' );
 
@@ -32,7 +32,7 @@ bender.test( {
 	},
 
 	// (#4473)
-	'test validator notEqual should accept passed argument': function () {
+	'test validator notEqual should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.notEqual( 'foo', errorMsg )( 'baz' );
 		var negativeResult = CKEDITOR.dialog.validate.notEqual( 'foo', errorMsg )( 'foo' );
 
@@ -41,7 +41,7 @@ bender.test( {
 	},
 
 	// (#4473)
-	'test validator inlineStyle should accept passed argument': function () {
+	'test validator inlineStyle should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.inlineStyle( errorMsg )( 'height: 10px; width: 20px;' );
 		var resultFromEmpty = CKEDITOR.dialog.validate.inlineStyle( errorMsg )( '' );
 		var negativeResult = CKEDITOR.dialog.validate.inlineStyle( errorMsg )( 'test' );
@@ -51,7 +51,7 @@ bender.test( {
 		assert.areSame( errorMsg, negativeResult );
 	},
 
-	'test validator integer should accept passed argument': function () {
+	'test validator integer should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.integer( errorMsg )( '123' );
 		var negativeResult = CKEDITOR.dialog.validate.integer( errorMsg )( '123.321' );
 
@@ -59,7 +59,7 @@ bender.test( {
 		assert.areSame( errorMsg, negativeResult );
 	},
 
-	'test validator notEmpty should accept passed argument': function () {
+	'test validator notEmpty should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.notEmpty( errorMsg )( 'test' );
 		var negativeResult = CKEDITOR.dialog.validate.notEmpty( errorMsg )( '  ' );
 
@@ -67,7 +67,7 @@ bender.test( {
 		assert.areSame( errorMsg, negativeResult );
 	},
 
-	'test validator number should accept passed argument': function () {
+	'test validator number should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.number( errorMsg )( '123' );
 		var negativeResult = CKEDITOR.dialog.validate.number( errorMsg )( 'test' );
 
@@ -75,7 +75,7 @@ bender.test( {
 		assert.areSame( errorMsg, negativeResult );
 	},
 
-	'test validator regex should accept passed argument': function () {
+	'test validator regex should accept passed argument': function() {
 		var result = CKEDITOR.dialog.validate.regex( /^\d*$/, errorMsg )( '123' );
 		var negativeResult = CKEDITOR.dialog.validate.regex( errorMsg )( '123.321' );
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->
Bug fix
## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
 [#4473](https://github.com/ckeditor/ckeditor4/issues/4473): Fix: [dialog.validate methods](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html) accept value only from `getValue()` method in given context. Affected validators:
	* [equals](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-equals)
	* [notEqual](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-notEqual)
	* [cssLength](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-cssLength)
	* [htmlLength](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-htmlLength)
	* [inlineStyle](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-inlineStyle)
```

## What changes did you make?

*Give an overview…*
This PR added tests for all [dialog.validate](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html) except [functions](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-functions) - since it will be covered in #5248.

Each validator validates examples given in the documentation. To be sure that our API works in the same manner as the documentation says.

The **fix**:
Instead of trying to get value from arguments cached in a variable (during the first call of `functions`) the value is once again searched in `arguments` when the returned validator function was called. Please note that the originally cached arguments are preserved since they are important to preserve composition parameters.

Thanks to that fix, it was also possible to simplify `validatorinlinestyle` tests.

Also thanks to test based on doc examples it appears that there were buggy samples for [regex validator](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-regex) - so they are corrected now.

## Which issues does your PR resolve?

Closes #4473 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
