### PR TITLE
Allow using custom styles from config.colorButton_css for Colorbutton plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 CKEditor 4 Changelog
 ====================
 
+## CKEditor 4.21.0
+
+API changes:
+
+* [#5352](https://github.com/ckeditor/ckeditor4/issues/5352): Added the `colorButton_contentsCss` configuration option allowing to add custom CSS to the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) menu content. Thanks to [mihilion](https://github.com/mihilion)!
+
 ## CKEditor 4.20.1
 
 Fixed Issues:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ CKEditor 4 Changelog
 
 API changes:
 
-* [#5352](https://github.com/ckeditor/ckeditor4/issues/5352): Added the `colorButton_contentsCss` configuration option allowing to add custom CSS to the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) menu content. Thanks to [mihilion](https://github.com/mihilion)!
+* [#5352](https://github.com/ckeditor/ckeditor4/issues/5352): Added the [`colorButton_contentsCss`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_contentsCss) configuration option allowing to add custom CSS to the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) menu content. Thanks to [mihilion](https://github.com/mihilion)!
 
 ## CKEditor 4.20.1
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -158,7 +158,7 @@
 					contentTransformations: contentTransformations,
 
 					panel: {
-						css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.colorButton_css ),
+						css: config.colorButton_contentsCss,
 						attributes: { role: 'listbox', 'aria-label': lang.panelTitle }
 					},
 
@@ -1009,13 +1009,15 @@ CKEDITOR.config.colorButton_historyRowLimit = 1;
 CKEDITOR.config.colorButton_renderContentColors = true;
 
 /**
- * Allows adding additional custom styles which will be applied when rendering colorbutton layout.
- * Accepts array which can include both strings with CSS styles, or paths to *.css files.
+ * The CSS file(s) to be used to apply the style to the color button menu content.
  *
- * 		config.colorButton_css = ['span.cke_colorbox { border-radius: 50%; }','/path/to/stylesheet.css'];
+ * ```javascript
+ * config.colorButton_contentsCss = '/css/myfile.css';
+ * config.colorButton_contentsCss = [ '/css/myfile.css', '/css/anotherfile.css' ];
+ * ```
  *
- * 	@since 4.20.0
- * 	@cfg {Array} [colorButton_css=[]]
- * 	@member CKEDITOR.config
+ * @since 4.21.0
+ * @cfg {String[]} [colorButton_contentsCss=CKEDITOR.skin.getPath( 'editor' )]
+ * @member CKEDITOR.config
  */
-CKEDITOR.config.colorButton_css = CKEDITOR.config.colorButton_css || [];
+CKEDITOR.config.colorButton_contentsCss = [ CKEDITOR.skin.getPath( 'editor' ) ];

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -1010,8 +1010,9 @@ CKEDITOR.config.colorButton_renderContentColors = true;
 
 /**
  * Allows adding additional custom styles which will be applied when rendering colorbutton layout.
+ * Accepts array which can include both strings with CSS styles, or paths to *.css files.
  *
- * 		config.colorButton_css = ['span.cke_colorbox { border-radius: 50%; }']
+ * 		config.colorButton_css = ['span.cke_colorbox { border-radius: 50%; }','/path/to/stylesheet.css'];
  *
  * 	@since 4.20.0
  * 	@cfg {Array} [colorButton_css=[]]

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -32,6 +32,7 @@
 					commandName: 'textColor',
 					title: lang.textColorTitle,
 					order: 10,
+					contentsCss: config.contentsCss,
 					contentTransformations: [
 						[
 							{
@@ -97,6 +98,7 @@
 					commandName: 'bgColor',
 					title: lang.bgColorTitle,
 					order: 20,
+					contentsCss: config.contentsCss,
 					contentTransformations: contentTransformations
 				} );
 			}
@@ -107,6 +109,7 @@
 					title = options.title,
 					order = options.order,
 					commandName = options.commandName,
+					contentsCss = options.contentsCss,
 					contentTransformations = options.contentTransformations || {},
 					style = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ] ),
 					colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
@@ -158,7 +161,7 @@
 					contentTransformations: contentTransformations,
 
 					panel: {
-						css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
+						css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( contentsCss ),
 						attributes: { role: 'listbox', 'aria-label': lang.panelTitle }
 					},
 

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -1017,7 +1017,7 @@ CKEDITOR.config.colorButton_renderContentColors = true;
  * ```
  *
  * @since 4.21.0
- * @cfg {String[]} [colorButton_contentsCss=CKEDITOR.skin.getPath( 'editor' )]
+ * @cfg {String/String[]} [colorButton_contentsCss=CKEDITOR.skin.getPath( 'editor' )]
  * @member CKEDITOR.config
  */
 CKEDITOR.config.colorButton_contentsCss = [ CKEDITOR.skin.getPath( 'editor' ) ];

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -32,7 +32,6 @@
 					commandName: 'textColor',
 					title: lang.textColorTitle,
 					order: 10,
-					contentsCss: config.contentsCss,
 					contentTransformations: [
 						[
 							{
@@ -98,7 +97,6 @@
 					commandName: 'bgColor',
 					title: lang.bgColorTitle,
 					order: 20,
-					contentsCss: config.contentsCss,
 					contentTransformations: contentTransformations
 				} );
 			}
@@ -109,7 +107,6 @@
 					title = options.title,
 					order = options.order,
 					commandName = options.commandName,
-					contentsCss = options.contentsCss,
 					contentTransformations = options.contentTransformations || {},
 					style = new CKEDITOR.style( config[ 'colorButton_' + type + 'Style' ] ),
 					colorBoxId = CKEDITOR.tools.getNextId() + '_colorBox',
@@ -161,7 +158,7 @@
 					contentTransformations: contentTransformations,
 
 					panel: {
-						css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( contentsCss ),
+						css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.colorButton_css ),
 						attributes: { role: 'listbox', 'aria-label': lang.panelTitle }
 					},
 
@@ -1010,3 +1007,14 @@ CKEDITOR.config.colorButton_historyRowLimit = 1;
  * @member CKEDITOR.config
  */
 CKEDITOR.config.colorButton_renderContentColors = true;
+
+/**
+ * Allows adding additional custom styles which will be applied when rendering colorbutton layout.
+ *
+ * 		config.colorButton_css = ['span.cke_colorbox { border-radius: 50%; }']
+ *
+ * 	@since 4.20.0
+ * 	@cfg {Array} [colorButton_css=[]]
+ * 	@member CKEDITOR.config
+ */
+CKEDITOR.config.colorButton_css = CKEDITOR.config.colorButton_css || [];

--- a/plugins/colorbutton/plugin.js
+++ b/plugins/colorbutton/plugin.js
@@ -158,7 +158,7 @@
 					contentTransformations: contentTransformations,
 
 					panel: {
-						css: CKEDITOR.skin.getPath( 'editor' ),
+						css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 						attributes: { role: 'listbox', 'aria-label': lang.panelTitle }
 					},
 

--- a/tests/plugins/colorbutton/manual/_assets/customstyle.css
+++ b/tests/plugins/colorbutton/manual/_assets/customstyle.css
@@ -1,0 +1,3 @@
+a.cke_colorbox, span.cke_colorbox {
+	border-radius: 50%;
+}

--- a/tests/plugins/colorbutton/manual/customstyle.css
+++ b/tests/plugins/colorbutton/manual/customstyle.css
@@ -1,0 +1,3 @@
+a.cke_colorbox {
+	border-radius: 50%;
+}

--- a/tests/plugins/colorbutton/manual/customstyle.css
+++ b/tests/plugins/colorbutton/manual/customstyle.css
@@ -1,3 +1,0 @@
-a.cke_colorbox {
-	border-radius: 50%;
-}

--- a/tests/plugins/colorbutton/manual/customstyle.html
+++ b/tests/plugins/colorbutton/manual/customstyle.html
@@ -2,6 +2,6 @@
 
 <script>
 	CKEDITOR.replace( 'editor1', {
-      contentsCss: ['span.cke_colorbox {	border-radius: 50%; }']
-  } );        
-</script>                                        
+      colorButton_css: ['span.cke_colorbox { border-radius: 50%; }']
+  } );
+</script>

--- a/tests/plugins/colorbutton/manual/customstyle.html
+++ b/tests/plugins/colorbutton/manual/customstyle.html
@@ -1,7 +1,7 @@
-<div id="editor1"></div>
+<div id="editor"></div>
 
 <script>
-	CKEDITOR.replace('editor1', {
-		colorButton_css: ['span.cke_colorbox { border-radius: 50%; }','customstyle.css']
-	});
+	CKEDITOR.replace( 'editor', {
+		colorButton_contentsCss: [ CKEDITOR.skin.getPath( 'editor' ), '%TEST_DIR%_assets/customstyle.css' ]
+	} );
 </script>

--- a/tests/plugins/colorbutton/manual/customstyle.html
+++ b/tests/plugins/colorbutton/manual/customstyle.html
@@ -1,7 +1,7 @@
 <div id="editor1"></div>
 
 <script>
-	CKEDITOR.replace( 'editor1', {
-      colorButton_css: ['span.cke_colorbox { border-radius: 50%; }']
-  } );
+	CKEDITOR.replace('editor1', {
+		colorButton_css: ['span.cke_colorbox { border-radius: 50%; }','customstyle.css']
+	});
 </script>

--- a/tests/plugins/colorbutton/manual/customstyle.html
+++ b/tests/plugins/colorbutton/manual/customstyle.html
@@ -1,0 +1,7 @@
+<div id="editor1"></div>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+      contentsCss: ['span.cke_colorbox {	border-radius: 50%; }']
+  } );        
+</script>                                        

--- a/tests/plugins/colorbutton/manual/customstyle.md
+++ b/tests/plugins/colorbutton/manual/customstyle.md
@@ -1,4 +1,4 @@
-@bender-tags: bug, 5352, 4.20.0
+@bender-tags: feature, 5352, 4.20.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
 
@@ -6,9 +6,9 @@
 
 ### Expected:
 
-Custom style has been applied, and color squares are now circles. 
+Custom style has been applied, and color squares are now circles.
 
 
 ### Unexpected:
 
-Custom style has not been applied, and color squares have default square shape.        
+Custom style has not been applied, and color squares have default square shape.

--- a/tests/plugins/colorbutton/manual/customstyle.md
+++ b/tests/plugins/colorbutton/manual/customstyle.md
@@ -3,12 +3,15 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
 
 1. Click **Text Color** button.
+2. Hover over any color.
 
 ### Expected:
 
-Custom style has been applied, and color squares are now circles.
+Custom style from string has been applied, and all color squares are now circles.
+Custom style from file has been applied, and outline around hovered color is a circle.
 
 
 ### Unexpected:
 
-Custom style has not been applied, and color squares have default square shape.
+Custom style from string has not been applied, and color squares have default square shape.
+Custom style from file has not been applied, and outline around hovered color is a square.

--- a/tests/plugins/colorbutton/manual/customstyle.md
+++ b/tests/plugins/colorbutton/manual/customstyle.md
@@ -1,4 +1,4 @@
-@bender-tags: feature, 5352, 4.20.0
+@bender-tags: bug, 5352, 4.20.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
 

--- a/tests/plugins/colorbutton/manual/customstyle.md
+++ b/tests/plugins/colorbutton/manual/customstyle.md
@@ -1,4 +1,4 @@
-@bender-tags: feature, 5352, 4.20.0
+@bender-tags: feature, 5352, 4.21.0
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
 
@@ -7,11 +7,10 @@
 
 ### Expected:
 
-Custom style from string has been applied, and all color squares are now circles.
-Custom style from file has been applied, and outline around hovered color is a circle.
-
+All color squares are circles.
 
 ### Unexpected:
 
-Custom style from string has not been applied, and color squares have default square shape.
-Custom style from file has not been applied, and outline around hovered color is a square.
+Color squares have default square shape.
+
+3. Repeat steps 1-2 for **Background Color** button.

--- a/tests/plugins/colorbutton/manual/customstyle.md
+++ b/tests/plugins/colorbutton/manual/customstyle.md
@@ -1,0 +1,14 @@
+@bender-tags: feature, 5352, 4.20.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, colorbutton, colordialog, sourcearea
+
+1. Click **Text Color** button.
+
+### Expected:
+
+Custom style has been applied, and color squares are now circles. 
+
+
+### Unexpected:
+
+Custom style has not been applied, and color squares have default square shape.        


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Add possibility to add custom styles for colorbutton layout.

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5352](https://github.com/ckeditor/ckeditor4/issues/5352): Allows using custom styles from `config.contentCss` for changing the look of Colorbutton widget panel.
```

## What changes did you make?

I have concatenating of new property `config.colorButton_css` to standard editor style being passed to `panel.css` in `plugin.js` file of Colorbutton widget. This solution was inspired with existing solution from `Format` plugin, only in Colorbutton new property was introduced for this purpose.

## Which issues does your PR resolve?

Closes #5352
