### PR TITLE
Bug fix: Autolink url regexp config fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ New Features:
 
 Fixed Issues:
 
-* [#5319](https://github.com/ckeditor/ckeditor4/issues/5319): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) [`config.autolink_urlRegex`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-autolink_urlRegex) option produces invalid links when configured directly by editor instance configuration. Thanks to [Aigars Zeiza](https://github.com/Zuzon)!
+* [#5319](https://github.com/ckeditor/ckeditor4/issues/5319): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) [`config.autolink_urlRegex`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-autolink_urlRegex) option produces invalid links when configured directly using editor instance configuration. Thanks to [Aigars Zeiza](https://github.com/Zuzon)!
 
 
 API changes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ New Features:
 
 Fixed Issues:
 
+* [#5319](https://github.com/ckeditor/ckeditor4/issues/5319): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) [`config.autolink_urlRegex`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-autolink_urlRegex) option produces invalid links when configured directly by editor instance configuration. Thanks to [Aigars Zeiza](https://github.com/Zuzon)!
+
+
 API changes:
 
 * [#5122](https://github.com/ckeditor/ckeditor4/issues/5122): Added ability to provide a list of buttons as an array to the [`config.removeButtons`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-removeButtons) config variable.

--- a/plugins/autolink/plugin.js
+++ b/plugins/autolink/plugin.js
@@ -81,7 +81,7 @@
 				var link = new CKEDITOR.dom.element( 'a' ),
 					value = text.replace( /"/g, '%22' );
 
-				value = value.match( CKEDITOR.config.autolink_urlRegex ) ? value : 'mailto:' + value;
+				value = value.match( editor.config.autolink_urlRegex ) ? value : 'mailto:' + value;
 
 				link.setText( text );
 				link.setAttribute( 'href', value );

--- a/tests/plugins/autolink/autolink.js
+++ b/tests/plugins/autolink/autolink.js
@@ -18,8 +18,8 @@
 				allowedContent: true,
 				pasteFilter: null,
 				removePlugins: 'link',
-				autolink_urlRegex: /^https:\/\/foobar.com$/,
-				autolink_emailRegex: /^foo@foobar\.com$/
+				autolink_urlRegex: /^url:xxx.xxx$/,
+				autolink_emailRegex: /^mail:xxx$/
 			}
 		},
 		encodedDefault: {
@@ -161,10 +161,10 @@
 			}
 		},
 
-		// (#3156)
+		// (#3156, #5319)
 		'test valid URL link with optional regex': function() {
-			var pastedText = 'https://foobar.com',
-				expected = '<a href="' + pastedText + '">' + pastedText + '</a>';
+			var pastedText = 'url:xxx.xxx',
+				expected = '<a href="http://' + pastedText + '">' + pastedText + '</a>';
 
 			assertPasteEvent( this.editors.optionalParameters, { dataValue: pastedText }, { dataValue: expected, type: 'html' } );
 		},
@@ -193,9 +193,9 @@
 			}
 		},
 
-		// (#3156)
+		// (#3156, #5319)
 		'test valid email link with optional regex': function() {
-			var pastedText = 'foo@foobar.com',
+			var pastedText = 'mail:xxx',
 				expected = '<a href="mailto:' + pastedText + '">' + pastedText + '</a>';
 
 			assertPasteEvent( this.editors.optionalParameters, { dataValue: pastedText }, { dataValue: expected, type: 'html' } );


### PR DESCRIPTION
Previously there was no possibility to override url regexp completely and it worked improperly.

<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5319](https://github.com/ckeditor/ckeditor4/issues/5319): Fixed: Autolink `config.autolink_urlRegex ` configuration option is not respected per editor instance.
```

## What changes did you make?

*Give an overview…*

## Which issues does your PR resolve?

Closes #5319
