### PR TITLE
Improve Tab navigation bahaviour with radio buttons inside the dialog 

### DIFF
--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -530,17 +530,17 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			// move focus to it.
 			if ( !isPreviousNodeInRadioGroup && isCurrentNodeInRadioGroup ) {
 				var radioGroup = getRadioGroup( currentIndex, direction ),
-					checkedItemIndex = getFocusedRadioGroupElement( radioGroup );
+					focusedItemIndex = getFocusedRadioGroupElement( radioGroup );
 
 				// If no radio button is checked then:
-				// When Tab was pressed, then select the first radio button.
-				// When Shift+Tab was pressed, then select the last radio button.
-				if ( checkedItemIndex === -1 ) {
-					checkedItemIndex = 0;
-					dialogUiElements[ currentIndex ].getInputElement().$.checked = true;
+				// When Tab was pressed, then focus the first radio button.
+				// When Shift+Tab was pressed, then focus the last radio button.
+				if ( focusedItemIndex === -1 ) {
+					focusedItemIndex = 0;
+					dialogUiElements[ currentIndex ].getInputElement().$.focus();
 				}
 
-				currentIndex = updateCurrentIndexBy( currentIndex, checkedItemIndex, direction );
+				currentIndex = updateCurrentIndexBy( currentIndex, focusedItemIndex, direction );
 
 				return currentIndex;
 			}
@@ -560,14 +560,14 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 				var radioGroup = getRadioGroup( currentIndex, direction );
 
 				if ( radioGroup.length > 0 ) {
-					var checkedItemIndex = getFocusedRadioGroupElement( radioGroup );
+					var focusedItemIndex = getFocusedRadioGroupElement( radioGroup );
 
-					if ( checkedItemIndex === -1 ) {
-						checkedItemIndex = 0;
-						dialogUiElements[ currentIndex ].getInputElement().$.checked = true;
+					if ( focusedItemIndex === -1 ) {
+						focusedItemIndex = 0;
+						dialogUiElements[ currentIndex ].getInputElement().$.focus();
 					}
 
-					currentIndex = updateCurrentIndexBy( currentIndex, checkedItemIndex, direction );
+					currentIndex = updateCurrentIndexBy( currentIndex, focusedItemIndex, direction );
 				}
 			} else {
 				var radioGroupLength = dialogUiElements[ startIndex ].items.length;

--- a/tests/plugins/dialog/_helpers/tools.js
+++ b/tests/plugins/dialog/_helpers/tools.js
@@ -82,6 +82,12 @@
 		throw new Error( 'Invalid focus options: ' + JSON.stringify( options ) );
 	}
 
+	function getRadioGroupElement( dialog, options ) {
+		var radioGroup = dialog.getContentElement( options.tab, options.radioGroupId );
+
+		return radioGroup._.children[ options.radioElementNumber ];
+	}
+
 
 	var dialogTools = {
 		// Dialog definitions used in test cases.
@@ -291,6 +297,156 @@
 							]
 						}
 					],
+					singleRadioGroup: function() {
+						return {
+							title: 'Single page dialog with radio group',
+							contents: [
+								{
+									id: 'sp-test1',
+									elements: [
+										{
+											type: 'text',
+											id: 'sp-input1',
+											label: 'input 1'
+										},
+										{
+											type: 'radio',
+											id: 'radio1',
+											items: [
+												[ 'foo1', 'foo1' ],
+												[ 'bar2', 'bar2' ],
+												[ 'bar3', 'bar3' ],
+												[ 'bar4', 'bar4' ]
+											]
+										},
+										{
+											type: 'checkbox',
+											id: 'sp-input3',
+											label: 'input 3'
+										}
+									]
+								}
+							],
+							onLoad: onLoadHandler
+						};
+					},
+					multipleRadioGroup: function() {
+						return {
+							title: 'Single page dialog with radio groups',
+							contents: [
+								{
+									id: 'sp-test1',
+									elements: [
+										{
+											type: 'text',
+											id: 'sp-input1',
+											label: 'input 1'
+										},
+										{
+											type: 'radio',
+											id: 'radio1',
+											items: [
+												[ 'foo1', 'foo1' ],
+												[ 'bar2', 'bar2' ],
+												[ 'bar3', 'bar3' ],
+												[ 'bar4', 'bar4' ]
+											]
+										},
+										{
+											type: 'radio',
+											id: 'radio2',
+											items: [
+												[ 'foo5', 'foo5' ],
+												[ 'bar6', 'bar6' ],
+												[ 'bar7', 'bar7' ],
+												[ 'bar8', 'bar8' ]
+											]
+										},
+										{
+											type: 'checkbox',
+											id: 'sp-input3',
+											label: 'input 3'
+										}
+									]
+								}
+							],
+							onLoad: onLoadHandler
+						};
+					},
+					onLoad: onLoadHandler
+				};
+			},
+			singleRadioGroup: function() {
+				return {
+					title: 'Single page dialog with radio group',
+					contents: [
+						{
+							id: 'srg-test1',
+							elements: [
+								{
+									type: 'text',
+									id: 'srg-input1',
+									label: 'input 1'
+								},
+								{
+									type: 'radio',
+									id: 'srg-radio1',
+									items: [
+										[ 'foo1', 'foo1' ],
+										[ 'bar2', 'bar2' ],
+										[ 'bar3', 'bar3' ],
+										[ 'bar4', 'bar4' ]
+									]
+								},
+								{
+									type: 'checkbox',
+									id: 'srg-input3',
+									label: 'input 3'
+								}
+							]
+						}
+					],
+					onLoad: onLoadHandler
+				};
+			},
+			multipleRadioGroup: function() {
+				return {
+					title: 'Single page dialog with radio groups',
+					contents: [
+						{
+							id: 'mrg-test1',
+							elements: [
+								{
+									type: 'text',
+									id: 'mrg-input1',
+									label: 'input 1'
+								},
+								{
+									type: 'radio',
+									id: 'mrg-radio1',
+									items: [
+										[ 'foo1', 'foo1' ],
+										[ 'bar2', 'bar2' ],
+										[ 'bar3', 'bar3' ]
+									]
+								},
+								{
+									type: 'radio',
+									id: 'mrg-radio2',
+									items: [
+										[ 'foo4', 'foo4' ],
+										[ 'bar5', 'bar5' ],
+										[ 'bar6', 'bar6' ]
+									]
+								},
+								{
+									type: 'checkbox',
+									id: 'mrg-input3',
+									label: 'input 3'
+								}
+							]
+						}
+					],
 					onLoad: onLoadHandler
 				};
 			}
@@ -312,6 +468,10 @@
 					expectedFocusedElement = dialog.getButton( options.buttonName );
 				} else {
 					expectedFocusedElement = dialog.getContentElement( options.tab, options.elementId );
+				}
+
+				if ( options.radioGroupId ) {
+					expectedFocusedElement = getRadioGroupElement( dialog, options );
 				}
 
 				if ( !expectedFocusedElement ) {
@@ -397,10 +557,14 @@
 			CKEDITOR.dialog.add( 'singlePageDialog', this.definitions.singlePage );
 			CKEDITOR.dialog.add( 'multiPageDialog', this.definitions.multiPage );
 			CKEDITOR.dialog.add( 'hiddenPageDialog', this.definitions.hiddenPage );
+			CKEDITOR.dialog.add( 'singleRadioGroupDialog', this.definitions.singleRadioGroup );
+			CKEDITOR.dialog.add( 'multipleRadioGroupDialog', this.definitions.multipleRadioGroup );
 
 			editor.addCommand( 'singlePageDialog', new CKEDITOR.dialogCommand( 'singlePageDialog' ) );
 			editor.addCommand( 'multiPageDialog', new CKEDITOR.dialogCommand( 'multiPageDialog' ) );
 			editor.addCommand( 'hiddenPageDialog', new CKEDITOR.dialogCommand( 'hiddenPageDialog' ) );
+			editor.addCommand( 'singleRadioGroupDialog', new CKEDITOR.dialogCommand( 'singleRadioGroupDialog' ) );
+			editor.addCommand( 'multipleRadioGroupDialog', new CKEDITOR.dialogCommand( 'multipleRadioGroupDialog' ) );
 		},
 
 		// Closes all opened dialogs.
@@ -412,6 +576,19 @@
 
 				dialog = CKEDITOR.dialog.getCurrent();
 			}
+		},
+
+		checkRadioGroupElement: function( options ) {
+			return function( dialog ) {
+				var radioGroupElement = getRadioGroupElement( dialog, options );
+				radioGroupElement.getElement().$.checked = true;
+
+				if ( options.focusElement ) {
+					radioGroupElement.getElement().focus();
+				}
+
+				return dialog;
+			};
 		}
 	};
 

--- a/tests/plugins/dialog/focus.js
+++ b/tests/plugins/dialog/focus.js
@@ -19,7 +19,8 @@
 		assertFocusedElement = window.dialogTools.assertFocusedElement,
 		assertFocusedTab = window.dialogTools.assertFocusedTab,
 		focusElement = window.dialogTools.focusElement,
-		assertTabsAriaAttribute = window.dialogTools.assertTabsAriaAttribute;
+		assertTabsAriaAttribute = window.dialogTools.assertTabsAriaAttribute,
+		checkRadioGroupElement = window.dialogTools.checkRadioGroupElement;
 
 	bender.editor = {
 		config: {
@@ -290,6 +291,181 @@
 				.then( assertFocusedTab( 'hp-test2' ) )
 				.then( focusElement( { key: KEYS.ARROW_RIGHT } ) )
 				.then( assertFocusedTab( 'hp-test4' ) );
+		},
+
+		'test moving the focus from input field to the first element of the radio group by pressing TAB key when no elements from the radio group was selected': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'singleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					elementId: 'srg-input1'
+				} ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					radioGroupId: 'srg-radio1',
+					radioElementNumber: 0
+				} ) );
+		},
+
+		'test moving the focus to the last element of the radio group by pressing SHIFT + TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'singleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					elementId: 'srg-input1'
+				} ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					radioGroupId: 'srg-radio1',
+					radioElementNumber: 3
+				} ) );
+		},
+
+		'test moving the focus from input field to previously checked radio group element by pressing TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'singleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					elementId: 'srg-input1'
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'srg-test1',
+					radioGroupId: 'srg-radio1',
+					radioElementNumber: 2
+				} ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					radioGroupId: 'srg-radio1',
+					radioElementNumber: 2
+				} ) );
+		},
+
+		'test moving the focus from the last radio group item to the next dialog element by pressing TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'singleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					elementId: 'srg-input1'
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'srg-test1',
+					radioGroupId: 'srg-radio1',
+					radioElementNumber: 3,
+					focusElement: true
+				} ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
+				.then( assertFocusedElement( {
+					tab: 'srg-test1',
+					elementId: 'srg-input3'
+				} ) );
+		},
+
+		'test moving the focus from the first focused radio group element to the first element from next radio group by pressing TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'multipleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					elementId: 'mrg-input1'
+				} ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio1',
+					radioElementNumber: 0
+				} ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio2',
+					radioElementNumber: 0
+				} ) );
+		},
+
+		'test moving the focus from the first element of the second radio group to the last element from the previous radio group by pressing SHIFT + TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'multipleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					elementId: 'mrg-input1'
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio2',
+					radioElementNumber: 0,
+					focusElement: true
+				} ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio1',
+					radioElementNumber: 2
+				} ) );
+		},
+
+		'test moving the focus from the previously checked radio group element to the next checked element from the next radio group by pressing TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'multipleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					elementId: 'mrg-input1'
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio2',
+					radioElementNumber: 2
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio1',
+					radioElementNumber: 1,
+					focusElement: true
+				} ) )
+				.then( focusElement( { key: KEYS.TAB } ) )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio2',
+					radioElementNumber: 2
+				} ) );
+		},
+
+		'test moving the focus from the checked radio group element to the previous checked element from the previous radio group by pressing SHIFT + TAB key': function() {
+			var bot = this.editorBot;
+
+			return bot.asyncDialog( 'multipleRadioGroupDialog' )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					elementId: 'mrg-input1'
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio1',
+					radioElementNumber: 2
+				} ) )
+				.then( checkRadioGroupElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio2',
+					radioElementNumber: 1,
+					focusElement: true
+				} ) )
+				.then( focusElement( { key: KEYS.TAB, shiftKey: true } ) )
+				.then( assertFocusedElement( {
+					tab: 'mrg-test1',
+					radioGroupId: 'mrg-radio1',
+					radioElementNumber: 2
+				} ) );
 		}
 	};
 

--- a/tests/plugins/dialog/manual/multipleradiogroup.html
+++ b/tests/plugins/dialog/manual/multipleradiogroup.html
@@ -1,0 +1,83 @@
+<button id="press">Open Dialog</button>
+<div id="editor"></div>
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	var editor = CKEDITOR.replace( 'editor' );
+
+	CKEDITOR.once( 'instanceLoaded', function() {
+		CKEDITOR.dialog.add( 'testDialog', function() {
+			return {
+				title: 'Test dialog',
+				contents: [
+					{
+						id: 'tab1',
+						label: 'Tab one',
+						elements: [
+							{
+								type: 'html',
+								id: 'field11',
+								html: 'foo'
+							},
+							{
+								type: 'radio',
+								id: 'radio1',
+								items: [
+									[ 'foo1', 'foo1' ],
+									[ 'bar2', 'bar2' ],
+									[ 'bar3', 'bar3' ],
+									[ 'bar4', 'bar4' ]
+								]
+							},
+							{
+								type: 'radio',
+								id: 'radio2',
+								items: [
+									[ 'foo5', 'foo5' ],
+									[ 'bar6', 'bar6' ],
+									[ 'bar7', 'bar7' ],
+									[ 'bar8', 'bar8' ]
+								]
+							},
+							{
+								type: 'radio',
+								id: 'radio3',
+								items: [
+									[ 'foo9', 'foo9' ],
+									[ 'bar10', 'bar10' ],
+								]
+							},
+							{
+								type: 'radio',
+								id: 'radio4',
+								items: [
+									[ 'foo11', 'foo11' ],
+								]
+							},
+							{
+								type: 'button',
+								id: 'busy',
+								label: 'Set dialog busy'
+							},
+							{
+								type: 'html',
+								id: 'field12',
+								html: 'foo'
+							}
+						]
+					}
+				]
+			}
+		} );
+
+		editor.addCommand( 'testDialog', new CKEDITOR.dialogCommand( 'testDialog', {
+			tabId: 'tab1'
+		} ) );
+	} );
+
+	document.getElementById( 'press' ).onclick = function() {
+		editor.execCommand( 'testDialog' );
+	};
+</script>

--- a/tests/plugins/dialog/manual/multipleradiogroup.md
+++ b/tests/plugins/dialog/manual/multipleradiogroup.md
@@ -11,4 +11,4 @@ Check:
 
 * Moving focus outside the radio groups.
 
-* Properly moving focus to the previously saved position.
+* Properly moving focus to the previously checked position.

--- a/tests/plugins/dialog/manual/multipleradiogroup.md
+++ b/tests/plugins/dialog/manual/multipleradiogroup.md
@@ -1,0 +1,14 @@
+@bender-tags: 4.20.1, bug, 439
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, dialog
+
+1. Click `Open Dialog` button.
+2. Play with radio groups:
+
+Check:
+
+* Moving focus between radio groups working properly.
+
+* Moving focus outside the radio groups.
+
+* Properly moving focus to the previously saved position.

--- a/tests/plugins/dialog/manual/radiogroupfocus.html
+++ b/tests/plugins/dialog/manual/radiogroupfocus.html
@@ -1,0 +1,8 @@
+<div id="editor"></div>
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/dialog/manual/radiogroupfocus.md
+++ b/tests/plugins/dialog/manual/radiogroupfocus.md
@@ -1,0 +1,17 @@
+@bender-tags: 4.20.1, bug, 439
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, image2
+
+1. Open image dialog.
+2. Move focus to `Alignment` radio group.
+3. Pres `Tab` again.
+
+**Expected:** Focus was moved outside the radio group and `Captioned image` checkbox is focused.
+
+**Unexpected:** Focus is still in the radiogroup and the `Left` item is focused.
+
+4. Having focus on the `Captioned image` checkbox press `Shift+Tab` key.
+
+**Expected:** Focus was moved to the previously selected radio button.
+
+**Unexpected:** Focus was moved to the last element of the radio group.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#439](https://github.com/ckeditor/ckeditor4/issues/439): Fixed incorrect Tab navigation behavior with radio buttons inside the dialog.
```

## What changes did you make?

*Give an overview…*

I've created a proposal for fixing moving focus in radio elements via `Tab` key in dialogs.

Closes #439.
