### PR TITLE
Fix encoding entities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixed Issues:
 API changes:
 
 * [#5122](https://github.com/ckeditor/ckeditor4/issues/5122): Added ability to provide a list of buttons as an array to the [`config.removeButtons`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removeButtons) config variable.
+* [#4941](https://github.com/ckeditor/ckeditor4/issues/4941): Fix: Some entities get wrongly encoded, when using [`entities_processNumerical = true`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-entities_processNumerical). Applied for not IE browsers.
 
 ## CKEditor 4.19.1
 

--- a/plugins/entities/plugin.js
+++ b/plugins/entities/plugin.js
@@ -118,54 +118,57 @@
 			var dataProcessor = editor.dataProcessor,
 				htmlFilter = dataProcessor && dataProcessor.htmlFilter;
 
-			if ( htmlFilter ) {
-				// Mandatory HTML basic entities.
-				var selectedEntities = [];
-
-				if ( config.basicEntities !== false )
-					selectedEntities.push( htmlbase );
-
-				if ( config.entities ) {
-					if ( selectedEntities.length )
-						selectedEntities.push( entities );
-
-					if ( config.entities_latin )
-						selectedEntities.push( latin );
-
-					if ( config.entities_greek )
-						selectedEntities.push( greek );
-
-					if ( config.entities_additional )
-						selectedEntities.push( config.entities_additional );
-				}
-
-				var entitiesTable = buildTable( selectedEntities.join( ',' ) );
-
-				// Create the Regex used to find entities in the text, leave it matches nothing if entities are empty.
-				var entitiesRegex = entitiesTable.regex ? '[' + entitiesTable.regex + ']' : 'a^';
-				delete entitiesTable.regex;
-
-				if ( config.entities && config.entities_processNumerical )
-					entitiesRegex = '[^ -~]|' + entitiesRegex;
-
-
-				// IE does not support unicode option in the Regex constructor (#4941).
-				entitiesRegex = CKEDITOR.env.ie ? new RegExp( entitiesRegex, 'g' ) : new RegExp( entitiesRegex, 'gu' );
-
-				// Decode entities that the browsers has transformed
-				// at first place.
-				var baseEntitiesTable = buildTable( [ htmlbase, 'shy' ].join( ',' ), true ),
-					baseEntitiesRegex = new RegExp( baseEntitiesTable.regex, 'g' );
-
-				htmlFilter.addRules( {
-					text: function( text ) {
-						return text.replace( baseEntitiesRegex, getChar ).replace( entitiesRegex, getEntity );
-					}
-				}, {
-					applyToAll: true,
-					excludeNestedEditable: true
-				} );
+			if ( !htmlFilter ) {
+				return;
 			}
+
+			// Mandatory HTML basic entities.
+			var selectedEntities = [];
+
+			if ( config.basicEntities !== false )
+				selectedEntities.push( htmlbase );
+
+			if ( config.entities ) {
+				if ( selectedEntities.length )
+					selectedEntities.push( entities );
+
+				if ( config.entities_latin )
+					selectedEntities.push( latin );
+
+				if ( config.entities_greek )
+					selectedEntities.push( greek );
+
+				if ( config.entities_additional )
+					selectedEntities.push( config.entities_additional );
+			}
+
+			var entitiesTable = buildTable( selectedEntities.join( ',' ) );
+
+			// Create the Regex used to find entities in the text, leave it matches nothing if entities are empty.
+			var entitiesRegex = entitiesTable.regex ? '[' + entitiesTable.regex + ']' : 'a^';
+			delete entitiesTable.regex;
+
+			if ( config.entities && config.entities_processNumerical ) {
+				entitiesRegex = '[^ -~]|' + entitiesRegex;
+			}
+
+
+			// IE does not support unicode option in the Regex constructor (#4941).
+			entitiesRegex = new RegExp( entitiesRegex, CKEDITOR.env.ie ? 'g' : 'gu' );
+
+			// Decode entities that the browsers has transformed
+			// at first place.
+			var baseEntitiesTable = buildTable( [ htmlbase, 'shy' ].join( ',' ), true ),
+				baseEntitiesRegex = new RegExp( baseEntitiesTable.regex, 'g' );
+
+			htmlFilter.addRules( {
+				text: function( text ) {
+					return text.replace( baseEntitiesRegex, getChar ).replace( entitiesRegex, getEntity );
+				}
+			}, {
+				applyToAll: true,
+				excludeNestedEditable: true
+			} );
 		}
 	} );
 } )();

--- a/plugins/entities/plugin.js
+++ b/plugins/entities/plugin.js
@@ -112,27 +112,7 @@
 
 			// (#4941)
 			function getCodePoint( character ) {
-				if ( !CKEDITOR.env.ie ) {
-					return character.codePointAt( 0 );
-				}
-
-				// IE does not support codePointAt.
-				var code = character.charCodeAt( 0 );
-				if ( code < 0xD800 || code > 0xDFFF ) {
-					return code;
-				}
-
-				var highSurrogate = code;
-				var lowSurrogate = character.charCodeAt( 1 );
-
-				// Check if high and lead surrogate are in the range.
-				if ( !( highSurrogate >= 0xD800 && highSurrogate <= 0xDBFF && lowSurrogate >= 0xDC00 && lowSurrogate <= 0xDFFF ) ) {
-					return code;
-				}
-
-				// Reverse mapping from a surrogate pair to a Unicode code point.
-				// Unicode 3.0.0 Chapter 3.7 Surrogate Pairs.
-				return ( highSurrogate - 0xD800 ) * 0x400 + lowSurrogate - 0xDC00 + 0x10000;
+				return CKEDITOR.env.ie ? character.charCodeAt( 0 ) : character.codePointAt( 0 );
 			}
 
 			var dataProcessor = editor.dataProcessor,

--- a/tests/plugins/entities/entities.js
+++ b/tests/plugins/entities/entities.js
@@ -207,6 +207,29 @@ bender.test( {
 		} );
 	},
 
+	'test entitles_processNumerical="force" with removed filters should leave entities untouched': function() {
+		bender.editorBot.create( {
+			name: 'entities_force5',
+			config: {
+				entities_processNumerical: 'force',
+				allowedContent: true,
+				on: {
+					instanceReady: function() {
+						this.dataProcessor.htmlFilter = {};
+					}
+				}
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&lt;&gt;&amp;</p>',
+				expectedHtml = '<p>&lt;&gt;&amp;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
 	'test entities="false" and entities_processNumerical="force" converts entities to numerical HTML entity': function() {
 		bender.editorBot.create( {
 			name: 'entities_1',

--- a/tests/plugins/entities/entities.js
+++ b/tests/plugins/entities/entities.js
@@ -82,5 +82,21 @@ bender.test( {
 		bot.setData( inputHtml, function() {
 			assert.areEqual( expectedHtml, editor.getData() );
 		} );
+	},
+
+	// (#4941)
+	'test entitles_processNumerical correct encode HTML entity': function() {
+		if ( CKEDITOR.env.ie ) {
+			assert.ignore();
+		}
+
+		var inputHtml = '<p>👍</p>',
+			expectedHtml = '<p>&#128077;</p>',
+			editor = this.editor,
+			bot = this.editorBot;
+
+		bot.setData( inputHtml, function() {
+			assert.areEqual( expectedHtml, editor.getData() );
+		} );
 	}
 } );

--- a/tests/plugins/entities/entities.js
+++ b/tests/plugins/entities/entities.js
@@ -85,18 +85,112 @@ bender.test( {
 	},
 
 	// (#4941)
-	'test entitles_processNumerical correct encode HTML entity': function() {
+	'test entitles_processNumerical correct converts HTML entity to a numerical HTML entity': function() {
 		if ( CKEDITOR.env.ie ) {
 			assert.ignore();
 		}
 
-		var inputHtml = '<p>👍</p>',
-			expectedHtml = '<p>&#128077;</p>',
+		var inputHtml = '<p>👍😄😍💗</p>',
+			expectedHtml = '<p>&#128077;&#128516;&#128525;&#128151;</p>',
 			editor = this.editor,
 			bot = this.editorBot;
 
 		bot.setData( inputHtml, function() {
 			assert.areEqual( expectedHtml, editor.getData() );
+		} );
+	},
+
+	// (#4941)
+	'test entitles_processNumerical="true" and entities_greek="false" converts greek letters to numeric HTML entities': function() {
+		bender.editorBot.create( {
+			name: 'entities_true2',
+			config: {
+				entities_processNumerical: true,
+				entities_greek: false
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>αβγδεζηθικλμνξοπρστυφχψω</p>',
+				expectedHtml =  '<p>&#945;&#946;&#947;&#948;&#949;&#950;&#951;&#952;&#953;&#954;&#955;&#956;&#957;&#958;&#959;&#960;&#961;&#963;&#964;&#965;&#966;&#967;&#968;&#969;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	// (#4941)
+	'test entitles_processNumerical="true" and entities_latin="false" converts some of latin letters entities to numeric HTML entities': function() {
+		bender.editorBot.create( {
+			name: 'entities_true3',
+			config: {
+				entities_processNumerical: true,
+				entities_latin: false
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&Agrave;&Aacute;&Icirc;&Iuml;&ETH;',
+				expectedHtml =  '<p>&#192;&#193;&#206;&#207;&#208;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	// (#4941)
+	'test entitles_processNumerical="force" converts entities to numerical HTML entity': function() {
+		bender.editorBot.create( {
+			name: 'entities_force',
+			config: {
+				entities_processNumerical: 'force'
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&nbsp; &gt; &lt; &amp; &quot;</p>',
+				expectedHtml = '<p>&#160; &#62; &#60; &#38; &#34;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	// (#4941)
+	'test entitles_processNumerical="force" converts greek letters to numeric HTML entities': function() {
+		bender.editorBot.create( {
+			name: 'entities_force2',
+			config: {
+				entities_processNumerical: 'force',
+				entities_greek: true
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>αβγδεζηθικλμνξοπρστυφχψω</p>',
+				expectedHtml =  '<p>&#945;&#946;&#947;&#948;&#949;&#950;&#951;&#952;&#953;&#954;&#955;&#956;&#957;&#958;&#959;&#960;&#961;&#963;&#964;&#965;&#966;&#967;&#968;&#969;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	// (#4941)
+	'test entitles_processNumerical="force" converts latin entities to numerical HTML entity': function() {
+		bender.editorBot.create( {
+			name: 'entities_force3',
+			config: {
+				entities_processNumerical: 'force',
+				entities_latin: true
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&Agrave;&Aacute;&Icirc;&Iuml;&ETH;',
+				expectedHtml =  '<p>&#192;&#193;&#206;&#207;&#208;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
 		} );
 	}
 } );

--- a/tests/plugins/entities/entities.js
+++ b/tests/plugins/entities/entities.js
@@ -100,7 +100,6 @@ bender.test( {
 		} );
 	},
 
-	// (#4941)
 	'test entitles_processNumerical="true" and entities_greek="false" converts greek letters to numeric HTML entities': function() {
 		bender.editorBot.create( {
 			name: 'entities_true2',
@@ -119,7 +118,6 @@ bender.test( {
 		} );
 	},
 
-	// (#4941)
 	'test entitles_processNumerical="true" and entities_latin="false" converts some of latin letters entities to numeric HTML entities': function() {
 		bender.editorBot.create( {
 			name: 'entities_true3',
@@ -138,7 +136,6 @@ bender.test( {
 		} );
 	},
 
-	// (#4941)
 	'test entitles_processNumerical="force" converts entities to numerical HTML entity': function() {
 		bender.editorBot.create( {
 			name: 'entities_force',
@@ -156,7 +153,6 @@ bender.test( {
 		} );
 	},
 
-	// (#4941)
 	'test entitles_processNumerical="force" converts greek letters to numeric HTML entities': function() {
 		bender.editorBot.create( {
 			name: 'entities_force2',
@@ -175,7 +171,6 @@ bender.test( {
 		} );
 	},
 
-	// (#4941)
 	'test entitles_processNumerical="force" converts latin entities to numerical HTML entity': function() {
 		bender.editorBot.create( {
 			name: 'entities_force3',
@@ -184,8 +179,79 @@ bender.test( {
 				entities_latin: true
 			}
 		}, function( bot ) {
-			var inputHtml = '<p>&Agrave;&Aacute;&Icirc;&Iuml;&ETH;',
+			var inputHtml = '<p>&Agrave;&Aacute;&Icirc;&Iuml;&ETH;</p>',
 				expectedHtml =  '<p>&#192;&#193;&#206;&#207;&#208;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	'test entitles_processNumerical="force" with filters off converts entities to numerical HTML entity': function() {
+		bender.editorBot.create( {
+			name: 'entities_force4',
+			config: {
+				entities_processNumerical: 'force',
+				allowedContent: true
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&apos;&quot;&lt;&gt;&amp;</p>',
+				expectedHtml =  '<p>&#39;&#34;&#60;&#62;&#38;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	'test entities="false" and entities_processNumerical="force" converts entities to numerical HTML entity': function() {
+		bender.editorBot.create( {
+			name: 'entities_1',
+			config: {
+				entities_processNumerical: 'force',
+				entities: false
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&lt;&gt;&amp;</p>',
+				expectedHtml = '<p>&#60;&#62;&#38;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	'test entities="false" leaves entities untouched': function() {
+		bender.editorBot.create( {
+			name: 'entities_2',
+			config: {
+				entities: false
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&lt;&gt;&amp;</p>',
+				expectedHtml = '<p>&lt;&gt;&amp;</p>',
+				editor = bot.editor;
+
+			bot.setData( inputHtml, function() {
+				assert.areEqual( expectedHtml, editor.getData() );
+			} );
+		} );
+	},
+
+	'test entities="true" and entities_processNumerical="false" leaves entities untouched': function() {
+		bender.editorBot.create( {
+			name: 'entities_3',
+			config: {
+				entities_processNumerical: false,
+				entities: true
+			}
+		}, function( bot ) {
+			var inputHtml = '<p>&lt;&gt;&amp;</p>',
+				expectedHtml = '<p>&lt;&gt;&amp;</p>',
 				editor = bot.editor;
 
 			bot.setData( inputHtml, function() {

--- a/tests/plugins/entities/manual/encodeentities.html
+++ b/tests/plugins/entities/manual/encodeentities.html
@@ -1,0 +1,14 @@
+<div id="editor">
+	<p>👍</p>
+</div>
+
+<script>
+	if ( CKEDITOR.env.ie ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		entities_processNumerical: true,
+		lang: 'en'
+	} );
+</script>

--- a/tests/plugins/entities/manual/encodeentities.md
+++ b/tests/plugins/entities/manual/encodeentities.md
@@ -1,0 +1,16 @@
+@bender-tags: bug, 4.20.0, 4941
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, entities, sourcearea
+
+1. Open source mode.
+
+**Expected** There is only one HTML entity `&#128077;`.
+
+**Unexpected** Two HTML entities appears: `&#55357;&#56397;`.
+
+2. Close source area.
+
+**Expected** 👍  entity is preserved.
+
+**Unexpected** A surrogate pair appears ��.
+

--- a/tests/plugins/entities/manual/encodeentities.md
+++ b/tests/plugins/entities/manual/encodeentities.md
@@ -2,7 +2,7 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, entities, sourcearea
 
-1. Open source mode.
+1. Open the source mode.
 
 **Expected** There is only one HTML entity `&#128077;`.
 

--- a/tests/plugins/entities/manual/entitiesprocessnumericalforce.html
+++ b/tests/plugins/entities/manual/entitiesprocessnumericalforce.html
@@ -1,0 +1,10 @@
+<div id="editor">
+	<p>&nbsp; &gt; &lt; &amp; &quot;</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		entities_processNumerical: 'force',
+		lang: 'en'
+	} );
+</script>

--- a/tests/plugins/entities/manual/entitiesprocessnumericalforce.md
+++ b/tests/plugins/entities/manual/entitiesprocessnumericalforce.md
@@ -1,0 +1,10 @@
+@bender-tags: bug, 4.20.0, 4941
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, entities, sourcearea
+
+1. Open the source mode.
+
+**Expected** Named entities was converted to a numerical HTML entities: `&#160; &#62; &#60; &#38; &#34;`.
+
+**Unexpected** Entities was not converted: `&nbsp; &gt; &lt; &amp; &quot;`.
+


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4941](https://github.com/ckeditor/ckeditor4/issues/4941): Fix: Some entities get wrongly encoded, when using `entities_processNumerical = true`
```

## What changes did you make?

There was an issue with using `String#charCodeAt()` in the `entities` plugin that returns an integer from 0 to 65535 representing UTF-16 code unit at the given index. In the case when index was greater than 65535 method returns a surrogate pair. To fix this I used `codePointAt()` which returns a Unicode code point value at the given index.

Another issue was with the regex which was unable to match and replace given unicodes. To fix this I updated existing entities regex by adding a `u`- unicode option. 

Unfortunately, this is not working on IE because `codePointAt()` and Unicode option are not supported there. Although it is possible to correctly convert HTMLEntity based on the values from the surrogate pair(see [d148812](https://github.com/ckeditor/ckeditor4/commit/d148812ee33f5231e4193a1a2acbd96f3f81e489#diff-d14edc554ac7a26f0fe8a2787c381907902340da10665f40992a0e417dfb240aR113-R137)) I was unable to find a solution to support the Unicode option on IE.


## Which issues does your PR resolve?

Closes #4941.
