### PR TITLE
Fire change event after upload completes

### DIFF
--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -88,6 +88,9 @@
 					this.replaceWith( '<img src="' + upload.url + '" ' +
 						'width="' + width + '" ' +
 						'height="' + height + '">' );
+					
+					// Fire change event in order to get updated content.
+					editor.fire('change');
 				}
 			} );
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

This allows user to get the updated data after image is uploaded.

Today, there is a bug, that after the upload completes, the call to getData() returns an old HTML version (without the image tag updated...)

This solve the  issue #1180

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

### This PR contains

- [ ] Unit tests
- [x] Manual tests

Test:
- Create a simplest editor with image and imageupload pluging
- Configure upload to some valid upload server
- Add the following event listener:
```js
editor.on('change',function(e){  console.log(e.editor.getDate())  })
```
- Paste some image into editor (and observe)
- Before this fix, 'change' is not fired
- After this fix, 'change' is fired and user can handle new data.

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#1180](https://github.com/ckeditor/ckeditor4/issues/1180): Fix bug when uploading pasting data and change event not fired correctly.
```

## What changes did you make?

Just added a call to fire method of editor instance, firing the "change" event.

## Which issues does your PR resolve?

Closes #1180
