### PR TITLE
Add support for array in the `config.removeButtons`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+API changes:
+
+* [#5122](https://github.com/ckeditor/ckeditor4/issues/5122): Added ability to provide a list of buttons as an array to the [`config.removeButtons`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removeButtons) config variable.
+
 ## CKEditor 4.19.2 [IN DEVELOPMENT]
 
 Fixed Issues:

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -782,7 +782,7 @@ CKEDITOR.config.toolbarLocation = 'top';
  * config.removeButtons = 'Underline,JustifyCenter';
  * ```
  *
- * From version 4.20.0 you can also pass an array of button names:
+ * Since version 4.20.0 you can also pass an array of button names:
  *
  * ```javascript
  * config.removeButtons = [ 'Underline', 'JustifyCenter' ];

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -415,9 +415,10 @@
 	} );
 
 	function getToolbarConfig( editor ) {
-		var removeButtons = getRemoveButtonsConfig( editor.config.removeButtons );
+		var removeButtons = getRemoveButtons( editor.config.removeButtons );
 
-		function getRemoveButtonsConfig( config ) {
+		// (#5122)
+		function getRemoveButtons( config ) {
 			if ( config && typeof config === 'string' ) {
 				return config.split( ',' );
 			}

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -415,9 +415,9 @@
 	} );
 
 	function getToolbarConfig( editor ) {
-		var removeButtons = getRemovedButtonsConfig( editor.config.removeButtons );
+		var removeButtons = getRemoveButtonsConfig( editor.config.removeButtons );
 
-		function getRemovedButtonsConfig( config ) {
+		function getRemoveButtonsConfig( config ) {
 			if ( config && typeof config === 'string' ) {
 				return config.split( ',' );
 			}

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -415,9 +415,15 @@
 	} );
 
 	function getToolbarConfig( editor ) {
-		var removeButtons = editor.config.removeButtons;
+		var removeButtons = getRemovedButtonsConfig( editor.config.removeButtons );
 
-		removeButtons = removeButtons && removeButtons.split( ',' );
+		function getRemovedButtonsConfig( config ) {
+			if ( config && typeof config === 'string' ) {
+				return config.split( ',' );
+			}
+
+			return config;
+		}
 
 		function buildToolbarConfig() {
 

--- a/plugins/toolbar/plugin.js
+++ b/plugins/toolbar/plugin.js
@@ -777,7 +777,15 @@ CKEDITOR.config.toolbarLocation = 'top';
  * List of toolbar button names that must not be rendered. This will also work
  * for non-button toolbar items, like the Font drop-down list.
  *
- *		config.removeButtons = 'Underline,JustifyCenter';
+ * ```javascript
+ * config.removeButtons = 'Underline,JustifyCenter';
+ * ```
+ *
+ * From version 4.20.0 you can also pass an array of button names:
+ *
+ * ```javascript
+ * config.removeButtons = [ 'Underline', 'JustifyCenter' ];
+ * ```
  *
  * This configuration option should not be overused. The recommended way is to use the
  * {@link CKEDITOR.config#removePlugins} setting to remove features from the editor
@@ -786,7 +794,7 @@ CKEDITOR.config.toolbarLocation = 'top';
  * In some cases though, a single plugin may define a set of toolbar buttons and
  * `removeButtons` may be useful when just a few of them are to be removed.
  *
- * @cfg {String} [removeButtons]
+ * @cfg {String/String[]} [removeButtons]
  * @member CKEDITOR.config
  */
 

--- a/tests/plugins/toolbar/config.js
+++ b/tests/plugins/toolbar/config.js
@@ -90,7 +90,34 @@
 					'<p><strong>A</strong><em>B</em>C</p><p>D</p><ol><li>E</li></ol>',
 					'<p><strong>A</strong><em>B</em>C</p><p>D</p><ol><li>E</li></ol>' );
 			} );
+		},
+
+		// (#5122)
+		'test config.removeButtons accepts array of buttons': function() {
+			bender.editorBot.create( {
+				name: 'editor-5122',
+				config: {
+					plugins: [ 'toolbar', 'wysiwygarea', 'basicstyles' ],
+					removeButtons: [ 'Bold', 'Italic' ]
+				}
+			},
+			function( bot ) {
+				var editor = bot.editor,
+					basicStyleGroup = getToolbarGroup( editor, 'basicstyles' );
+
+				assert.isTrue( comp( [ 'underline', 'strike', 'subscript', 'superscript' ], basicStyleGroup ) );
+
+				bot.assertInputOutput(
+					'<p><strong>A</strong><em>B</em><sup>C</sup></p>',
+					'<p>AB<sup>C</sup></p>',
+					'<p>AB<sup>C</sup></p>' );
+			} );
 		}
 	} );
 
+	function getToolbarGroup( editor, name ) {
+		return CKEDITOR.tools.array.find( editor.toolbar, function( group ) {
+			return group.name === name;
+		} );
+	}
 } )();

--- a/tests/plugins/toolbar/manual/removebuttons.html
+++ b/tests/plugins/toolbar/manual/removebuttons.html
@@ -3,7 +3,7 @@
 </div>
 
 <script>
-CKEDITOR.replace( 'editor', {
-	removeButtons: [ 'Bold', 'Italic' ]
-} );
+    CKEDITOR.replace( 'editor', {
+	    removeButtons: [ 'Bold', 'Italic' ]
+    } );
 </script>

--- a/tests/plugins/toolbar/manual/removebuttons.html
+++ b/tests/plugins/toolbar/manual/removebuttons.html
@@ -1,0 +1,9 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit amet</p>
+</div>
+
+<script>
+CKEDITOR.replace( 'editor', {
+	removeButtons: [ 'Bold', 'Italic' ]
+} );
+</script>

--- a/tests/plugins/toolbar/manual/removebuttons.md
+++ b/tests/plugins/toolbar/manual/removebuttons.md
@@ -2,9 +2,10 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles
 
-1. Open the console.
+1. Open the browser console.
 
-	**Expected** There are no errors in the console.
+**Expected** There are no errors in the console.
+	
 1. Look at the editor's toolbar.
 
-	**Expected** There are no "Bold" and "Italic" buttons.
+**Expected** There are no "Bold" and "Italic" buttons.

--- a/tests/plugins/toolbar/manual/removebuttons.md
+++ b/tests/plugins/toolbar/manual/removebuttons.md
@@ -1,0 +1,10 @@
+@bender-tags: 4.20.0, feature, 5122
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles
+
+1. Open the console.
+
+	**Expected** There are no errors in the console.
+1. Look at the editor's toolbar.
+
+	**Expected** There are no "Bold" and "Italic" buttons.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5122](https://github.com/ckeditor/ckeditor4/issues/5122): Added ability to provide a list of buttons as an array to the [`config.removeButtons`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removeButtons) config variable.
```

## What changes did you make?

I've added a simple helper that calls `split()` on the `config.removeButtons` variable only if it's a string. Otherwise, the original value is returned.

## Which issues does your PR resolve?

Closes #5122.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
