### PR TITLE
Fix for incorrect table resize cursor position after scrolling the editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Features:
 
 Fixed Issues:
 
+* [#4889](https://github.com/ckeditor/ckeditor4/issues/4889): Fixed: Incorrect position of the [Table Resize](https://ckeditor.com/cke4/addon/tableresize) cursor after scrolling the editor horizontally.
 * [#5319](https://github.com/ckeditor/ckeditor4/issues/5319): Fixed: [Autolink](https://ckeditor.com/cke4/addon/autolink) [`config.autolink_urlRegex`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-autolink_urlRegex) option produces invalid links when configured directly using editor instance configuration. Thanks to [Aigars Zeiza](https://github.com/Zuzon)!
 
 

--- a/plugins/tableresize/plugin.js
+++ b/plugins/tableresize/plugin.js
@@ -402,11 +402,12 @@
 		init: function( editor ) {
 			editor.on( 'contentDom', function() {
 				var resizer,
-					editable = editor.editable();
+					editable = editor.editable(),
+					// In Classic editor it is better to use document
+					// instead of editable so event will work below body.
+					listenerTarget = editable.isInline() ? editable : editor.document;
 
-				// In Classic editor it is better to use document
-				// instead of editable so event will work below body.
-				editable.attachListener( editable.isInline() ? editable : editor.document, 'mousemove', function( evt ) {
+				editable.attachListener( listenerTarget, 'mousemove', function( evt ) {
 					evt = evt.data;
 
 					var target = evt.getTarget();
@@ -455,6 +456,15 @@
 						!resizer && ( resizer = new columnResizer( editor ) );
 						resizer.attachTo( pillar );
 					}
+				} );
+
+				// Reset pillars position on scroll (#4889).
+				editable.attachListener( listenerTarget, 'scroll', function() {
+					var tables = editable.find( 'table' ).toArray();
+
+					CKEDITOR.tools.array.forEach( tables, CKEDITOR.tools.debounce( function( table ) {
+						table.removeCustomData( '_cke_table_pillars' );
+					}, 200 ) );
 				} );
 			} );
 		}

--- a/tests/plugins/tableresize/manual/scrollupdate.html
+++ b/tests/plugins/tableresize/manual/scrollupdate.html
@@ -1,4 +1,77 @@
-<div id="editor" style="width: 250px; overflow: auto;" contenteditable="true">
+<h2>Inline editor</h2>
+<div id="inline" style="width: 250px; overflow: auto;" contenteditable="true">
+	<table border="1" style="width:500px">
+		<tr>
+			<td>Column 1</td>
+			<td>Column 2</td>
+			<td>Column 3</td>
+			<td>Column 4</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+	</table>
+</div>
+
+<h2><code>div-based</code> editor</h2>
+<div id="div" style="width: 250px; overflow: auto;" contenteditable="true">
+	<table border="1" style="width:500px">
+		<tr>
+			<td>Column 1</td>
+			<td>Column 2</td>
+			<td>Column 3</td>
+			<td>Column 4</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+	</table>
+</div>
+
+<h2><code>iframe</code>-based editor</h2>
+<div id="iframe" style="width: 250px; overflow: auto;" contenteditable="true">
 	<table border="1" style="width:500px">
 		<tr>
 			<td>Column 1</td>
@@ -34,5 +107,12 @@
 </div>
 
 <script>
-	CKEDITOR.inline( 'editor' );
+	CKEDITOR.inline( 'inline' );
+	CKEDITOR.replace( 'div', {
+		extraPlugins: 'divarea',
+		width: 250
+	} );
+	CKEDITOR.replace( 'iframe', {
+		width: 250
+	} );
 </script>

--- a/tests/plugins/tableresize/manual/scrollupdate.html
+++ b/tests/plugins/tableresize/manual/scrollupdate.html
@@ -1,0 +1,38 @@
+<div id="editor" style="width: 250px; overflow: auto;" contenteditable="true">
+	<table border="1" style="width:500px">
+		<tr>
+			<td>Column 1</td>
+			<td>Column 2</td>
+			<td>Column 3</td>
+			<td>Column 4</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+			<td>Cell</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.inline( 'editor' );
+</script>

--- a/tests/plugins/tableresize/manual/scrollupdate.md
+++ b/tests/plugins/tableresize/manual/scrollupdate.md
@@ -3,6 +3,8 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, tabletools, floatingspace
 
 1. Scroll the editor to its right end and then slightly to the left.
+
+	**Note** Use a mouse wheel or a gesture on trackpad to scroll. The bug does not occur when dragging the scrollbar.
 1. Try to resize the last column.
 
 	**Expected** The resizing cursor is in the right place.

--- a/tests/plugins/tableresize/manual/scrollupdate.md
+++ b/tests/plugins/tableresize/manual/scrollupdate.md
@@ -8,3 +8,4 @@
 	**Expected** The resizing cursor is in the right place.
 
 	**Unexpected** The resizing cursor is moved from the column's border.
+1. Repeat the procedure for all editors.

--- a/tests/plugins/tableresize/manual/scrollupdate.md
+++ b/tests/plugins/tableresize/manual/scrollupdate.md
@@ -1,0 +1,10 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.20.0, 4889
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tableresize, tabletools, floatingspace
+
+1. Scroll the editor to its right end and then slightly to the left.
+1. Try to resize the last column.
+
+	**Expected** The resizing cursor is in the right place.
+
+	**Unexpected** The resizing cursor is moved from the column's border.

--- a/tests/plugins/tableresize/tableresize.html
+++ b/tests/plugins/tableresize/tableresize.html
@@ -18,6 +18,32 @@
 	</table>
 </div>
 
+<div id="inline-overflow" contenteditable="true" style="width: 250px;overflow: hidden;">
+	<table border="1" style="width: 500px;">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+
+<textarea id="classic-overflow">
+	&lt;table border="1" style="width: 500px;"&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Cell 1.1&lt;/td&gt;
+			&lt;td&gt;Cell 1.2&lt;/td&gt;
+		&lt;/tr&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Cell 2.1&lt;/td&gt;
+			&lt;td&gt;Cell 2.2&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/table&gt;
+</textarea>
+
 <table border="1" id="outside">
 	<tbody>
 		<tr>

--- a/tests/plugins/tableresize/tableresize.js
+++ b/tests/plugins/tableresize/tableresize.js
@@ -109,6 +109,16 @@ bender.editors = {
 		name: 'intable',
 		creator: 'inline'
 	},
+	inlineOverflow: {
+		name: 'inline-overflow',
+		creator: 'inline'
+	},
+	classicOverflow: {
+		name: 'classic-overflow',
+		config: {
+			width: 250
+		}
+	},
 	undo: {
 		name: 'undo'
 	}
@@ -301,6 +311,44 @@ bender.test( {
 				} );
 			}
 		} );
+
+		wait();
+	},
+
+	// (#4889)
+	'test pillars are resetted on scroll (inline)': function() {
+		var editor = this.editors.inlineOverflow,
+			editable = editor.editable(),
+			table = editable.findOne( 'table' );
+
+		init( table, editor );
+
+		editable.fire( 'scroll', {} );
+
+		setTimeout( function() {
+			resume( function() {
+				assert.areSame( null, table.getCustomData( '_cke_table_pillars' ) );
+			} );
+		}, 210 );
+
+		wait();
+	},
+
+	// (#4889)
+	'test pillars are resetted on scroll (classic)': function() {
+		var editor = this.editors.classicOverflow,
+			editable = editor.editable(),
+			table = editable.findOne( 'table' );
+
+		init( table, editor );
+
+		editor.document.fire( 'scroll', {} );
+
+		setTimeout( function() {
+			resume( function() {
+				assert.areSame( null, table.getCustomData( '_cke_table_pillars' ) );
+			} );
+		}, 210 );
 
 		wait();
 	}


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4889](https://github.com/ckeditor/ckeditor4/issues/4889): Fixed: incorrect position of the [Table Resize](https://ckeditor.com/cke4/addon/tableresize) cursor after scrolling the editor horizontally.
```

## What changes did you make?

I've added a debounced listener for the `scroll` event that removes cached positions of pillars from the table being currently resized. It forces the plugin to recalculate pillars positions.

The current fix adds the listener to both `iframe`-based and inline editors however I was able to reproduce it only in inline one. The fix can be easily refactored to work only in the inline editors.

## Which issues does your PR resolve?

Closes #4889.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
