### PR TITLE
Add mathJaxConfig option

### DIFF
--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -308,10 +308,10 @@
 
 				var mathJaxConfig = editor.config.mathJaxConfig || {};
 
-				if ( !mathJaxConfig.showMathMenu )
+				if ( mathJaxConfig.showMathMenu === undefined )
 					mathJaxConfig.showMathMenu = false;
 
-				if ( !mathJaxConfig.messageStyle )
+				if ( mathJaxConfig.messageStyle === undefined )
 					mathJaxConfig.messageStyle = 'none';
 
 				doc.write( '<!DOCTYPE html>' +

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -305,10 +305,14 @@
 				// and call insertBefore on such element then IE9 will see crash.
 				if ( CKEDITOR.env.ie )
 					iFrame.removeAttribute( 'src' );
-				
+
 				var mathJaxConfig = editor.config.mathJaxConfig || {};
-				if ( !mathJaxConfig.showMathMenu ) mathJaxConfig.showMathMenu = false;
-				if ( !mathJaxConfig.messageStyle ) mathJaxConfig.messageStyle = 'none';
+
+				if ( !mathJaxConfig.showMathMenu )
+					mathJaxConfig.showMathMenu = false;
+
+				if ( !mathJaxConfig.messageStyle )
+					mathJaxConfig.messageStyle = 'none';
 
 				doc.write( '<!DOCTYPE html>' +
 							'<html>' +

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -305,6 +305,10 @@
 				// and call insertBefore on such element then IE9 will see crash.
 				if ( CKEDITOR.env.ie )
 					iFrame.removeAttribute( 'src' );
+				
+				var mathJaxConfig = editor.config.mathJaxConfig || {};
+				if ( !mathJaxConfig.showMathMenu ) mathJaxConfig.showMathMenu = false;
+				if ( !mathJaxConfig.messageStyle ) mathJaxConfig.messageStyle = 'none';
 
 				doc.write( '<!DOCTYPE html>' +
 							'<html>' +
@@ -313,10 +317,9 @@
 								'<script type="text/x-mathjax-config">' +
 
 									// MathJax configuration, disable messages.
-									'MathJax.Hub.Config( {' +
-										'showMathMenu: false,' +
-										'messageStyle: "none"' +
-									'} );' +
+									'MathJax.Hub.Config( ' +
+										JSON.stringify(mathJaxConfig) +
+									' );' +
 
 									// Get main CKEDITOR form parent.
 									'function getCKE() {' +

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -308,9 +308,11 @@
 
 				var mathJaxConfig = editor.config.mathJaxConfig || {};
 
+				// disable math menu
 				if ( mathJaxConfig.showMathMenu === undefined )
 					mathJaxConfig.showMathMenu = false;
 
+				// disable messages
 				if ( mathJaxConfig.messageStyle === undefined )
 					mathJaxConfig.messageStyle = 'none';
 
@@ -320,7 +322,7 @@
 								'<meta charset="utf-8">' +
 								'<script type="text/x-mathjax-config">' +
 
-									// MathJax configuration, disable messages.
+									// MathJax configuration
 									'MathJax.Hub.Config( ' +
 										JSON.stringify(mathJaxConfig) +
 									' );' +


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Give the ability to change MathJax configuration when using [mathjax plugin](https://ckeditor.com/cke4/addon/mathjax)

```js
new CKEDITOR.replace( 'editor', {
    mathJaxLib: '/mathjax?config=TeX-AMS_SVG',
    mathJaxClass: 'mathjax-latex',
    mathJaxConfig: {
        mtextFontInherit: true // pass option to iframe
    }
})
```

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* skip
```

## What changes did you make?

Moved MathJax configuration options from iframe's head to `load()` function. 

## Which issues does your PR resolve?

Closes #3709
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
