### PR TITLE
Fix for caret moving to the previous cell after tabbing into the next cell and then removing its content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Fixed Issues:
 
 * [#2881](https://github.com/ckeditor/ckeditor4/issues/2881): Fixed: Changing table headers from "Both" to "First column" in the [Table](https://ckeditor.com/cke4/addon/table) dialog does not change the first column cell correctly.
 * [#2996](https://github.com/ckeditor/ckeditor4/issues/2996): Fixed: Table header "scope" attribute is incorrect for the "Headers: both" option in the [Table](https://ckeditor.com/cke4/addon/table) dialog.
+* [#4802](https://github.com/ckeditor/ckeditor4/issues/4802): Fixed: [Tableselection](https://ckeditor.com/cke4/addon/tableselection) caret moves to the previous cell after tabbing into the next cell and then removing its content.
 
 ## CKEditor 4.20
 

--- a/plugins/tableselection/plugin.js
+++ b/plugins/tableselection/plugin.js
@@ -1149,6 +1149,21 @@
 				}
 			}
 
+			function getTableKeyUpListener( editor ) {
+				return function( evt ) {
+					var key = evt.data.getKey(),
+						selection = editor.getSelection();
+
+					// Handle only Tab key in table selection.
+					if ( key !== 9 || !selection.isInTable() ) {
+						return;
+					}
+
+					// Restore fake selection after pressing Tab (#4802).
+					restoreFakeSelection( editor );
+				};
+			}
+
 			function clearCellInRange( range ) {
 				var node = range.getEnclosedNode();
 
@@ -1172,6 +1187,7 @@
 			var editable = editor.editable();
 			editable.attachListener( editable, 'keydown', getTableOnKeyDownListener( editor ), null, null, -1 );
 			editable.attachListener( editable, 'keypress', tableKeyPressListener, null, null, -1 );
+			editable.attachListener( editable, 'keyup', getTableKeyUpListener( editor ), null, null, -1 );
 		}
 	};
 

--- a/tests/plugins/tableselection/manual/tabbackspace.html
+++ b/tests/plugins/tableselection/manual/tabbackspace.html
@@ -1,0 +1,48 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="iframe">
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="div">
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<table border="1">
+		<tr>
+			<td>Cell 1.1</td>
+			<td>Cell 1.2</td>
+		</tr>
+		<tr>
+			<td>Cell 2.1</td>
+			<td>Cell 2.2</td>
+		</tr>
+	</table>
+</div>
+<script>
+	CKEDITOR.replace( 'iframe' );
+	CKEDITOR.replace( 'div', {
+		extraPlugins: 'divarea'
+	} );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/tableselection/manual/tabbackspace.html
+++ b/tests/plugins/tableselection/manual/tabbackspace.html
@@ -40,6 +40,10 @@
 	</table>
 </div>
 <script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
 	CKEDITOR.replace( 'iframe' );
 	CKEDITOR.replace( 'div', {
 		extraPlugins: 'divarea'

--- a/tests/plugins/tableselection/manual/tabbackspace.md
+++ b/tests/plugins/tableselection/manual/tabbackspace.md
@@ -1,11 +1,11 @@
+@bender-tags: 4.20.1, bug, 4802 
 @bender-ui: collapsed
-@bender-tags: bug, 4802, 4.20.1
 @bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, sourcearea, elementspath, undo, floatingspace, tab
 
 1. Put the caret in the first cell.
 2. Press <kbd>Tab</kbd>.
 3. Press <kbd>Backspace</kbd>.
 
-	**Expected** The selection stays in the second cell.
+**Expected** The selection stays in the second cell.
 
-	**Unexpected** The selection is moved to the first cell.
+**Unexpected** The selection is moved to the first cell.

--- a/tests/plugins/tableselection/manual/tabbackspace.md
+++ b/tests/plugins/tableselection/manual/tabbackspace.md
@@ -1,0 +1,11 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4802, 4.20.1
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tableselection, sourcearea, elementspath, undo, floatingspace, tab
+
+1. Put the caret in the first cell.
+2. Press <kbd>Tab</kbd>.
+3. Press <kbd>Backspace</kbd>.
+
+	**Expected** The selection stays in the second cell.
+
+	**Unexpected** The selection is moved to the first cell.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4802](https://github.com/ckeditor/ckeditor4/issues/4802): Fixed: Caret moves to the previous cell after tabbing into the next cell and then removing its content.
```

## What changes did you make?

I've added the`keyup` event listener that updates fake selection after pressing the <kbd>Tab</kbd> key.

I added only a manual test as I wasn't able to come up with a sensible automated one.

## Which issues does your PR resolve?

Closes #4802.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
