### PR TITLE
Fix: selection optimization in list disallow full list removal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Fixed Issues:
 * [#4889](https://github.com/ckeditor/ckeditor4/issues/4889): Fixed: Incorrect position of the [Table Resize](https://ckeditor.com/cke4/addon/tableresize) cursor after scrolling the editor horizontally.
 * [#5319](https://github.com/ckeditor/ckeditor4/issues/5319): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) [`config.autolink_urlRegex`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-autolink_urlRegex) option produces invalid links when configured directly using editor instance configuration. Thanks to [Aigars Zeiza](https://github.com/Zuzon)!
 * [#4941](https://github.com/ckeditor/ckeditor4/issues/4941): Fixed: Some entities get wrongly encoded when using [`entities_processNumerical = true`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-entities_processNumerical) configuration option.
+* [#4931](https://github.com/ckeditor/ckeditor4/issues/4931): Fixed: Selecting whole editor's content when there's only a list with an empty element at the end inside and deleting it does not delete all list items.
 
 
 API changes:

--- a/core/selection/optimization.js
+++ b/core/selection/optimization.js
@@ -117,7 +117,10 @@
 			return false;
 		}
 
-		var isInList = range.endContainer.is && range.endContainer.is( 'li' );
+		// The endContainer might be a text inside li element (in IE8).
+		var isInList = range.endContainer.is ?
+			range.endContainer.is( 'li' ) :
+			range.endContainer.getParent().is && range.endContainer.getParent().is( 'li' );
 
 		// Prevent optimization in lists (#4931).
 		if ( isInList ) {

--- a/core/selection/optimization.js
+++ b/core/selection/optimization.js
@@ -117,7 +117,9 @@
 			return false;
 		}
 
-		if ( range.endOffset === 0 ) {
+		var isInList = range.endContainer.is && range.endContainer.is( 'li' );
+
+		if ( range.endOffset === 0 && !isInList )  {
 			return true;
 		}
 
@@ -125,7 +127,7 @@
 			endsInText = isText( range.endContainer ),
 			limit = startsInText ? range.startContainer.getLength() : range.startContainer.getChildCount();
 
-		return range.startOffset === limit || startsInText ^ endsInText;
+		return !isInList && ( range.startOffset === limit || startsInText ^ endsInText );
 	}
 
 	// Prevent infinite recurrency when the browser does not allow the expected selection.

--- a/core/selection/optimization.js
+++ b/core/selection/optimization.js
@@ -120,7 +120,11 @@
 		var isInList = range.endContainer.is && range.endContainer.is( 'li' );
 
 		// Prevent optimization in lists (#4931).
-		if ( range.endOffset === 0 && !isInList )  {
+		if ( isInList ) {
+			return false;
+		}
+
+		if ( range.endOffset === 0 )  {
 			return true;
 		}
 
@@ -128,7 +132,7 @@
 			endsInText = isText( range.endContainer ),
 			limit = startsInText ? range.startContainer.getLength() : range.startContainer.getChildCount();
 
-		return !isInList && ( range.startOffset === limit || startsInText ^ endsInText );
+		return range.startOffset === limit || startsInText ^ endsInText;
 	}
 
 	// Prevent infinite recurrency when the browser does not allow the expected selection.

--- a/core/selection/optimization.js
+++ b/core/selection/optimization.js
@@ -119,6 +119,7 @@
 
 		var isInList = range.endContainer.is && range.endContainer.is( 'li' );
 
+		// Prevent optimization in lists (#4931).
 		if ( range.endOffset === 0 && !isInList )  {
 			return true;
 		}

--- a/plugins/selectall/plugin.js
+++ b/plugins/selectall/plugin.js
@@ -33,8 +33,9 @@
 
 						textarea.focus();
 					} else {
-						if ( editable.is( 'body' ) )
+						if ( editable.is( 'body' ) ) {
 							editor.document.$.execCommand( 'SelectAll', false, null );
+						}
 						else {
 							var range = editor.createRange();
 							range.selectNodeContents( editable );
@@ -48,6 +49,19 @@
 
 				},
 				canUndo: false
+			} );
+
+			editor.on( 'contentDom', function() {
+				var editable = editor.editable();
+				editable.attachListener( editable, 'keydown', function( evt ) {
+					if ( evt.data.getKeystroke() != CKEDITOR.CTRL + 65 ) {
+						return;
+					}
+
+					editor.execCommand( 'selectAll' );
+					evt.cancel();
+					evt.data.preventDefault();
+				} );
 			} );
 
 			editor.ui.addButton && editor.ui.addButton( 'SelectAll', {

--- a/plugins/selectall/plugin.js
+++ b/plugins/selectall/plugin.js
@@ -33,9 +33,8 @@
 
 						textarea.focus();
 					} else {
-						if ( editable.is( 'body' ) ) {
+						if ( editable.is( 'body' ) )
 							editor.document.$.execCommand( 'SelectAll', false, null );
-						}
 						else {
 							var range = editor.createRange();
 							range.selectNodeContents( editable );
@@ -49,19 +48,6 @@
 
 				},
 				canUndo: false
-			} );
-
-			editor.on( 'contentDom', function() {
-				var editable = editor.editable();
-				editable.attachListener( editable, 'keydown', function( evt ) {
-					if ( evt.data.getKeystroke() != CKEDITOR.CTRL + 65 ) {
-						return;
-					}
-
-					editor.execCommand( 'selectAll' );
-					evt.cancel();
-					evt.data.preventDefault();
-				} );
 			} );
 
 			editor.ui.addButton && editor.ui.addButton( 'SelectAll', {

--- a/tests/core/selection/manual/optimizationlist.html
+++ b/tests/core/selection/manual/optimizationlist.html
@@ -1,110 +1,26 @@
 <h2>Iframe editor</h2>
 <div id="editor1">
-	<ul>
-		<li>1</li>
-		<li>2</li>
-		<li>3</li>
-		<li>4</li>
-		<li>5
-		<ul>
-			<li>6
-			<ul>
-				<li>7
-				<ul>
-					<li>8</li>
-				</ul>
-				</li>
-			</ul>
-			</li>
-			<li>9</li>
-		</ul>
-		</li>
-		<li>0</li>
-	</ul>
-
 	<ol>
-		<li>12</li>
-		<li>14</li>
-		<li>16</li>
-		<li>18</li>
-		<li>20
+		<li>1</li>
+		<li>2
 		<ol>
-			<li>22
-			<ol>
-				<li>24</li>
-			</ol>
-			</li>
-			<li>26
-			<ol>
-				<li>28
-				<ol>
-					<li>30
-					<ol>
-						<li>32</li>
-					</ol>
-					</li>
-					<li></li>
-				</ol>
-				</li>
-			</ol>
-			</li>
+			<li>1</li>
 		</ol>
 		</li>
+		<li>&nbsp;</li>
 	</ol>
 </div>
 
 <h2>Divarea editor</h2>
 <div id="editor2">
-	<ul>
-		<li>1</li>
-		<li>2</li>
-		<li>3</li>
-		<li>4</li>
-		<li>5
-		<ul>
-			<li>6
-			<ul>
-				<li>7
-				<ul>
-					<li>8</li>
-				</ul>
-				</li>
-			</ul>
-			</li>
-			<li>9</li>
-		</ul>
-		</li>
-		<li>0</li>
-	</ul>
-
 	<ol>
-		<li>12</li>
-		<li>14</li>
-		<li>16</li>
-		<li>18</li>
-		<li>20
+		<li>1</li>
+		<li>2
 		<ol>
-			<li>22
-			<ol>
-				<li>24</li>
-			</ol>
-			</li>
-			<li>26
-			<ol>
-				<li>28
-				<ol>
-					<li>30
-					<ol>
-						<li>32</li>
-					</ol>
-					</li>
-					<li></li>
-				</ol>
-				</li>
-			</ol>
-			</li>
+			<li>1</li>
 		</ol>
 		</li>
+		<li>&nbsp;</li>
 	</ol>
 </div>
 

--- a/tests/core/selection/manual/optimizationlist.html
+++ b/tests/core/selection/manual/optimizationlist.html
@@ -1,0 +1,39 @@
+<h2>Iframe editor</h2>
+<div id="editor1">
+	<ol>
+		<li>1</li>
+		<li>2
+		<ol>
+			<li>1</li>
+		</ol>
+		</li>
+		<li>&nbsp;</li>
+	</ol>
+
+</div>
+
+<h2>Divarea editor</h2>
+<div id="editor2">
+	<ol>
+		<li>1</li>
+		<li>2
+		<ol>
+			<li>1</li>
+		</ol>
+		</li>
+		<li>&nbsp;</li>
+	</ol>
+
+</div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor1' );
+
+	CKEDITOR.replace( 'editor2', {
+		extraPlugins: 'divarea',
+	} );
+</script>

--- a/tests/core/selection/manual/optimizationlist.html
+++ b/tests/core/selection/manual/optimizationlist.html
@@ -1,13 +1,55 @@
 <h2>Iframe editor</h2>
 <div id="editor1">
-	<ol>
+	<ul>
 		<li>1</li>
-		<li>2
+		<li>2</li>
+		<li>3</li>
+		<li>4</li>
+		<li>5
+		<ul>
+			<li>6
+			<ul>
+				<li>7
+				<ul>
+					<li>8</li>
+				</ul>
+				</li>
+			</ul>
+			</li>
+			<li>9</li>
+		</ul>
+		</li>
+		<li>0</li>
+	</ul>
+
+	<ol>
+		<li>12</li>
+		<li>14</li>
+		<li>16</li>
+		<li>18</li>
+		<li>20
 		<ol>
-			<li>1</li>
+			<li>22
+			<ol>
+				<li>24</li>
+			</ol>
+			</li>
+			<li>26
+			<ol>
+				<li>28
+				<ol>
+					<li>30
+					<ol>
+						<li>32</li>
+					</ol>
+					</li>
+					<li></li>
+				</ol>
+				</li>
+			</ol>
+			</li>
 		</ol>
 		</li>
-		<li>&nbsp;</li>
 	</ol>
 </div>
 

--- a/tests/core/selection/manual/optimizationlist.html
+++ b/tests/core/selection/manual/optimizationlist.html
@@ -9,7 +9,6 @@
 		</li>
 		<li>&nbsp;</li>
 	</ol>
-
 </div>
 
 <h2>Divarea editor</h2>

--- a/tests/core/selection/manual/optimizationlist.html
+++ b/tests/core/selection/manual/optimizationlist.html
@@ -55,16 +55,57 @@
 
 <h2>Divarea editor</h2>
 <div id="editor2">
-	<ol>
+	<ul>
 		<li>1</li>
-		<li>2
+		<li>2</li>
+		<li>3</li>
+		<li>4</li>
+		<li>5
+		<ul>
+			<li>6
+			<ul>
+				<li>7
+				<ul>
+					<li>8</li>
+				</ul>
+				</li>
+			</ul>
+			</li>
+			<li>9</li>
+		</ul>
+		</li>
+		<li>0</li>
+	</ul>
+
+	<ol>
+		<li>12</li>
+		<li>14</li>
+		<li>16</li>
+		<li>18</li>
+		<li>20
 		<ol>
-			<li>1</li>
+			<li>22
+			<ol>
+				<li>24</li>
+			</ol>
+			</li>
+			<li>26
+			<ol>
+				<li>28
+				<ol>
+					<li>30
+					<ol>
+						<li>32</li>
+					</ol>
+					</li>
+					<li></li>
+				</ol>
+				</li>
+			</ol>
+			</li>
 		</ol>
 		</li>
-		<li>&nbsp;</li>
 	</ol>
-
 </div>
 
 <script>

--- a/tests/core/selection/manual/optimizationlist.md
+++ b/tests/core/selection/manual/optimizationlist.md
@@ -2,12 +2,11 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo
 
-
 1. Select entire content via `Ctrl+A`.
 2. Delete content with backspace key.
 
-**Expected** The entire list is removed from the editor
+**Expected** The entire list is removed from the editor.
 
-**Unexpected** There are list leftovers in the editor
+**Unexpected** There are list leftovers in the editor.
 
 3. Repeat steps in the second editor.

--- a/tests/core/selection/manual/optimizationlist.md
+++ b/tests/core/selection/manual/optimizationlist.md
@@ -5,7 +5,9 @@
 1. Select entire content via `Ctrl+A`.
 2. Delete content with backspace key.
 
-**Expected** The entire list is removed from the editor.
+**Expected** The entire list content is removed from the editor.
+
+**Note** It is possible that list styling was not removed, so the first list item punctuation is in the content.
 
 **Unexpected** There are list leftovers in the editor.
 

--- a/tests/core/selection/manual/optimizationlist.md
+++ b/tests/core/selection/manual/optimizationlist.md
@@ -1,13 +1,13 @@
 @bender-tags: selection, 4.20.0, bug, 4931
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo, selectall
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo
 
 1. Select entire content via `Ctrl+A`.
 2. Delete content with backspace key.
 
 **Expected** The entire list content is removed from the editor.
 
-**Note** It is possible that list styling was not removed, so the first list item punctuation is in the content.
+**Note** It is possible that list styling was not removed, so the first list item punctuation is in the content **without any preceding whitespace**.
 
 **Unexpected** There are list leftovers in the editor.
 

--- a/tests/core/selection/manual/optimizationlist.md
+++ b/tests/core/selection/manual/optimizationlist.md
@@ -1,0 +1,13 @@
+@bender-tags: selection, 4.19.2, bug, 4931
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo, div, table, image, basicstyles, format
+
+
+1. Select entire content via `Ctrl+A`
+2. Delete content with backspace key.
+
+**Expected** The entire list is removed from the editor
+
+**Unexpected** There are list leftovers in the editor
+
+3. Repeat steps in the second editor

--- a/tests/core/selection/manual/optimizationlist.md
+++ b/tests/core/selection/manual/optimizationlist.md
@@ -1,6 +1,6 @@
 @bender-tags: selection, 4.20.0, bug, 4931
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo, selectall
 
 1. Select entire content via `Ctrl+A`.
 2. Delete content with backspace key.

--- a/tests/core/selection/manual/optimizationlist.md
+++ b/tests/core/selection/manual/optimizationlist.md
@@ -1,13 +1,13 @@
-@bender-tags: selection, 4.19.2, bug, 4931
+@bender-tags: selection, 4.20.0, bug, 4931
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo, div, table, image, basicstyles, format
+@bender-ckeditor-plugins: wysiwygarea, toolbar, elementspath, sourcearea, list, undo
 
 
-1. Select entire content via `Ctrl+A`
+1. Select entire content via `Ctrl+A`.
 2. Delete content with backspace key.
 
 **Expected** The entire list is removed from the editor
 
 **Unexpected** There are list leftovers in the editor
 
-3. Repeat steps in the second editor
+3. Repeat steps in the second editor.

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -64,7 +64,7 @@
 		// (#4931) do not expect optimization in list
 		'test selection optimization case 8': testSelection( {
 			initial: '<ul><li>[foo</li><li>]bar</li></ul>',
-			expected: '<ul><li>[foo</li><li>]@bar</li></ul>'
+			expected: '<ul><li>[foo@</li><li>]bar</li></ul>'
 		} ),
 
 		'test selection optimization case 9': testSelection( {

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -67,6 +67,12 @@
 			expected: '<ul><li>[foo@</li><li>]bar</li></ul>'
 		} ),
 
+		// (#4931)
+		'test selection optimization skips optimization if last list element is empty': testSelection( {
+			initial: '<ul><li>[foo</li><li>]</li></ul>',
+			expected: '<ul><li>[foo@</li><li>]</li></ul>'
+		} ),
+
 		'test selection optimization case 9': testSelection( {
 			initial: '<ul><li>foo</li><li>[bar</li></ul><p>]baz</p>',
 			expected: '<ul><li>foo</li><li>[bar]@</li></ul><p>baz</p>'

--- a/tests/core/selection/optimization.js
+++ b/tests/core/selection/optimization.js
@@ -61,9 +61,10 @@
 			expected: '<p>foo</p><p>^bar@</p><p>baz</p>'
 		} ),
 
+		// (#4931) do not expect optimization in list
 		'test selection optimization case 8': testSelection( {
 			initial: '<ul><li>[foo</li><li>]bar</li></ul>',
-			expected: '<ul><li>[foo]@</li><li>bar</li></ul>'
+			expected: '<ul><li>[foo</li><li>]@bar</li></ul>'
 		} ),
 
 		'test selection optimization case 9': testSelection( {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [X] Unit tests
- [X] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4931](https://github.com/ckeditor/ckeditor4/issues/4931): Fix: selection optimization skips list elements and disallow list removal.
```

## What changes did you make?

*Give an overview…*

Besides all details I put in the issue comments: I found that we have additional selection optimization which is responsible for shrinking selection under some circumstances. I added an additional check if the end selection container is a `li` element and prevents optimization if so.

## Which issues does your PR resolve?

Closes #4931 .
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
