### PR TITLE
Introduce `CKEDITOR.config.tabletools_scopedHeaders`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ CKEditor 4 Changelog
 
 New Features:
 
-* [#5084](https://github.com/ckeditor/ckeditor4/issues/5084): Introduce new types of table cells – "Column Header" and "Row Header" due to added support for `scope` attribute.
+* [#5084](https://github.com/ckeditor/ckeditor4/issues/5084): Added the [`config.tabletools_scopedHeaders`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-tabletools_scopedHeaders) configuration option controlling the behaviour of table headers with and without the `[scope]` attribute.
 * [#5219](https://github.com/ckeditor/ckeditor4/issues/5219): Added the [`config.image2_defaultLockRatio`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-image2_defaultLockRatio) config variable to allow setting the default value of the "Lock ratio" option in the [Enhanced Image](https://ckeditor.com/cke4/addon/image2) dialog.
 * [#2008](https://github.com/ckeditor/ckeditor-dev/pull/2008): Extended the [Mentions](https://ckeditor.com/cke4/addon/mentions) and [Emoji](https://ckeditor.com/cke4/addon/emoji) plugins with a feature option that adds a space after accepted autocompletion match. See:
 	* [`configDefinition.followingSpace`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_mentions_configDefinition.html#property-followingSpace) option for mentions plugin, and

--- a/plugins/tabletools/dialogs/tableCell.js
+++ b/plugins/tabletools/dialogs/tableCell.js
@@ -122,12 +122,7 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 				requiredContent: 'th[scope]',
 				label: langCell.cellType,
 				'default': 'td',
-				items: [
-					[ langCell.data, 'td' ],
-					[ langCell.header, 'th' ],
-					[ langCell.columnHeader, 'thc' ],
-					[ langCell.rowHeader, 'thr' ]
-				],
+				items: getAvailableCellTypes( editor ),
 				setup: setupCells( function( selectedCell ) {
 					var cellName = selectedCell.getName(),
 						scope = selectedCell.getAttribute( 'scope' );
@@ -577,5 +572,20 @@ CKEDITOR.dialog.add( 'cellProperties', function( editor ) {
 		} else if ( property == 'border-color' ) {
 			selectedCell.removeAttribute( 'borderColor' );
 		}
+	}
+
+	function getAvailableCellTypes( editor ) {
+		if ( editor.config.tabletools_scopedHeaders ) {
+			return [
+				[ langCell.data, 'td' ],
+				[ langCell.columnHeader, 'thc' ],
+				[ langCell.rowHeader, 'thr' ]
+			];
+		}
+
+		return [
+			[ langCell.data, 'td' ],
+			[ langCell.header, 'th' ]
+		];
 	}
 } );

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -1271,6 +1271,46 @@ CKEDITOR.tools.buildTableMap = function( table, startRow, startCell, endRow, end
 };
 
 /**
+ * Indicates if table header elements (`th`) needs the
+ * [`scope` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope).
+ *
+ * This config variable changes the available values of the "Cell Type" field inside the
+ * "Cell Properties" dialog. If it's set to `false` (the default value), the "Cell Type" field
+ * will contain two options:
+ *
+ * * "Data",
+ * * "Header".
+ *
+ * If the option is set to `true`, the "Cell Type" field in the "Cell Properties" dialog
+ * will contain three possible values:
+ *
+ * * "Data",
+ * * "Column Header",
+ * * "Row Header".
+ *
+ * Additionally, if this config variable is set to `true` and there is a `th` element without the
+ * `scope` attribute in the editor's content, its "Cell Type" value will be set to an empty value.
+ * To fix this, the `th` element needs to be transformed to gain the `scope` attribute.
+ * The sample transformation that adds `[scope=col]` to all scopeless `th` elements is presented below:
+ *
+ * ```javascript
+ * editor.filter.addTransformations( [
+ * 	[
+ * 		{
+ * 			element: 'th',
+ * 			left: function( el ) {
+ * 				return !el.attributes.scope;
+ * 			},
+ * 			right: function( el ) {
+ * 				el.attributes.scope = 'col';
+ * 			}
+ * 		}
+ * 	]
+ * ] );
+ * ```
+ *
+ * The transformation is added to the editor using {@link CKEDITOR.filter#addTransformations}.
+ *
  * @since 4.20.0
  * @cfg [tabletools_scopedHeaders=false]
  * @member CKEDITOR.config

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -1271,10 +1271,7 @@ CKEDITOR.tools.buildTableMap = function( table, startRow, startCell, endRow, end
 };
 
 /**
- * Indicates if table header elements (`th`) needs the
- * [`scope` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope).
- *
- * This config variable changes the available values of the "Cell Type" field inside the
+ * Changes the available values of the "Cell Type" field inside the
  * "Cell Properties" dialog. If it's set to `false` (the default value), the "Cell Type" field
  * will contain two options:
  *
@@ -1288,9 +1285,16 @@ CKEDITOR.tools.buildTableMap = function( table, startRow, startCell, endRow, end
  * * "Column Header",
  * * "Row Header".
  *
- * Additionally, if this config variable is set to `true` and there is a `th` element without the
+ * Column and row header options updates table headers (`th`) with the
+ * [`scope` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope)
+ * that may improve accessibility experience in more complex tables. Read the
+ * [w3.org guide about using the scope attribute to associate header cells
+ * and data cells in data tables](https://www.w3.org/WAI/WCAG21/Techniques/html/H63)
+ * to learn more.
+ *
+ * If this config variable is set to `true` and there is a `th` element without the
  * `scope` attribute in the editor's content, its "Cell Type" value will be set to an empty value.
- * To fix this, the `th` element needs to be transformed to gain the `scope` attribute.
+ * To avoid that issue, tables with `th` elements need to be migrated.
  * The sample transformation that adds `[scope=col]` to all scopeless `th` elements is presented below:
  *
  * ```javascript

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -1269,3 +1269,10 @@ CKEDITOR.tools.buildTableMap = function( table, startRow, startCell, endRow, end
 	}
 	return aMap;
 };
+
+/**
+ * @since 4.20.0
+ * @cfg [tabletools_scopedHeaders=false]
+ * @member CKEDITOR.config
+ */
+CKEDITOR.config.tabletools_scopedHeaders = false;

--- a/plugins/tabletools/plugin.js
+++ b/plugins/tabletools/plugin.js
@@ -334,7 +334,7 @@
 				return selection;
 			}
 
-			range = ranges[0];
+			range = ranges[ 0 ];
 			if ( range.collapsed || range.endOffset !== 0 ) {
 				return selection;
 			}

--- a/tests/plugins/tabletools/_helpers/cellproperties.js
+++ b/tests/plugins/tabletools/_helpers/cellproperties.js
@@ -1,8 +1,12 @@
 /* exported doTest, assertChildren */
 
-function doTest( name, dialogCallback ) {
+function doTest( name, dialogCallback, editorName ) {
+	if ( !editorName ) {
+		editorName = 'basic';
+	}
+
 	return function() {
-		var bot = this.editorBot;
+		var bot = this.editorBots[ editorName ];
 
 		bender.tools.testInputOut( name, function( source, expected ) {
 			bot.setHtmlWithSelection( source );

--- a/tests/plugins/tabletools/cellproperties.html
+++ b/tests/plugins/tabletools/cellproperties.html
@@ -507,3 +507,21 @@
 		</tbody>
 	</table>
 </textarea>
+
+<textarea id="table-cell-th-ui">
+	<table>
+		<tbody>
+			<tr>
+				<th>[aa]</th>
+			</tr>
+		</tbody>
+	</table>
+	=>
+	<table>
+		<tbody>
+			<tr>
+				<th>aa</th>
+			</tr>
+		</tbody>
+	</table>
+</textarea>

--- a/tests/plugins/tabletools/cellproperties.js
+++ b/tests/plugins/tabletools/cellproperties.js
@@ -6,10 +6,25 @@
 ( function() {
 	'use strict';
 
-	bender.editor = true;
+	bender.editors = {
+		basic: {
+			name: 'basic'
+		},
+		scopedHeadersOn: {
+			name: 'scopedHeadersOn',
+			config: {
+				tabletools_scopedHeaders: true
+			}
+		},
+		scopedHeadersOff: {
+			name: 'scopedHeadersOff',
+			config: {
+				tabletools_scopedHeaders: false
+			}
+		}
+	};
 
 	bender.test( {
-
 		'test cell properties dialog (text selection)': doTest( 'table-1', function( dialog ) {
 				dialog.setValueOf( 'info', 'width', 100 );
 				dialog.setValueOf( 'info', 'height', 50 );
@@ -157,19 +172,56 @@
 		} ),
 
 		// (#5084)
-		'test cell data type has th name and does not have scope attribute': doTest( 'table-cell-th', function( dialog ) {
-			dialog.setValueOf( 'info', 'cellType', 'th' );
-		} ),
+		'test cell data type has th name and does not have scope attribute (default scopedHeaders)':
+			doTest( 'table-cell-th', function( dialog ) {
+				dialog.setValueOf( 'info', 'cellType', 'th' );
+			} ),
+
+		// (#5084)
+		'test cell data type has th name and does not have scope attribute (scopedHeaders=false)':
+			doTest( 'table-cell-th', function( dialog ) {
+				dialog.setValueOf( 'info', 'cellType', 'th' );
+			}, 'scopedHeadersOff' ),
+
+		// (#5084)
+		'test th is represented as an empty option which does not change the content (scopedHeaders=true)':
+			doTest( 'table-cell-th-ui', function( dialog ) {
+				var actualCellType = dialog.getValueOf( 'info', 'cellType' );
+
+				assert.areSame( '', actualCellType );
+
+				dialog.setValueOf( 'info', 'cellType', '' );
+			}, 'scopedHeadersOn' ),
+
+		// (#5084)
+		'test th is represented as a "Header" option which does not change the content (scopedHeaders=false)':
+			doTest( 'table-cell-th-ui', function( dialog ) {
+				var actualCellType = dialog.getValueOf( 'info', 'cellType' );
+
+				assert.areSame( 'th', actualCellType );
+
+				dialog.setValueOf( 'info', 'cellType', 'th' );
+			}, 'scopedHeadersOff' ),
+
+		// (#5084)
+		'test th is represented as a "Header" option which does not change the content (default scopedHeaders)':
+			doTest( 'table-cell-th-ui', function( dialog ) {
+				var actualCellType = dialog.getValueOf( 'info', 'cellType' );
+
+				assert.areSame( 'th', actualCellType );
+
+				dialog.setValueOf( 'info', 'cellType', 'th' );
+			} ),
 
 		// (#5084)
 		'test cell column header type has th name and have scope attribute set to col': doTest( 'table-cell-thc', function( dialog ) {
 			dialog.setValueOf( 'info', 'cellType', 'thc' );
-		} ),
+		}, 'scopedHeadersOn' ),
 
 		// (#5084)
 		'test cell row header type has th name and have scope attribute set to row': doTest( 'table-cell-thr', function( dialog ) {
 			dialog.setValueOf( 'info', 'cellType', 'thr' );
-		} ),
+		}, 'scopedHeadersOn' ),
 
 		// https://dev.ckeditor.com/ticket/16893
 		'test allowedContent rule': function() {

--- a/tests/plugins/tabletools/manual/allowedcontent.html
+++ b/tests/plugins/tabletools/manual/allowedcontent.html
@@ -57,7 +57,6 @@
 		eventName = CKEDITOR.env.ie && CKEDITOR.env.version === 8 ? 'click' : 'change',
 		editor;
 
-	//Create checkboxes
 	for ( var key in cellPropMap ) {
 		var name = cellPropMap[ key ],
 			additionalInfo = name === 'colordialog' ? '<br> Adds button for picking color next to border and background color options.' : '';
@@ -105,9 +104,7 @@
 		switch ( rule ) {
 			case 'th':
 				if ( state ) {
-					allowedContent.th = {
-						attributes: [ 'scope' ]
-					}
+					allowedContent.th = true;
 				} else {
 					delete allowedContent.th;
 				}

--- a/tests/plugins/tabletools/manual/cellproperties.html
+++ b/tests/plugins/tabletools/manual/cellproperties.html
@@ -22,7 +22,7 @@
 
 <script>
 	CKEDITOR.replace( 'editor', {
-		allowedContent: '*[lang,dir]; table tbody thead tr td tfoot; th[scope]'
+		allowedContent: '*[lang,dir]; table tbody thead tr td th tfoot'
 	} );
 	CKEDITOR.replace( 'editor1' );
 </script>

--- a/tests/plugins/tabletools/manual/cellpropertiescelltype.html
+++ b/tests/plugins/tabletools/manual/cellpropertiescelltype.html
@@ -16,6 +16,7 @@
 
 <script>
 	CKEDITOR.replace( 'editor', {
-		language: 'en'
+		language: 'en',
+		tabletools_scopedHeaders: true
 	} );
 </script>

--- a/tests/plugins/tabletools/manual/cellpropertiescelltype.md
+++ b/tests/plugins/tabletools/manual/cellpropertiescelltype.md
@@ -6,34 +6,20 @@
 
 1. Right click at any cell, and select `Cell` -> `Cell Properties`.
 
-**Expected** Cell has `Data` type.
+	**Expected** Cell has `Data` type.
+1. Change cell type to `Column Header`.
 
-2. Change cell type to `Header`.
+	**Expected** Cell has `th` type and `scope` attribute set on `col`.
+1. Right click at recent cell, and select `Cell` -> `Cell Properties`.
 
-**Expected** Cell has `th` type and do not have `scope` attribute.
+	**Expected** Cell has `Column Header` type.
+1. Change cell type to `Row Header`.
 
-3. Right click at recent cell, and select `Cell` -> `Cell Properties`.
+	**Expected** Cell has `th` type and `scope` attribute set on `row`.
+1. Right click at recent cell, and select `Cell` -> `Cell Properties`.
 
-**Expected** Cell has `Header` type.
+	**Expected** Cell has `Row Header` type.
+1. Change cell type to `Data`.
 
-4. Change cell type to `Column Header`.
-
-**Expected** Cell has `th` type and `scope` attribute set on `col`.
-
-5. Right click at recent cell, and select `Cell` -> `Cell Properties`.
-
-**Expected** Cell has `Column Header` type.
-
-6. Change cell type to `Row Header`.
-
-**Expected** Cell has `th` type and `scope` attribute set on `row`.
-
-7. Right click at recent cell, and select `Cell` -> `Cell Properties`.
-
-**Expected** Cell has `Row Header` type.
-
-8. Change cell type to `Data`.
-
-**Expected** Cell has `td` type and do not have `scope` attribute.
-
-9. Play with cell types and verify if they type matches expectations from the above.
+	**Expected** Cell has `td` type and do not have `scope` attribute.
+1. Play with cell types and verify if they type matches expectations from the above.

--- a/tests/plugins/tabletools/manual/scopedheaders.html
+++ b/tests/plugins/tabletools/manual/scopedheaders.html
@@ -1,0 +1,55 @@
+<h2>Scoped headers on</h2>
+<div id="editor1">
+	<table border="1">
+		<tr>
+			<th>Column 1</th>
+			<th>Column 2</th>
+		</tr>
+		<tr>
+			<td>Cell 1.2</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+
+<h2>Scoped headers off</h2>
+<div id="editor2">
+	<table border="1">
+		<tr>
+			<th>Column 1</th>
+			<th>Column 2</th>
+		</tr>
+		<tr>
+			<td>Cell 1.2</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+
+<h2>Scoped headers default</h2>
+<div id="editor3">
+	<table border="1">
+		<tr>
+			<th>Column 1</th>
+			<th>Column 2</th>
+		</tr>
+		<tr>
+			<td>Cell 1.2</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		tabletools_scopedHeaders: true,
+		language: 'en'
+	} );
+	CKEDITOR.replace( 'editor2', {
+		tabletools_scopedHeaders: false,
+		language: 'en'
+	} );
+	CKEDITOR.replace( 'editor3', {
+		language: 'en'
+	} );
+</script>

--- a/tests/plugins/tabletools/manual/scopedheaders.md
+++ b/tests/plugins/tabletools/manual/scopedheaders.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.20.0, 5804, feature
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools
+
+1. Open the "Cell Properties" dialog for one of the column headers.
+1. Check the "Cell Type" value.
+
+	**Expected** For the "Scoped headers on": the empty option is selected.
+
+	For other editors: the "Header" option is selected.
+1. Check available values for the "Cell Type" field
+
+	**Expected** For the "Scoped headers on": Data, Column Header, Row Header
+
+	For other editors: Data, Header

--- a/tests/plugins/tabletools/manual/scopedheaders.md
+++ b/tests/plugins/tabletools/manual/scopedheaders.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.20.0, 5804, feature
+@bender-tags: 4.20.0, 5084, feature
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, table, tabletools
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5084](https://github.com/ckeditor/ckeditor4/issues/5084): Added the [`config.tabletools_scopedHeaders`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-tabletools_scopedHeaders) configuration option controlling the behaviour of table headers with and without the `[scope]` attribute.
```

## What changes did you make?

I've introduced the `CKEDITOR.config.tabletools_scopedHeaders` config variable which controls how the UI of "Cell Properties" dialog identify the `th` elements without the `[scope]` attribute:

* `true` means that such cells will be represented as an empty option and available values are "Data", "Column Header" and "Row Header",
* `false` means that such cells will be represented as "Header" option and available values are "Data" and "Header".

 I've also added detailed API docs for it.
