### PR TITLE
Clipboard Plugin: Add ability to include content forms

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1489,7 +1489,7 @@
 				} else if ( type ) {
 					// Create filter based on rules (string or object).
 					const filter = new CKEDITOR.filter(editor, type);
-					const { pasteContentForms } = editor.config;
+					const pasteContentForms = editor.config.pasteContentForms;
 					if (pasteContentForms) {
 						filter.addContentForms(pasteContentForms);
 					}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1488,7 +1488,12 @@
 					return filters.semanticContent || ( filters.semanticContent = createSemanticContentFilter() );
 				} else if ( type ) {
 					// Create filter based on rules (string or object).
-					return new CKEDITOR.filter( editor, type );
+					const filter = new CKEDITOR.filter(editor, type);
+					const { pasteContentForms } = editor.config;
+					if (pasteContentForms) {
+						filter.addContentForms(pasteContentForms);
+					}
+					return filter;
 				}
 
 				return null;
@@ -3542,6 +3547,15 @@
  * @since 4.5.0
  * @readonly
  * @property {CKEDITOR.filter} [pasteFilter]
+ * @member CKEDITOR.editor
+ */
+
+ /**
+ * An array of {@link CKEDITOR.feature content forms} to be added to a custom `pastFilter`.
+ *
+ * @since 4.21.0
+ * @readonly
+ * @property {CKEDITOR.filter} [pasteContentForms]
  * @member CKEDITOR.editor
  */
 

--- a/tests/plugins/clipboard/pastefilter.js
+++ b/tests/plugins/clipboard/pastefilter.js
@@ -46,7 +46,7 @@
 		},
 
 		editorCustomContentForm: {
-			name: 'editorCustom',
+			name: 'editorCustomContentForm',
 			config: {
 				pasteFilter: 'p strong',
 				pasteContentForms: [

--- a/tests/plugins/clipboard/pastefilter.js
+++ b/tests/plugins/clipboard/pastefilter.js
@@ -45,6 +45,23 @@
 			}
 		},
 
+		editorCustomContentForm: {
+			name: 'editorCustom',
+			config: {
+				pasteFilter: 'p strong',
+				pasteContentForms: [
+					'strong', 
+					'b', [
+						'span',
+						function (el) {
+							return el.styles['font-weight'] === 'bold';
+						},
+					],
+				],
+				allowedContent: true
+			}
+		},
+
 		editorCustomObject: {
 			name: 'editorCustomObject',
 			config: {
@@ -85,6 +102,8 @@
 	var contents = {
 		listWithSpan: '<ul><li>he<span>fkdjfkdj</span>llo</li><li>moto</li></ul>',
 		various: '<div><h1>Header 1</h1><h3>Header <span>3</span></h3><p>Heeey</p></div>',
+		differentBold:
+			'<p>Normal Text <strong>Strong text</strong> <b>Bold B Text</b> <span style="font-weight:bold">Span Bold Text</span></p>',
 		classyAndStylish: '<h1 id="foo" class="ugly" style="background-color: red;">I am so classy and stylish :)</h1>'
 	};
 
@@ -280,6 +299,11 @@
 	createTest(
 		'test custom object', 'editorCustomObject', contents.various,
 		'<p>Header 1</p><h3>Header 3</h3><p>Heeey</p>'
+	);
+
+	createTest(
+		'test custom content form', 'editorCustomContentForm', contents.differentBold,
+		'<p>Normal Text <strong>Strong text</strong> <strong>Bold B Text</strong> <strong>Span Bold Text</strong></p>',
 	);
 
 	createTest(

--- a/tests/plugins/clipboard/pastefilter.js
+++ b/tests/plugins/clipboard/pastefilter.js
@@ -51,7 +51,8 @@
 				pasteFilter: 'p strong',
 				pasteContentForms: [
 					'strong', 
-					'b', [
+					'b',
+					[
 						'span',
 						function (el) {
 							return el.styles['font-weight'] === 'bold';


### PR DESCRIPTION
## What is the purpose of this pull request?
In the clipboard plugin, this change adds the ability to include content forms in the custom paste filter.
The need came up for me when wanting to transform a number of "bold" tags into a single tag.
aka, convert all `<strong>`, `<b>`, and `<span style="font-weight: bold">` tags into `<strong>`.

### This PR contains
- [x] Unit tests

## Did you follow the CKEditor 4 code style guide?
- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* Clipboard plugin: Allows custom content forms for `pasteFilter`
```

## What changes did you make?
This change adds a `pasteContentForms` config option that will be added via `addContentForms` to the `pastFilter`

