### PR TITLE
Fix broken integration between `uploadimage` and `clipboard`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ CKEditor 4 Changelog
 
 Fixed Issues:
 
+* [#5333](https://github.com/ckeditor/ckeditor4/issues/5333): Fixed: The original name of the uploaded image is not preserved by the [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin if the [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin has enabled image handling.
 * [#2881](https://github.com/ckeditor/ckeditor4/issues/2881): Fixed: Changing table headers from "Both" to "First column" in the [Table](https://ckeditor.com/cke4/addon/table) dialog does not change the first column cell correctly.
 * [#2996](https://github.com/ckeditor/ckeditor4/issues/2996): Fixed: Table header "scope" attribute is incorrect for the "Headers: both" option in the [Table](https://ckeditor.com/cke4/addon/table) dialog.
 * [#4802](https://github.com/ckeditor/ckeditor4/issues/4802): Fixed: [Tableselection](https://ckeditor.com/cke4/addon/tableselection) caret moves to the previous cell after tabbing into the next cell and then removing its content.

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -57,6 +57,7 @@
 				return;
 			}
 
+			// (#5333)
 			if ( editor.config.clipboard_handleImages ) {
 				editor.config.clipboard_handleImages = false;
 

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -57,6 +57,12 @@
 				return;
 			}
 
+			if ( editor.config.clipboard_handleImages ) {
+				editor.config.clipboard_handleImages = false;
+
+				CKEDITOR.warn( 'clipboard-image-handling-disabled', { editor: editor.name, plugin: 'uploadimage' } );
+			}
+
 			// Handle images which are available in the dataTransfer.
 			fileTools.addUploadWidget( editor, 'uploadimage', {
 				supportedTypes: /image\/(jpeg|png|gif|bmp)/,

--- a/tests/plugins/uploadimage/manual/clipboardintegration.html
+++ b/tests/plugins/uploadimage/manual/clipboardintegration.html
@@ -1,0 +1,20 @@
+<p>Last dropped file: <span id="lastFile"></span></p>
+<div id="editor1"></div>
+
+<script>
+	CKEDITOR.replace( 'editor1', {
+		language: 'en',
+		imageUploadUrl: '%BASE_PATH%',
+		on: {
+			instanceReady: function( evt ) {
+				bender.tools.ignoreUnsupportedEnvironment( 'uploadimage' );
+
+				CKEDITOR.fileTools.fileLoader.prototype.upload = function( url ) {
+					CKEDITOR.document.getById( 'lastFile' ).setText( this.fileName );
+
+					this.responseData = {};
+				};
+			},
+		}
+	} );
+</script>

--- a/tests/plugins/uploadimage/manual/clipboardintegration.md
+++ b/tests/plugins/uploadimage/manual/clipboardintegration.md
@@ -1,0 +1,16 @@
+@bender-tags: 4.20.1, bug, 5333
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, uploadwidget, uploadimage, image, floatingspace, toolbar, sourcearea
+
+1. Open the console.
+
+**Expected** There is `[CKEDITOR] Error code: clipboard-image-handling-disabled.` warning in the console after the editor is loaded.
+
+**Unexpected** There is no warning in the console.
+2. Drag and drop an image into the editor.
+
+**Expected** The original name of the file is displayed above the editor.
+
+**Unexpected** The name in the `image-<timestamp>-<n>.<ext>` format is displayed above the editor.
+
+3. Repeat step `2` for the paste method.

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -582,7 +582,9 @@
 
 			bender.editorBot.create( {
 				name: 'configerror_test',
-				extraPlugins: 'uploadimage'
+				config: {
+					extraPlugins: 'uploadimage'
+				}
 			}, function( bot ) {
 				spy.restore();
 

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -589,6 +589,100 @@
 				assert.areSame( 0, spy.callCount, 'CKEDITOR.error call count' );
 				assert.isFalse( !!bot.editor.widgets.registered.uploadimage, 'uploadimage widget' );
 			} );
+		},
+
+		// (#5333)
+		'test warning about disabling the clipboard image handling logic (default config value)': createHandlingImageWarnTest(
+			'clipboard-warning-default' ),
+
+		// (#5333)
+		'test warning about disabling the clipboard image handling logic (config value of true)': createHandlingImageWarnTest(
+			'clipboard-warning-true', true ),
+
+		// (#5333)
+		'test warning about disabling the clipboard image handling logic (config value of false)': createHandlingImageWarnTest(
+			'clipboard-warning-false', false ),
+
+		// (#5333)
+		'test original file name is preserved after the upload': function() {
+			bender.editorBot.create( {
+				name: 'clipboard-integration-original-file-name',
+				config: {
+					uploadUrl: '%BASE_PATH',
+					extraPlugins: 'uploadimage'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					imageName = 'test.png',
+					image = {
+						name: imageName,
+						type: 'image/png'
+					};
+
+				bot.setData( '', function() {
+					resumeAfter( editor, 'paste', function() {
+						var widget = CKEDITOR.tools.object.values( editor.widgets.instances )[ 0 ],
+							loader = widget._getLoader();
+
+						assert.areSame( imageName, loader.fileName, 'The name of the uploaded file' );
+					} );
+
+					pasteFilesWithFilesMimeType( editor, [ image ] );
+
+					wait();
+				} );
+			} );
 		}
 	} );
+
+	function createHandlingImageWarnTest( editorName, configValue ) {
+		return function() {
+			var spy = sinon.spy( CKEDITOR, 'warn' ),
+				editorConfig =  {
+					uploadUrl: '%BASE_PATH',
+					extraPlugins: 'uploadimage'
+				};
+
+			if ( configValue !== undefined ) {
+				editorConfig.clipboard_handleImages = configValue;
+			}
+
+			bender.editorBot.create( {
+				name: editorName,
+				config: editorConfig
+			}, function() {
+				var warnCall = spy.getCall( 0 ),
+					expectedWarnDetails = {
+						editor: editorName,
+						plugin: 'uploadimage'
+					};
+
+				spy.restore();
+
+				if ( configValue === false ) {
+					assert.areSame( 0, spy.callCount, 'CKEDITOR.warn call count' );
+				} else {
+					assert.areSame( 1, spy.callCount, 'CKEDITOR.warn call count' );
+					assert.areSame( 'clipboard-image-handling-disabled', warnCall.args[ 0 ],
+						'CKEDITOR.warn error code' );
+					objectAssert.areDeepEqual( expectedWarnDetails, warnCall.args[ 1 ], 'CKEDITOR.warn details' );
+				}
+			} );
+		};
+	}
+
+	function pasteFilesWithFilesMimeType( editor, files, pasteMethod ) {
+		var	nativeData = bender.tools.mockNativeDataTransfer(),
+			dataTransfer;
+
+		pasteMethod = pasteMethod || 'paste';
+		nativeData.files = files;
+		nativeData.types.push( 'Files' );
+		dataTransfer = new CKEDITOR.plugins.clipboard.dataTransfer( nativeData );
+
+		editor.fire( 'paste', {
+			dataTransfer: dataTransfer,
+			dataValue: ''
+		} );
+	}
 } )();


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5333](https://github.com/ckeditor/ckeditor4/issues/5333): Fixed: original name of the uploaded image was not preserved in the [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin if the [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin had enabled image handling.
```

## What changes did you make?

I've introduced the new error code, `clipboard-image-handling-disabled`, that is used when the `uploadimage` plugin detects that the `clipboard` plugin has enabled image handling. In that case the mentioned warning is emitted and the clipboard's handling logic is disabled (by setting the `editor.config.clipboard_handleImages` config variable to `false`).

It's probably not the _best_ solution for the issue but it's the fastest one and it guarantees that there will be no conflict between these two plugins.

~~If we decide that it's the right way to do it, I'll prepare also the second PR for docs to introduce the new error code there.~~ Docs PR: ckeditor/ckeditor4-docs#409

## Which issues does your PR resolve?

Closes #5333.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
