### PR TITLE
Improvement for allowing subscript and superscript at the same time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,11 +7,10 @@ New Features:
 
 * [#5084](https://github.com/ckeditor/ckeditor4/issues/5084): Introduce new types of table cells – "Column Header" and "Row Header" due to added support for `scope` attribute.
 * [#5219](https://github.com/ckeditor/ckeditor4/issues/5219): Added the [`config.image2_defaultLockRatio`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-image2_defaultLockRatio) config variable to allow setting the default value of the "Lock ratio" option in the [Enhanced Image](https://ckeditor.com/cke4/addon/image2) dialog.
-* [#5215](https://github.com/ckeditor/ckeditor4/issues/5215): Added a new config option to allow setting subscript and superscript simultaneously on the same element.
 * [#2008](https://github.com/ckeditor/ckeditor-dev/pull/2008): Extended the [Mentions](https://ckeditor.com/cke4/addon/mentions) and [Emoji](https://ckeditor.com/cke4/addon/emoji) plugins with a feature option that adds a space after accepted autocompletion match. See:
 	* [`configDefinition.followingSpace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_mentions_configDefinition.html#property-followingSpace) option for mentions plugin, and
 	* [`config.emoji_followingSpace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-emoji_followingSpace) option for emoji plugin.
-
+* [#5215](https://github.com/ckeditor/ckeditor4/issues/5215): Added the [`config.coreStyles_toggleSubSup`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-coreStyles_toggleSubSup) configuration option disallowing setting subscript and superscript simultaneously on the same element using UI buttons. This option is turned off by default.
 
 Fixed Issues:
 

--- a/plugins/basicstyles/plugin.js
+++ b/plugins/basicstyles/plugin.js
@@ -106,19 +106,32 @@ CKEDITOR.plugins.add( 'basicstyles', {
 	afterInit: function( editor ) {
 		var subscriptCommand = editor.getCommand( 'subscript' ),
 			superscriptCommand = editor.getCommand( 'superscript' ),
-			allowAddSubSup = editor.config.coreStyles_allowSubscriptSuperscript;
+			allowAddSubSup = editor.config.coreStyles_toggleSubSup;
 
 		// Prevent adding subscript and superscript only when both buttons exists. (#5215)
-		if ( allowAddSubSup || !( subscriptCommand && superscriptCommand ) ) {
-			return
+		if ( !allowAddSubSup || !( subscriptCommand && superscriptCommand ) ) {
+			return;
 		}
 
 		editor.on( 'beforeCommandExec', function( evt ) {
+			var areSubAndSupActive = subscriptCommand.state == CKEDITOR.TRISTATE_ON && superscriptCommand.state == CKEDITOR.TRISTATE_ON;
+
 			if ( evt.data.name === 'subscript' ) {
+				// If sub and superscript are enabled, disable only subscript.
+				if ( areSubAndSupActive ) {
+					disableSubSup( subscriptCommand, evt );
+					return;
+				}
+
 				offActiveCommand( superscriptCommand );
 			}
 
 			if ( evt.data.name === 'superscript' ) {
+				if ( areSubAndSupActive ) {
+					disableSubSup( superscriptCommand, evt );
+					return;
+				}
+
 				offActiveCommand( subscriptCommand );
 			}
 		} );
@@ -136,6 +149,11 @@ CKEDITOR.plugins.add( 'basicstyles', {
 				command.exec( editor );
 				editor.fire( 'lockSnapshot' );
 			}
+		}
+
+		function disableSubSup( command, event ) {
+			command.exec( editor );
+			event.cancel();
 		}
 	}
 } );
@@ -248,9 +266,9 @@ CKEDITOR.config.coreStyles_superscript = { element: 'sup' };
 /**
  * Allow setting subscript and superscript simultaneously on the same element.
  *
- * @cfg {Boolean} [coreStyles_allowSubscriptSuperscript=false]
+ * @cfg {Boolean} [coreStyles_toggleSubSup=false]
  * @since 4.20.0
  * @member CKEDITOR.config
  */
 
-CKEDITOR.config.coreStyles_allowSubscriptSuperscript = false;
+CKEDITOR.config.coreStyles_toggleSubSup = false;

--- a/plugins/basicstyles/plugin.js
+++ b/plugins/basicstyles/plugin.js
@@ -104,57 +104,37 @@ CKEDITOR.plugins.add( 'basicstyles', {
 	},
 
 	afterInit: function( editor ) {
-		var subscriptCommand = editor.getCommand( 'subscript' ),
-			superscriptCommand = editor.getCommand( 'superscript' ),
-			allowAddSubSup = editor.config.coreStyles_toggleSubSup;
-
-		// Prevent adding subscript and superscript only when both buttons exists. (#5215)
-		if ( !allowAddSubSup || !( subscriptCommand && superscriptCommand ) ) {
+		// If disabled, sub and sub scripts can be applied to element simoultaneously.
+		// The rest of that code takes care of toggling both elements (#5215).
+		if ( !editor.config.coreStyles_toggleSubSup ) {
 			return;
 		}
 
-		editor.on( 'beforeCommandExec', function( evt ) {
-			var areSubAndSupActive = subscriptCommand.state == CKEDITOR.TRISTATE_ON && superscriptCommand.state == CKEDITOR.TRISTATE_ON;
+		var subscriptCommand = editor.getCommand( 'subscript' ),
+			superscriptCommand = editor.getCommand( 'superscript' );
 
-			if ( evt.data.name === 'subscript' ) {
-				// If sub and superscript are enabled, disable only subscript.
-				if ( areSubAndSupActive ) {
-					disableSubSup( subscriptCommand, evt );
-					return;
-				}
-
-				offActiveCommand( superscriptCommand );
-			}
-
-			if ( evt.data.name === 'superscript' ) {
-				if ( areSubAndSupActive ) {
-					disableSubSup( superscriptCommand, evt );
-					return;
-				}
-
-				offActiveCommand( subscriptCommand );
-			}
-		} );
+		// Both commands are required for toggle operation.
+		if ( !subscriptCommand || !superscriptCommand ) {
+			return;
+		}
 
 		editor.on( 'afterCommandExec', function( evt ) {
-			// Unlock and save snapshot after subscript or superscript was added to create a undo step. (#5215)
-			if ( evt.data.name === 'subscript' || evt.data.name === 'superscript' ) {
-				editor.fire( 'unlockSnapshot' );
-				editor.fire( 'saveSnapshot' );
+			var commandName = evt.data.name;
+
+			if ( commandName !== 'subscript' && commandName !== 'superscript' ) {
+				return;
+			}
+
+			var executedCommand = commandName === 'subscript' ? subscriptCommand : superscriptCommand,
+				otherCommand = commandName === 'subscript' ? superscriptCommand : subscriptCommand;
+
+			// Disable the other command if both are enabled.
+			if ( executedCommand.state === CKEDITOR.TRISTATE_ON && otherCommand.state === CKEDITOR.TRISTATE_ON ) {
+				otherCommand.exec( editor );
+				// Merge undo images, so toggle operation is treated as a single undo step.
+				editor.fire( 'updateSnapshot' );
 			}
 		} );
-
-		function offActiveCommand( command ) {
-			if ( command.state === CKEDITOR.TRISTATE_ON ) {
-				command.exec( editor );
-				editor.fire( 'lockSnapshot' );
-			}
-		}
-
-		function disableSubSup( command, event ) {
-			command.exec( editor );
-			event.cancel();
-		}
 	}
 } );
 
@@ -264,7 +244,10 @@ CKEDITOR.config.coreStyles_subscript = { element: 'sub' };
 CKEDITOR.config.coreStyles_superscript = { element: 'sup' };
 
 /**
- * Allow setting subscript and superscript simultaneously on the same element.
+ * Disallow setting subscript and superscript simultaneously on the same element using UI buttons.
+ *
+ * By default, you can apply subscript and superscript styles to the same element. Enabling that option
+ * will remove the superscript style when the subscript button is pressed and vice versa.
  *
  * @cfg {Boolean} [coreStyles_toggleSubSup=false]
  * @since 4.20.0

--- a/tests/plugins/basicstyles/basicstyles.js
+++ b/tests/plugins/basicstyles/basicstyles.js
@@ -48,7 +48,10 @@ bender.test( {
 	// (#5215)
 	'test toggle subscript and superscript on selected text': function() {
 		bender.editorBot.create( {
-			name: 'editor-subsup1'
+			name: 'editor-subsup1',
+			config: {
+				coreStyles_toggleSubSup: true
+			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
@@ -70,7 +73,10 @@ bender.test( {
 	// (#5215)
 	'test properly toggle subscript and superscript on selected text with other basic styles': function() {
 		bender.editorBot.create( {
-			name: 'editor-subsup2'
+			name: 'editor-subsup2',
+			config: {
+				coreStyles_toggleSubSup: true
+			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
@@ -94,6 +100,7 @@ bender.test( {
 		bender.editorBot.create( {
 			name: 'editor-subsup3',
 			config: {
+				coreStyles_toggleSubSup: true,
 				extraPlugins: 'undo'
 			}
 		}, function( bot ) {
@@ -130,7 +137,10 @@ bender.test( {
 	// (#5215)
 	'test toggle subscript and superscript not disappear selection': function() {
 		bender.editorBot.create( {
-			name: 'editor-subsup4'
+			name: 'editor-subsup4',
+			config: {
+				coreStyles_toggleSubSup: true
+			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
@@ -158,7 +168,10 @@ bender.test( {
 	// (#5215)
 	'test toggle subscript and superscript contain only one active UI button': function() {
 		bender.editorBot.create( {
-			name: 'editor-subsup5'
+			name: 'editor-subsup5',
+			config: {
+				coreStyles_toggleSubSup: true
+			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
@@ -184,11 +197,11 @@ bender.test( {
 		} );
 	},
 
-	'test allow add subscript and superscript at the same time when coreStyles_allowSubscriptSuperscript is ON': function() {
+	'test allow add subscript and superscript at the same time when config.coreStyles_toggleSubSup is OFF': function() {
 		bender.editorBot.create( {
 			name: 'editor-subsup6',
 			config: {
-				coreStyles_allowSubscriptSuperscript: true
+				coreStyles_toggleSubSup: false
 			}
 		}, function( bot ) {
 			var editor = bot.editor;
@@ -208,27 +221,39 @@ bender.test( {
 		} );
 	},
 
-	'test disallow add subscript and superscript at the same time when coreStyles_allowSubscriptSuperscript is explicit OFF': function() {
+	'test remove subscript from content which contain subscript and superscript elements': function() {
 		bender.editorBot.create( {
 			name: 'editor-subsup7',
 			config: {
-				coreStyles_allowSubscriptSuperscript: false
+				coreStyles_toggleSubSup: true
 			}
 		}, function( bot ) {
 			var editor = bot.editor;
 
-			bot.setHtmlWithSelection( '<p>[foo] bar</p>' );
+			bot.setHtmlWithSelection( '<p><sup><sub>[foo]</sub></sup> bar</p>' );
 			editor.execCommand( 'subscript' );
-			assert.areSame(
-				'<p><sub>foo</sub> bar</p>',
-				editor.editable().getData(),
-				'There is no added subscript element' );
-
-			editor.execCommand( 'superscript' );
 			assert.areSame(
 				'<p><sup>foo</sup> bar</p>',
 				editor.editable().getData(),
-				'There is no subscript and superscript element' );
+				'Subscript element is not removed' );
+		} );
+	},
+
+	'test remove superscript from content which contain subscript and superscript elements': function() {
+		bender.editorBot.create( {
+			name: 'editor-subsup8',
+			config: {
+				coreStyles_toggleSubSup: true
+			}
+		}, function( bot ) {
+			var editor = bot.editor;
+
+			bot.setHtmlWithSelection( '<p><sup><sub>[foo]</sub></sup> bar</p>' );
+			editor.execCommand( 'superscript' );
+			assert.areSame(
+				'<p><sub>foo</sub> bar</p>',
+				editor.editable().getData(),
+				'Superscript element is not removed' );
 		} );
 	}
 } );

--- a/tests/plugins/basicstyles/manual/toggleexistingsubsupscript.html
+++ b/tests/plugins/basicstyles/manual/toggleexistingsubsupscript.html
@@ -1,0 +1,10 @@
+<h2>Classic editor</h2>
+<div id="editor">
+	<p><sub><sup>foobar</sup></sub></p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		coreStyles_toggleSubSup: true
+	} );
+</script>

--- a/tests/plugins/basicstyles/manual/toggleexistingsubsupscript.md
+++ b/tests/plugins/basicstyles/manual/toggleexistingsubsupscript.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.20.0, feature, 5215
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, basicstyles, sourcearea, elementspath, undo, floatingspace
+
+1. Select `foobar` text.
+2. Click subscript button.
+
+**Expected** Selected text contain only `superscript` style.
+
+3. Click undo button.
+4. Click redo button.
+
+**Expected** There is only one step needed to back to enabled `subscript` button.
+
+5. Repeat above steps for `subscript` button.

--- a/tests/plugins/basicstyles/manual/togglesubsupscript.html
+++ b/tests/plugins/basicstyles/manual/togglesubsupscript.html
@@ -1,7 +1,9 @@
+<h2>Classic editor</h2>
 <div id="editor">
 	<p>foo bar</p>
 </div>
 
+<h2>Inline editor</h2>
 <div id="inline" contenteditable="true">
 	<p>foo bar</p>
 </div>

--- a/tests/plugins/basicstyles/manual/togglesubsupscript.html
+++ b/tests/plugins/basicstyles/manual/togglesubsupscript.html
@@ -9,7 +9,7 @@
 <script>
 	var cfg = {
 		lang: 'en',
-		coreStyles_disallowSubscriptSuperscript: true
+		coreStyles_toggleSubSup: true
 	}
 
 	CKEDITOR.replace( 'editor', cfg );


### PR DESCRIPTION
It's a follow-up to https://github.com/ckeditor/ckeditor4/pull/5312

Changes:
* Renamed config option to `coreStyles_toggleSubSup`.
* Fixed a bug that removed sup and superscript elements when pasting content containing these elements via sourcemode and then attempting to disable one of them in toolbar.
Screencast with bug:


https://user-images.githubusercontent.com/18471998/190137470-66757ee2-3ec0-4e3e-9605-88e3425fcf45.mov


* Added unit test to cover fix for the above issue.
* Updated changelog.