### PR TITLE
Fix adding and change scope `both` attribute in tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [#2881](https://github.com/ckeditor/ckeditor4/issues/2881): Fixed: Changing table headers from "Both" to "First column" in the [Table](https://ckeditor.com/cke4/addon/table) dialog does not change the first column cell correctly.
+* [#2996](https://github.com/ckeditor/ckeditor4/issues/2996): Fixed: Table header "scope" attribute is incorrect for the "Headers: both" option in the [Table](https://ckeditor.com/cke4/addon/table) dialog.
+
 ## CKEditor 4.20
 
 New Features:

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -54,6 +54,11 @@
 
 		var dialogadvtab = editor.plugins.dialogadvtab;
 
+
+		function shouldReplaceThByTd( cell, headers, index ) {
+			return cell.type == CKEDITOR.NODE_ELEMENT && ( !headers || index !== 0 );
+		}
+
 		return {
 			title: editor.lang.table.title,
 			minWidth: 310,
@@ -198,9 +203,13 @@
 							theRow = thead.getFirst();
 							for ( i = 0; i < theRow.getChildCount(); i++ ) {
 								var newCell = theRow.getChild( i );
-								if ( newCell.type == CKEDITOR.NODE_ELEMENT ) {
+								// In case when header is replaced to td element,
+								// check if the replaced cell should contain a 'row' scope (#2996).
+								if ( shouldReplaceThByTd( newCell, headers, i ) ) {
 									newCell.renameNode( 'td' );
 									newCell.removeAttribute( 'scope' );
+								} else {
+									newCell.setAttribute( 'scope', 'row' );
 								}
 							}
 
@@ -215,7 +224,13 @@
 						for ( row = 0; row < table.$.rows.length; row++ ) {
 							newCell = new CKEDITOR.dom.element( table.$.rows[ row ].cells[ 0 ] );
 							newCell.renameNode( 'th' );
-							newCell.setAttribute( 'scope', 'row' );
+
+							// If "both" is set, the first cell in table head should have scope "col"(#2996).
+							if ( headers === 'both' && row === 0 ) {
+								newCell.setAttribute( 'scope', 'col' );
+							} else {
+								newCell.setAttribute( 'scope', 'row' );
+							}
 						}
 					}
 

--- a/plugins/table/dialogs/table.js
+++ b/plugins/table/dialogs/table.js
@@ -204,7 +204,7 @@
 							for ( i = 0; i < theRow.getChildCount(); i++ ) {
 								var newCell = theRow.getChild( i );
 								// In case when header is replaced to td element,
-								// check if the replaced cell should contain a 'row' scope (#2996).
+								// check if the replaced cell should contain a 'row' scope (#2881).
 								if ( shouldReplaceThByTd( newCell, headers, i ) ) {
 									newCell.renameNode( 'td' );
 									newCell.removeAttribute( 'scope' );

--- a/tests/plugins/table/headers1row1col.js
+++ b/tests/plugins/table/headers1row1col.js
@@ -13,15 +13,6 @@
 	};
 
 	bender.test( {
-		_should: {
-			ignore: {
-				// (#2881), (#2996).
-				'1 row, 1 col, none -> both': true,
-				'1 row, 1 col, row -> col': true,
-				'1 row, 1 col, both -> col': true
-			}
-		},
-
 		'1 row, 1 col, none -> none': testHeadersManipulation( 'none', 'none' ),
 
 		'1 row, 1 col, none -> col': testHeadersManipulation( 'none', 'col' ),

--- a/tests/plugins/table/headers1row2col.js
+++ b/tests/plugins/table/headers1row2col.js
@@ -13,15 +13,6 @@
 	};
 
 	bender.test( {
-		_should: {
-			ignore: {
-				// (#2881), (#2996).
-				'1 row, 2 cols, none -> both': true,
-				'1 row, 2 cols, row -> col': true,
-				'1 row, 2 cols, both -> col': true
-			}
-		},
-
 		'1 row, 2 cols, none -> none': testHeadersManipulation( 'none', 'none' ),
 
 		'1 row, 2 cols, none -> col': testHeadersManipulation( 'none', 'col' ),

--- a/tests/plugins/table/headers2row1col.js
+++ b/tests/plugins/table/headers2row1col.js
@@ -13,15 +13,6 @@
 	};
 
 	bender.test( {
-		_should: {
-			ignore: {
-				// (#2881), (#2996).
-				'2 rows, 1 col, none -> both': true,
-				'2 rows, 1 col, row -> both': true,
-				'2 rows, 1 col, both -> col': true
-			}
-		},
-
 		'2 rows, 1 col, none -> none': testHeadersManipulation( 'none', 'none' ),
 
 		'2 rows, 1 col, none -> col': testHeadersManipulation( 'none', 'col' ),

--- a/tests/plugins/table/headers2row2col.js
+++ b/tests/plugins/table/headers2row2col.js
@@ -13,15 +13,6 @@
 	};
 
 	bender.test( {
-		_should: {
-			ignore: {
-				// (#2881), (#2996).
-				'2 rows, 2 cols, none -> both': true,
-				'2 rows, 2 cols, row -> both': true,
-				'2 rows, 2 cols, both -> col': true
-			}
-		},
-
 		'2 rows, 2 cols, none -> none': testHeadersManipulation( 'none', 'none' ),
 
 		'2 rows, 2 cols, none -> col': testHeadersManipulation( 'none', 'col' ),

--- a/tests/plugins/table/manual/changescopeattribute.html
+++ b/tests/plugins/table/manual/changescopeattribute.html
@@ -53,9 +53,15 @@
 </div>
 
 <script>
-	CKEDITOR.replace( 'iframe' );
-	CKEDITOR.replace( 'div', {
-		extraPlugins: 'divarea'
+	CKEDITOR.replace( 'iframe', {
+		language: 'en'
 	} );
-	CKEDITOR.inline( 'inline' );
+	CKEDITOR.replace( 'div', {
+		extraPlugins: 'divarea',
+		language: 'en'
+	} );
+	CKEDITOR.inline( 'inline', {
+		extraPlugins: 'sourcedialog',
+		language: 'en'
+	} );
 </script>

--- a/tests/plugins/table/manual/changescopeattribute.html
+++ b/tests/plugins/table/manual/changescopeattribute.html
@@ -1,0 +1,61 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="iframe">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<thead>
+			<tr>
+				<th scope="col"></th>
+				<th scope="col"></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<th scope="row"></th>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="div">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<thead>
+			<tr>
+				<th scope="col"></th>
+				<th scope="col"></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<th scope="row"></th>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true">
+	<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+		<thead>
+			<tr>
+				<th scope="col"></th>
+				<th scope="col"></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<th scope="row"></th>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<script>
+	CKEDITOR.replace( 'iframe' );
+	CKEDITOR.replace( 'div', {
+		extraPlugins: 'divarea'
+	} );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/table/manual/changescopeattribute.md
+++ b/tests/plugins/table/manual/changescopeattribute.md
@@ -1,14 +1,13 @@
-@bender-tags: 4.20.1, bug, 2996
+@bender-tags: 4.20.1, bug, 2881
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, table, sourcearea, elementspath, tabletools, contextmenu, htmlwriter, floatingspace
-@bender-include: helpers/utils.js
 
 1. Click the Right mouse button and open `Table Properties`.
 2. Change `Headers` option to `First Column`.
 3. Open source area.
 
-**Expected:** The first `<th>` element inside `<thead>` has `scope` attribute sets to `row`.
+**Expected:** The first `<th>` element inside `<table>` has `scope` attribute sets to `row`.
 
-**Unexpected:** The first `<th>` element inside `<thead>` does not have `scope` attribute.
+**Unexpected:** The first `<th>` element inside `<table>` does not have `scope` attribute or there is no `<th>` element,
 
 4. Repeat above steps for the `divarea` and `inline` editor.

--- a/tests/plugins/table/manual/changescopeattribute.md
+++ b/tests/plugins/table/manual/changescopeattribute.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.20.1, bug, 2996
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, table, sourcearea, elementspath, tabletools, contextmenu, htmlwriter, floatingspace
+@bender-include: helpers/utils.js
+
+1. Click the Right mouse button and open `Table Properties`.
+2. Change `Headers` option to `First Column`.
+3. Open source area.
+
+**Expected:** The first `<th>` element inside `<thead>` has `scope` attribute sets to `row`.
+
+**Unexpected:** The first `<th>` element inside `<thead>` does not have `scope` attribute.
+
+4. Repeat above steps for the `divarea` and `inline` editor.

--- a/tests/plugins/table/manual/scopeattribute.html
+++ b/tests/plugins/table/manual/scopeattribute.html
@@ -1,0 +1,12 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="iframe"></div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="div"></div>
+
+<script>
+	CKEDITOR.replace( 'iframe' );
+	CKEDITOR.replace( 'div', {
+		extraPlugins: 'divarea'
+	} );
+</script>

--- a/tests/plugins/table/manual/scopeattribute.html
+++ b/tests/plugins/table/manual/scopeattribute.html
@@ -5,8 +5,11 @@
 <div id="div"></div>
 
 <script>
-	CKEDITOR.replace( 'iframe' );
+	CKEDITOR.replace( 'iframe', {
+		language: 'en'
+	} );
 	CKEDITOR.replace( 'div', {
-		extraPlugins: 'divarea'
+		extraPlugins: 'divarea',
+		language: 'en'
 	} );
 </script>

--- a/tests/plugins/table/manual/scopeattribute.md
+++ b/tests/plugins/table/manual/scopeattribute.md
@@ -1,0 +1,13 @@
+@bender-tags: 4.20.1, bug, 2996
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, table, sourcearea, elementspath, htmlwriter, tabletools, contextmenu
+@bender-include: helpers/utils.js
+
+1. Create 2x2 table with `both` headers option.
+2. Check the source code of table.
+
+**Expected:** `<th>` elements inside `<thead>` should contain `scope` attribute sets to `col`.
+
+**Unexpected:** The first cell inside `<thead>` has `scope` attribute sets to `row`.
+
+3. Repeat above steps for div-based editor.

--- a/tests/plugins/table/manual/scopeattribute.md
+++ b/tests/plugins/table/manual/scopeattribute.md
@@ -1,7 +1,6 @@
 @bender-tags: 4.20.1, bug, 2996
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, table, sourcearea, elementspath, htmlwriter, tabletools, contextmenu
-@bender-include: helpers/utils.js
 
 1. Create 2x2 table with `both` headers option.
 2. Check the source code of table.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#2996](https://github.com/ckeditor/ckeditor4/issues/2996): Fix: Table header "scope" attribute is incorrect for 'header: both' option.
* [#2881](https://github.com/ckeditor/ckeditor4/issues/2881): Fix: Changing table headers from "Both" to "First column" doesn't work on the first column cell.
```

## What changes did you make?

I've fixed adding header `both` type and preserving changing header type from `both` to `First Column`.

Also, I didn't add any additional unit tests as there were tests that were ignored, so I just removed ignoring them.

## Which issues does your PR resolve?

Closes #2881, #2996.
