### PR TITLE
Add enter key support for `Find&Replace`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Fixed Issues:
 	* [`inlineStyle`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog_validate.html#method-inlineStyle)
 * [#5147](https://github.com/ckeditor/ckeditor4/issues/5147): Fixed: [Accessibility Help](https://ckeditor.com/cke4/addon/a11yhelp) dialog does not contain info about focus being moved back to the editing area upon leaving dialogs.
 * [#5144](https://github.com/ckeditor/ckeditor4/issues/5144): Fixed: [Menu buttons](https://ckeditor.com/cke4/addon/menubutton) and [panel buttons](https://ckeditor.com/cke4/addon/panelbutton) incorrectly indicates the open status of their associated pop-up menus in the browser's accessibility tree.
-
+* [#5022](https://github.com/ckeditor/ckeditor4/issues/5022): Fixed: [Find and Replace](https://ckeditor.com/cke4/addon/find) does not respond to the `Enter` key.
 
 API changes:
 

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -559,54 +559,6 @@
 		var lang = editor.lang.find,
 			ENTER_KEY = 13;
 
-		function execFind( dialog ) {
-			if ( !finder.find(
-				dialog.getValueOf( 'find', 'txtFindFind' ),
-				dialog.getValueOf( 'find', 'txtFindCaseChk' ),
-				dialog.getValueOf( 'find', 'txtFindWordChk' ),
-				dialog.getValueOf( 'find', 'txtFindCyclic' )
-			) ) {
-				alert( lang.notFoundMsg ); // jshint ignore:line
-			}
-
-		}
-
-		function execFindInReplace( dialog ) {
-			if ( !finder.find(
-				dialog.getValueOf( 'replace', 'txtFindReplace' ),
-				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-				dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-			) ) {
-				alert( lang.notFoundMsg ); // jshint ignore:line
-			}
-		}
-
-		function execReplace( dialog ) {
-			if ( !finder.replace(
-				dialog,
-				dialog.getValueOf( 'replace', 'txtFindReplace' ),
-				dialog.getValueOf( 'replace', 'txtReplace' ),
-				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-				dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-			) ) {
-				alert( lang.notFoundMsg ); // jshint ignore:line
-			}
-		}
-
-		function execReplaceAll( dialog ) {
-			while ( finder.replace(
-				dialog,
-				dialog.getValueOf( 'replace', 'txtFindReplace' ),
-				dialog.getValueOf( 'replace', 'txtReplace' ),
-				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-				false,
-				true
-			) ) {}
-		}
-
 		return {
 			title: lang.title,
 			resizable: CKEDITOR.DIALOG_RESIZE_NONE,
@@ -878,6 +830,54 @@
 				}
 			}
 		};
+
+		function execFind( dialog ) {
+			if ( !finder.find(
+				dialog.getValueOf( 'find', 'txtFindFind' ),
+				dialog.getValueOf( 'find', 'txtFindCaseChk' ),
+				dialog.getValueOf( 'find', 'txtFindWordChk' ),
+				dialog.getValueOf( 'find', 'txtFindCyclic' )
+			) ) {
+				alert( lang.notFoundMsg ); // jshint ignore:line
+			}
+
+		}
+
+		function execFindInReplace( dialog ) {
+			if ( !finder.find(
+				dialog.getValueOf( 'replace', 'txtFindReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+			) ) {
+				alert( lang.notFoundMsg ); // jshint ignore:line
+			}
+		}
+
+		function execReplace( dialog ) {
+			if ( !finder.replace(
+				dialog,
+				dialog.getValueOf( 'replace', 'txtFindReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+			) ) {
+				alert( lang.notFoundMsg ); // jshint ignore:line
+			}
+		}
+
+		function execReplaceAll( dialog ) {
+			while ( finder.replace(
+				dialog,
+				dialog.getValueOf( 'replace', 'txtFindReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+				false,
+				true
+			) ) {}
+		}
 
 		function createTextNodeWithPreservedSpaces( editor, text ) {
 			var textWithPreservedSpaces = text.replace( consecutiveWhitespaceRegex,

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -582,7 +582,24 @@
 						label: lang.findWhat,
 						isChanged: false,
 						labelLayout: 'horizontal',
-						accessKey: 'F'
+						accessKey: 'F',
+						onKeyDown: function( evt ) {
+							var keystroke = evt.data.getKeystroke();
+
+							if ( keystroke !== 13 ) {
+								return;
+							}
+
+							var dialog = this.getDialog();
+							if ( !finder.find(
+								dialog.getValueOf( 'find', 'txtFindFind' ),
+								dialog.getValueOf( 'find', 'txtFindCaseChk' ),
+								dialog.getValueOf( 'find', 'txtFindWordChk' ),
+								dialog.getValueOf( 'find', 'txtFindCyclic' )
+							) ) {
+								alert( lang.notFoundMsg ); // jshint ignore:line
+							}
+						}
 					},
 					{
 						type: 'button',
@@ -592,6 +609,7 @@
 						label: lang.find,
 						onClick: function() {
 							var dialog = this.getDialog();
+
 							if ( !finder.find(
 								dialog.getValueOf( 'find', 'txtFindFind' ),
 								dialog.getValueOf( 'find', 'txtFindCaseChk' ),
@@ -646,7 +664,24 @@
 						label: lang.findWhat,
 						isChanged: false,
 						labelLayout: 'horizontal',
-						accessKey: 'F'
+						accessKey: 'F',
+						onKeyDown: function( evt ) {
+							var keystroke = evt.data.getKeystroke();
+
+							if ( keystroke !== 13 ) {
+								return;
+							}
+
+							var dialog = this.getDialog();
+							if ( !finder.find(
+								dialog.getValueOf( 'replace', 'txtFindReplace' ),
+								dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+								dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+								dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+							) ) {
+								alert( lang.notFoundMsg ); // jshint ignore:line
+							}
+						}
 					},
 					{
 						type: 'button',
@@ -678,7 +713,26 @@
 						label: lang.replaceWith,
 						isChanged: false,
 						labelLayout: 'horizontal',
-						accessKey: 'R'
+						accessKey: 'R',
+						onKeyDown: function( evt ) {
+							var keystroke = evt.data.getKeystroke();
+
+							if ( keystroke !== 13 ) {
+								return;
+							}
+
+							var dialog = this.getDialog();
+							if ( !finder.replace(
+								dialog,
+								dialog.getValueOf( 'replace', 'txtFindReplace' ),
+								dialog.getValueOf( 'replace', 'txtReplace' ),
+								dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+								dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+								dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+							) ) {
+								alert( lang.notFoundMsg ); // jshint ignore:line
+							}
+						}
 					},
 					{
 						type: 'button',

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -557,6 +557,61 @@
 		}
 
 		var lang = editor.lang.find;
+		function execFindOrReplace( dialog, type ) {
+			if ( !dialog ) {
+				return;
+			}
+
+			if ( type === 'find' ) {
+				if ( !finder.find(
+					dialog.getValueOf( 'find', 'txtFindFind' ),
+					dialog.getValueOf( 'find', 'txtFindCaseChk' ),
+					dialog.getValueOf( 'find', 'txtFindWordChk' ),
+					dialog.getValueOf( 'find', 'txtFindCyclic' )
+				) ) {
+					alert( lang.notFoundMsg ); // jshint ignore:line
+				}
+			}
+
+			if ( type === 'findInReplace' ) {
+				if ( !finder.find(
+					dialog.getValueOf( 'replace', 'txtFindReplace' ),
+					dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+					dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+				) ) {
+					alert( lang.notFoundMsg ); // jshint ignore:line
+				}
+			}
+
+			if ( type === 'replace' ) {
+				if ( !finder.replace(
+					dialog,
+					dialog.getValueOf( 'replace', 'txtFindReplace' ),
+					dialog.getValueOf( 'replace', 'txtReplace' ),
+					dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+					dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+				) ) {
+					alert( lang.notFoundMsg ); // jshint ignore:line
+				}
+			}
+
+			if ( type === 'replaceAll' ) {
+				while ( finder.replace(
+					dialog,
+					dialog.getValueOf( 'replace', 'txtFindReplace' ),
+					dialog.getValueOf( 'replace', 'txtReplace' ),
+					dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+					false,
+					true
+				) ) {
+
+				}
+			}
+		}
+
 		return {
 			title: lang.title,
 			resizable: CKEDITOR.DIALOG_RESIZE_NONE,
@@ -591,14 +646,7 @@
 							}
 
 							var dialog = this.getDialog();
-							if ( !finder.find(
-								dialog.getValueOf( 'find', 'txtFindFind' ),
-								dialog.getValueOf( 'find', 'txtFindCaseChk' ),
-								dialog.getValueOf( 'find', 'txtFindWordChk' ),
-								dialog.getValueOf( 'find', 'txtFindCyclic' )
-							) ) {
-								alert( lang.notFoundMsg ); // jshint ignore:line
-							}
+							execFindOrReplace( dialog, 'find' );
 						}
 					},
 					{
@@ -609,15 +657,7 @@
 						label: lang.find,
 						onClick: function() {
 							var dialog = this.getDialog();
-
-							if ( !finder.find(
-								dialog.getValueOf( 'find', 'txtFindFind' ),
-								dialog.getValueOf( 'find', 'txtFindCaseChk' ),
-								dialog.getValueOf( 'find', 'txtFindWordChk' ),
-								dialog.getValueOf( 'find', 'txtFindCyclic' )
-							) ) {
-								alert( lang.notFoundMsg ); // jshint ignore:line
-							}
+							execFindOrReplace( dialog, 'find' );
 						}
 					} ]
 				},
@@ -673,14 +713,7 @@
 							}
 
 							var dialog = this.getDialog();
-							if ( !finder.find(
-								dialog.getValueOf( 'replace', 'txtFindReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-							) ) {
-								alert( lang.notFoundMsg ); // jshint ignore:line
-							}
+							execFindOrReplace( dialog, 'findInReplace' );
 						}
 					},
 					{
@@ -691,16 +724,7 @@
 						label: lang.replace,
 						onClick: function() {
 							var dialog = this.getDialog();
-							if ( !finder.replace(
-								dialog,
-								dialog.getValueOf( 'replace', 'txtFindReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-							) ) {
-								alert( lang.notFoundMsg ); // jshint ignore:line
-							}
+							execFindOrReplace( dialog, 'replace' );
 						}
 					} ]
 				},
@@ -722,16 +746,7 @@
 							}
 
 							var dialog = this.getDialog();
-							if ( !finder.replace(
-								dialog,
-								dialog.getValueOf( 'replace', 'txtFindReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-							) ) {
-								alert( lang.notFoundMsg ); // jshint ignore:line
-							}
+							execFindOrReplace( dialog, 'replace' );
 						}
 					},
 					{
@@ -753,17 +768,7 @@
 								finder.matchRange = null;
 							}
 							editor.fire( 'saveSnapshot' );
-							while ( finder.replace(
-								dialog,
-								dialog.getValueOf( 'replace', 'txtFindReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplace' ),
-								dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-								dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-								false,
-								true
-							) ) {
-
-							}
+							execFindOrReplace( dialog, 'replaceAll' );
 
 							if ( finder.replaceCounter ) {
 								alert( lang.replaceSuccessMsg.replace( /%1/, finder.replaceCounter ) ); // jshint ignore:line

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -559,24 +559,7 @@
 		var lang = editor.lang.find,
 			ENTER_KEY = 13;
 
-		function execFind( dialog, type ) {
-			if ( !dialog ) {
-				return;
-			}
-
-			if ( type === 'findInReplace' ) {
-				if ( !finder.find(
-					dialog.getValueOf( 'replace', 'txtFindReplace' ),
-					dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-					dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-				) ) {
-					alert( lang.notFoundMsg ); // jshint ignore:line
-				}
-
-				return;
-			}
-
+		function execFind( dialog ) {
 			if ( !finder.find(
 				dialog.getValueOf( 'find', 'txtFindFind' ),
 				dialog.getValueOf( 'find', 'txtFindCaseChk' ),
@@ -588,25 +571,18 @@
 
 		}
 
-		function execReplace( dialog, type ) {
-			if ( !dialog ) {
-				return;
+		function execFindInReplace( dialog ) {
+			if ( !finder.find(
+				dialog.getValueOf( 'replace', 'txtFindReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+			) ) {
+				alert( lang.notFoundMsg ); // jshint ignore:line
 			}
+		}
 
-			if ( type === 'replaceAll' ) {
-				while ( finder.replace(
-					dialog,
-					dialog.getValueOf( 'replace', 'txtFindReplace' ),
-					dialog.getValueOf( 'replace', 'txtReplace' ),
-					dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-					false,
-					true
-				) ) {}
-
-				return;
-			}
-
+		function execReplace( dialog ) {
 			if ( !finder.replace(
 				dialog,
 				dialog.getValueOf( 'replace', 'txtFindReplace' ),
@@ -617,6 +593,18 @@
 			) ) {
 				alert( lang.notFoundMsg ); // jshint ignore:line
 			}
+		}
+
+		function execReplaceAll( dialog ) {
+			while ( finder.replace(
+				dialog,
+				dialog.getValueOf( 'replace', 'txtFindReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+				false,
+				true
+			) ) {}
 		}
 
 		return {
@@ -652,8 +640,7 @@
 								return;
 							}
 
-							var dialog = this.getDialog();
-							execFind( dialog );
+							execFind( this.getDialog() );
 						}
 					},
 					{
@@ -663,8 +650,7 @@
 						style: 'width:100%',
 						label: lang.find,
 						onClick: function() {
-							var dialog = this.getDialog();
-							execFind( dialog );
+							execFind( this.getDialog() );
 						}
 					} ]
 				},
@@ -719,8 +705,7 @@
 								return;
 							}
 
-							var dialog = this.getDialog();
-							execFind( dialog, 'findInReplace' );
+							execFindInReplace( this.getDialog() );
 						}
 					},
 					{
@@ -730,8 +715,7 @@
 						style: 'width:100%',
 						label: lang.replace,
 						onClick: function() {
-							var dialog = this.getDialog();
-							execReplace( dialog );
+							execReplace( this.getDialog() );
 						}
 					} ]
 				},
@@ -752,8 +736,7 @@
 								return;
 							}
 
-							var dialog = this.getDialog();
-							execReplace( dialog );
+							execReplace( this.getDialog() );
 						}
 					},
 					{
@@ -775,7 +758,7 @@
 								finder.matchRange = null;
 							}
 							editor.fire( 'saveSnapshot' );
-							execReplace( dialog, 'replaceAll' );
+							execReplaceAll( dialog );
 
 							if ( finder.replaceCounter ) {
 								alert( lang.replaceSuccessMsg.replace( /%1/, finder.replaceCounter ) ); // jshint ignore:line

--- a/plugins/find/dialogs/find.js
+++ b/plugins/find/dialogs/find.js
@@ -556,21 +556,12 @@
 			return searchRange;
 		}
 
-		var lang = editor.lang.find;
-		function execFindOrReplace( dialog, type ) {
+		var lang = editor.lang.find,
+			ENTER_KEY = 13;
+
+		function execFind( dialog, type ) {
 			if ( !dialog ) {
 				return;
-			}
-
-			if ( type === 'find' ) {
-				if ( !finder.find(
-					dialog.getValueOf( 'find', 'txtFindFind' ),
-					dialog.getValueOf( 'find', 'txtFindCaseChk' ),
-					dialog.getValueOf( 'find', 'txtFindWordChk' ),
-					dialog.getValueOf( 'find', 'txtFindCyclic' )
-				) ) {
-					alert( lang.notFoundMsg ); // jshint ignore:line
-				}
 			}
 
 			if ( type === 'findInReplace' ) {
@@ -582,19 +573,24 @@
 				) ) {
 					alert( lang.notFoundMsg ); // jshint ignore:line
 				}
+
+				return;
 			}
 
-			if ( type === 'replace' ) {
-				if ( !finder.replace(
-					dialog,
-					dialog.getValueOf( 'replace', 'txtFindReplace' ),
-					dialog.getValueOf( 'replace', 'txtReplace' ),
-					dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
-					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
-					dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
-				) ) {
-					alert( lang.notFoundMsg ); // jshint ignore:line
-				}
+			if ( !finder.find(
+				dialog.getValueOf( 'find', 'txtFindFind' ),
+				dialog.getValueOf( 'find', 'txtFindCaseChk' ),
+				dialog.getValueOf( 'find', 'txtFindWordChk' ),
+				dialog.getValueOf( 'find', 'txtFindCyclic' )
+			) ) {
+				alert( lang.notFoundMsg ); // jshint ignore:line
+			}
+
+		}
+
+		function execReplace( dialog, type ) {
+			if ( !dialog ) {
+				return;
 			}
 
 			if ( type === 'replaceAll' ) {
@@ -606,9 +602,20 @@
 					dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
 					false,
 					true
-				) ) {
+				) ) {}
 
-				}
+				return;
+			}
+
+			if ( !finder.replace(
+				dialog,
+				dialog.getValueOf( 'replace', 'txtFindReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplace' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCaseChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceWordChk' ),
+				dialog.getValueOf( 'replace', 'txtReplaceCyclic' )
+			) ) {
+				alert( lang.notFoundMsg ); // jshint ignore:line
 			}
 		}
 
@@ -641,12 +648,12 @@
 						onKeyDown: function( evt ) {
 							var keystroke = evt.data.getKeystroke();
 
-							if ( keystroke !== 13 ) {
+							if ( keystroke !== ENTER_KEY ) {
 								return;
 							}
 
 							var dialog = this.getDialog();
-							execFindOrReplace( dialog, 'find' );
+							execFind( dialog );
 						}
 					},
 					{
@@ -657,7 +664,7 @@
 						label: lang.find,
 						onClick: function() {
 							var dialog = this.getDialog();
-							execFindOrReplace( dialog, 'find' );
+							execFind( dialog );
 						}
 					} ]
 				},
@@ -708,12 +715,12 @@
 						onKeyDown: function( evt ) {
 							var keystroke = evt.data.getKeystroke();
 
-							if ( keystroke !== 13 ) {
+							if ( keystroke !== ENTER_KEY ) {
 								return;
 							}
 
 							var dialog = this.getDialog();
-							execFindOrReplace( dialog, 'findInReplace' );
+							execFind( dialog, 'findInReplace' );
 						}
 					},
 					{
@@ -724,7 +731,7 @@
 						label: lang.replace,
 						onClick: function() {
 							var dialog = this.getDialog();
-							execFindOrReplace( dialog, 'replace' );
+							execReplace( dialog );
 						}
 					} ]
 				},
@@ -741,12 +748,12 @@
 						onKeyDown: function( evt ) {
 							var keystroke = evt.data.getKeystroke();
 
-							if ( keystroke !== 13 ) {
+							if ( keystroke !== ENTER_KEY ) {
 								return;
 							}
 
 							var dialog = this.getDialog();
-							execFindOrReplace( dialog, 'replace' );
+							execReplace( dialog );
 						}
 					},
 					{
@@ -768,7 +775,7 @@
 								finder.matchRange = null;
 							}
 							editor.fire( 'saveSnapshot' );
-							execFindOrReplace( dialog, 'replaceAll' );
+							execReplace( dialog, 'replaceAll' );
 
 							if ( finder.replaceCounter ) {
 								alert( lang.replaceSuccessMsg.replace( /%1/, finder.replaceCounter ) ); // jshint ignore:line

--- a/tests/plugins/find/find.js
+++ b/tests/plugins/find/find.js
@@ -13,6 +13,8 @@ bender.editor = {
 	}
 };
 
+var ENTER_KEY = 13;
+
 window.alert = function() {};
 
 bender.test( {
@@ -379,8 +381,61 @@ bender.test( {
 	// (#4987)
 	'test space separator: IDEOGRAPHIC SPACE': function() {
 		assertSpaceSeparator( this.editorBot, '\u3000', 'IDEOGRAPHIC SPACE' );
-	}
+	},
 
+	// (#5022)
+	'test find dialog with searching pattern by using Enter key': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>test</p>' );
+		bot.dialog( 'find', function( dialog ) {
+			dialog.setValueOf( 'find', 'txtFindFind', 'test' );
+
+			dialog.getContentElement( 'find', 'txtFindFind' )
+				.getInputElement()
+				.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ENTER_KEY } ) );
+
+			assert.areSame( '<p><span title="highlight">test</span></p>', bot.getData( true ) );
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	// (#5022)
+	'test replace dialog with searching pattern by using Enter key': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>test</p>' );
+		bot.dialog( 'replace', function( dialog ) {
+			dialog.setValueOf( 'replace', 'txtFindReplace', 'test' );
+
+			dialog.getContentElement( 'replace', 'txtFindReplace' )
+				.getInputElement()
+				.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ENTER_KEY } ) );
+
+			assert.areSame( '<p><span title="highlight">test</span></p>', bot.getData( true ) );
+			dialog.getButton( 'cancel' ).click();
+		} );
+	},
+
+	// (#5022)
+	'test replace dialog with replacing pattern by using Enter key': function() {
+		var bot = this.editorBot;
+
+		bot.setHtmlWithSelection( '<p>test</p>' );
+
+		bot.dialog( 'replace', function( dialog ) {
+			dialog.setValueOf( 'replace', 'txtFindReplace', 'test' );
+			dialog.setValueOf( 'replace', 'txtReplace', 'replaced' );
+
+			var txtReplaceInput = dialog.getContentElement( 'replace', 'txtReplace' ).getInputElement();
+
+			txtReplaceInput.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ENTER_KEY } ) );
+			txtReplaceInput.fire( 'keydown', new CKEDITOR.dom.event( { keyCode: ENTER_KEY } ) );
+
+			dialog.getButton( 'cancel' ).click();
+			assert.areSame( '<p>replaced</p>', bot.getData() );
+		} );
+	}
 } );
 
 function assertSpaceSeparator( bot, unicode, name, expectedHtmlEntities ) {

--- a/tests/plugins/find/manual/findbykeyboard.html
+++ b/tests/plugins/find/manual/findbykeyboard.html
@@ -1,0 +1,7 @@
+<textarea id="editor">
+	<p>foo bar</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/find/manual/findbykeyboard.md
+++ b/tests/plugins/find/manual/findbykeyboard.md
@@ -6,6 +6,6 @@
 2. In `Find what:` input type `foo`.
 3. Press `Enter` key.
 
-**Expected:** The pattern has been founded and the searched text is highlighted on the editable.
+**Expected:** The pattern was found.
 
 **Unexpected:** Nothing happened.

--- a/tests/plugins/find/manual/findbykeyboard.md
+++ b/tests/plugins/find/manual/findbykeyboard.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.19.1, bug, 5022
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, find
+
+1. Open Find and Replace dialog and move to `Find` tab.
+2. In `Find what:` input type `foo`.
+3. Press `Enter` key.
+
+**Expected:** The pattern has been founded and the searched text is highlighted on the editable.
+
+**Unexpected:** Nothing happened.

--- a/tests/plugins/find/manual/replacebykeyboard.html
+++ b/tests/plugins/find/manual/replacebykeyboard.html
@@ -1,0 +1,7 @@
+<textarea id="editor">
+	<p>foo bar</p>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/find/manual/replacebykeyboard.md
+++ b/tests/plugins/find/manual/replacebykeyboard.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.19.1, bug, 5022
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, find
+
+1. Open Find and Replace dialog and move to `Replace` tab.
+2. In `Find what:` input type `foo`.
+3. Press `Enter` key.
+
+**Expected:** The pattern has been founded and the searched text is highlighted on the editable.
+
+**Unexpected:** Nothing happened.
+
+4. In `Replace with:` input type `test`.
+5. Press `Enter` key.
+
+**Expected:** The pattern has been replaced.
+
+**Unexpected:** Nothing happened.

--- a/tests/plugins/find/manual/replacebykeyboard.md
+++ b/tests/plugins/find/manual/replacebykeyboard.md
@@ -6,13 +6,13 @@
 2. In `Find what:` input type `foo`.
 3. Press `Enter` key.
 
-**Expected:** The pattern has been founded and the searched text is highlighted on the editable.
+**Expected:** The pattern was found.
 
 **Unexpected:** Nothing happened.
 
 4. In `Replace with:` input type `test`.
 5. Press `Enter` key.
 
-**Expected:** The pattern has been replaced.
+**Expected:** The pattern was replaced.
 
 **Unexpected:** Nothing happened.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5022](https://github.com/ckeditor/ckeditor4/issues/5022): Fixed: [Find/Replace](https://ckeditor.com/cke4/addon/find) Find and replace does not respond to the `Enter` key.
```

## What changes did you make?

Enter key not triggered find or replace because dialogs by default contain [handling only to dialog `OK` button](https://github.com/ckeditor/ckeditor4/blob/t/5022/plugins/dialog/plugin.js#L545-L554). To fix this I added `onKeyEvent` to the dialog inputs with executing `find` or `replace` method on current finder.

## Which issues does your PR resolve?

Closes #5022.
