### PR TITLE
Fix "Cannot read property 'attributes' of null"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ New features:
 
 * [#3540](https://github.com/ckeditor/ckeditor4/issues/3540): The [startup data](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html) passed to the widget's command is now used to also populate widget's template.
 
+Fixed Issues:
+
+* [#698](https://github.com/ckeditor/ckeditor4/issues/698): Fixed: The error is thrown after applying formatting to the widget with inline editable and switching to the source mode. Thanks to [Glen](https://github.com/glen-84)!
+
 API changes:
 
 * [#5352](https://github.com/ckeditor/ckeditor4/issues/5352): Added the [`colorButton_contentsCss`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_contentsCss) configuration option allowing to add custom CSS to the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) menu content. Thanks to [mihilion](https://github.com/mihilion)!

--- a/plugins/embedsemantic/plugin.js
+++ b/plugins/embedsemantic/plugin.js
@@ -82,7 +82,7 @@
 					ret.add( new CKEDITOR.htmlParser.text( this.data.url ) );
 
 					// Transfer widget classes from widget element back to data (https://dev.ckeditor.com/ticket/13199).
-					if ( element.attributes[ 'class' ] ) {
+					if ( element && element.attributes[ 'class' ] ) {
 						ret.attributes[ 'class' ] = element.attributes[ 'class' ];
 					}
 

--- a/plugins/embedsemantic/plugin.js
+++ b/plugins/embedsemantic/plugin.js
@@ -82,7 +82,7 @@
 					ret.add( new CKEDITOR.htmlParser.text( this.data.url ) );
 
 					// Transfer widget classes from widget element back to data (https://dev.ckeditor.com/ticket/13199).
-					if ( element && element.attributes[ 'class' ] ) {
+					if ( element.attributes[ 'class' ] ) {
 						ret.attributes[ 'class' ] = element.attributes[ 'class' ];
 					}
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3060,9 +3060,9 @@
 						} );
 
 						// If widget did not have data-cke-widget attribute before upcasting remove it.
-						if ( widgetElement && widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' ) { 
+						if ( widgetElement && widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' ) {
 							delete widgetElement.attributes[ 'data-widget' ];
-							}
+						}
 					}
 				}
 				// Nested editable.

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3117,7 +3117,16 @@
 				if ( !retElement )
 					retElement = widgetElement;
 
-				toBe.wrapper.replaceWith( retElement );
+				// In some edge cases (especially applying formating
+				// at the boundary of the inline editable) the widget
+				// is going to be duplicated (split in half).
+				// In that case there won't be a retElement
+				// and we can safely remove such doppelganger widget (#698).
+				if ( retElement ) {
+					toBe.wrapper.replaceWith( retElement );
+				} else {
+					toBe.wrapper.remove();
+				}
 			}
 		}, null, null, 13 );
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3060,7 +3060,7 @@
 						} );
 
 						// If widget did not have data-cke-widget attribute before upcasting remove it.
-						if ( widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
+						if ( widgetElement && widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
 							delete widgetElement.attributes[ 'data-widget' ];
 					}
 				}

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -3060,8 +3060,9 @@
 						} );
 
 						// If widget did not have data-cke-widget attribute before upcasting remove it.
-						if ( widgetElement && widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' )
+						if ( widgetElement && widgetElement.attributes[ 'data-cke-widget-keep-attr' ] != '1' ) { 
 							delete widgetElement.attributes[ 'data-widget' ];
+							}
 					}
 				}
 				// Nested editable.

--- a/tests/plugins/widget/inlineeditables.js
+++ b/tests/plugins/widget/inlineeditables.js
@@ -1,0 +1,57 @@
+/* bender-tags: widget */
+
+( function() {
+	'use strict';
+
+	CKEDITOR.dtd.$editable.span = 1;
+
+	CKEDITOR.plugins.add( 'spanwidget', {
+		requires: 'widget',
+		init: function( editor )	{
+			editor.widgets.add( 'spanwidget', {
+				editables: {
+					content: {
+						selector: 'span'
+					}
+				},
+				upcast: function( element ) {
+					return element.name == 'span';
+				}
+			} );
+		}
+	} );
+
+	bender.editor = {
+		config: {
+			extraAllowedContent: 'span',
+			extraPlugins: 'basicstyles,sourcearea,spanwidget'
+		}
+	};
+
+	bender.test( {
+		// #698
+		'test switching to source mode after bolding text in an inline editable': function() {
+			var editor = this.editor,
+				editorBot = this.editorBot;
+
+			editorBot.setData( '<strong><span>lorem</span></strong>', function() {
+				var textNode = editor.editable().findOne( 'span' ).getFirst().getFirst(),
+					rng = editor.createRange();
+
+				editor.focus();
+
+				// Select the `m`.
+				rng.setStart( textNode, 4 );
+				rng.setEnd( textNode, 5 );
+				editor.getSelection().selectRanges( [ rng ] );
+
+				editor.execCommand( 'bold' );
+				editor.setMode( 'source' );
+
+				// Just pass the test if nothing threw before.
+				assert.pass();
+			} );
+		}
+	} );
+
+} )();

--- a/tests/plugins/widget/manual/inlineeditable.html
+++ b/tests/plugins/widget/manual/inlineeditable.html
@@ -1,0 +1,30 @@
+<div id="editor">
+	<strong><span>Test</span></strong>
+</div>
+
+<script>
+	( function() {
+		CKEDITOR.dtd.$editable.span = 1;
+
+		CKEDITOR.plugins.add( 'spanwidget', {
+			requires: 'widget',
+			init: function( editor )	{
+				editor.widgets.add( 'spanwidget', {
+					editables: {
+						content: {
+							selector: 'span'
+						}
+					},
+					upcast: function( element ) {
+						return element.name == 'span';
+					}
+				} );
+			}
+		} );
+
+		CKEDITOR.replace( 'editor', {
+			extraPlugins: 'spanwidget',
+			extraAllowedContent: 'span'
+		} );
+	} )();
+</script>

--- a/tests/plugins/widget/manual/inlineeditable.md
+++ b/tests/plugins/widget/manual/inlineeditable.md
@@ -1,17 +1,18 @@
-@bender-tags: widget, bug, 698, 4.21.0
+@bender-tags: 4.21.0, bug, 698, widget
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, basicstyles, widget
 
 1. Open browser console.
 1. Select `t` (the last letter) from `Test`.
-1. Click the "Bold" toolbar button.
+1. Click the `Bold` toolbar button.
 1. Switch to the source mode.
 
-	**Expected** Editor is switched to the source mode.
+**Expected** Editor is switched to the source mode.
 
-	**Unexpected** There is an error in the console and editor is not switched to the source mode.
+**Unexpected** There is an error in the console and editor is not switched to the source mode.
+
 1. Switch back to the editing mode.
 
-	**Expected** Editor is switched to the editing mode.
+**Expected** Editor is switched to the editing mode.
 
-	**Unexpected** There is an error in the console and editor is not switched to the editing mode.
+**Unexpected** There is an error in the console and editor is not switched to the editing mode.

--- a/tests/plugins/widget/manual/inlineeditable.md
+++ b/tests/plugins/widget/manual/inlineeditable.md
@@ -1,0 +1,17 @@
+@bender-tags: widget, bug, 698, 4.21.0
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, sourcearea, basicstyles, widget
+
+1. Open browser console.
+1. Select `t` (the last letter) from `Test`.
+1. Click the "Bold" toolbar button.
+1. Switch to the source mode.
+
+	**Expected** Editor is switched to the source mode.
+
+	**Unexpected** There is an error in the console and editor is not switched to the source mode.
+1. Switch back to the editing mode.
+
+	**Expected** Editor is switched to the editing mode.
+
+	**Unexpected** There is an error in the console and editor is not switched to the editing mode.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

No, it's a minor change. Let me know if this is necessary.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#698](https://github.com/ckeditor/ckeditor4/issues/698): Fix "Cannot read property 'attributes' of null".
```

## What changes did you make?

Checked that `element` and `widgetElement` are non-null before accessing `attributes`.

## Which issues does your PR resolve?

Closes #698.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
