### PR TITLE
Making the upload image plugin supporting 'image/webp' format.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.20.3 [IN-DEVELOPMENT]
 
+New Features:
+
+* [#4400](https://github.com/ckeditor/ckeditor4/issues/4400): Added the [`config.uploadImage_supportedTypes`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-uploadImage_supportedTypes) configuration option allowing to change the image formats accepted by the [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin. Thanks to [SilverYoCha](https://github.com/SilverYoCha)!
+
 ## CKEditor 4.20.2
 
 Fixed Issues:

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -66,7 +66,7 @@
 
 			// Handle images which are available in the dataTransfer.
 			fileTools.addUploadWidget( editor, 'uploadimage', {
-				supportedTypes: /image\/(jpeg|png|gif|bmp)/,
+				supportedTypes: editor.config.uploadImage_supportedTypes,
 
 				uploadUrl: uploadUrl,
 
@@ -158,4 +158,17 @@
 	 * @cfg {String} [imageUploadUrl='' (empty string = disabled)]
 	 * @member CKEDITOR.config
 	 */
+
+	/**
+	 * A regular expression that defines which image types are supported
+	 * by upload image plugin.
+	 *
+	 *		// Accepts only png and jpeg image types.
+	 *		config.uploadImage_supportedTypes = /image\/(png|jpeg)/;
+	 *
+	 * @since 4.20.2
+	 * @cfg {RegExp} [uploadImage_supportedTypes=/image\/(jpeg|png|gif|bmp)/]
+	 * @member CKEDITOR.config
+	 */
+	 CKEDITOR.config.uploadImage_supportedTypes = /image\/(jpeg|png|gif|bmp)/;
 } )();

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -161,14 +161,16 @@
 
 	/**
 	 * A regular expression that defines which image types are supported
-	 * by upload image plugin.
+	 * by the [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin.
 	 *
-	 *		// Accepts only png and jpeg image types.
-	 *		config.uploadImage_supportedTypes = /image\/(png|jpeg)/;
+	 * ```javascript
+	 * // Accepts only png and jpeg image types.
+	 * config.uploadImage_supportedTypes = /image\/(png|jpeg)/;
+	 * ```
 	 *
-	 * @since 4.20.2
+	 * @since 4.20.3
 	 * @cfg {RegExp} [uploadImage_supportedTypes=/image\/(jpeg|png|gif|bmp)/]
 	 * @member CKEDITOR.config
 	 */
-	 CKEDITOR.config.uploadImage_supportedTypes = /image\/(jpeg|png|gif|bmp)/;
+	CKEDITOR.config.uploadImage_supportedTypes = /image\/(jpeg|png|gif|bmp)/;
 } )();

--- a/tests/plugins/uploadimage/manual/customsupportedtypes.html
+++ b/tests/plugins/uploadimage/manual/customsupportedtypes.html
@@ -1,0 +1,14 @@
+<div id="editor">
+	<p>Drop image here:</p>
+</div>
+
+<script>
+	CKEDITOR.once( 'instanceReady', function() {
+		bender.tools.ignoreUnsupportedEnvironment( 'uploadimage' );
+	} );
+
+	CKEDITOR.replace( 'editor', {
+		uploadUrl: '%BASE_PATH%',
+		uploadImage_supportedTypes: /^image\/jp(e)?g$/
+	} );
+</script>

--- a/tests/plugins/uploadimage/manual/customsupportedtypes.md
+++ b/tests/plugins/uploadimage/manual/customsupportedtypes.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.20.3, feature, 4400
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, uploadimage, undo, image2
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
+
+**Note:** dropped images are replaced with Lena photo after the "upload" is finished.
+
+1. Drop [JPG image](%BASE_PATH%_assets/lena.jpg) into the editor.
+
+**Expected** The image is inserted into the editor.
+
+**Unexpected** The image is not inserted into the editor and the notification about unsupported image format is shown.
+
+2. Drop [PNG image](%BASE_PATH%_assets/logo.png) into the editor.
+
+**Expected** The image is not inserted into the editor and the notification about unsupported image format is shown.
+
+**Unexpected** The image is inserted into the editor.

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -25,7 +25,7 @@
 			}
 		},
 		classicSupportingWebp: {
-			name: 'classic',
+			name: 'classicSupportingWebp',
 			creator: 'replace',
 			config: {
 				extraPlugins: 'uploadimage,image',
@@ -314,21 +314,7 @@
 			} );
 		},
 
-		'test supportedTypes webp': function() {
-			var bot = this.editorBots.classic,
-				editor = this.editors.classicSupportingWebp;
-
-			bot.setData( '', function() {
-				resumeAfter( editor, 'paste', function() {
-					assertUploadingWidgets( editor, LOADING_IMG );
-				} );
-
-				pasteFiles( editor, [ { name: 'test.webp', type: 'image/webp' } ] );
-
-				wait();
-			} );
-		},
-
+		// (#4400)
 		'test not supportedTypes webp': function() {
 			var bot = this.editorBots.classic,
 				editor = this.editors.classic;
@@ -354,6 +340,22 @@
 				} );
 
 				pasteFiles( editor, [ { name: 'test.tiff', type: 'image/tiff' } ] );
+
+				wait();
+			} );
+		},
+
+		// (#4400)
+		'test setting config.uploadImage_supportedTypes allows uploading webp images': function() {
+			var bot = this.editorBots.classicSupportingWebp,
+				editor = this.editors.classicSupportingWebp;
+
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, LOADING_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.webp', type: 'image/webp' } ] );
 
 				wait();
 			} );

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -24,6 +24,18 @@
 				pasteFilter: null
 			}
 		},
+		classicSupportingWebp: {
+			name: 'classic',
+			creator: 'replace',
+			config: {
+				extraPlugins: 'uploadimage,image',
+				removePlugins: 'image2',
+				imageUploadUrl: 'http://foo/upload',
+				uploadImage_supportedTypes: /image\/(jpeg|png|gif|bmp|webp)/,
+				// Disable pasteFilter on Webkits (pasteFilter defaults semantic-text on Webkits).
+				pasteFilter: null
+			}
+		},
 		inline: {
 			name: 'inline',
 			creator: 'inline',
@@ -297,6 +309,36 @@
 				} );
 
 				pasteFiles( editor, [ { name: 'test.bmp', type: 'image/bmp' } ] );
+
+				wait();
+			} );
+		},
+
+		'test supportedTypes webp': function() {
+			var bot = this.editorBots.classic,
+				editor = this.editors.classicSupportingWebp;
+
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assertUploadingWidgets( editor, LOADING_IMG );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.webp', type: 'image/webp' } ] );
+
+				wait();
+			} );
+		},
+
+		'test not supportedTypes webp': function() {
+			var bot = this.editorBots.classic,
+				editor = this.editors.classic;
+
+			bot.setData( '', function() {
+				resumeAfter( editor, 'paste', function() {
+					assert.areSame( 0, editor.editable().find( 'img[data-widget="uploadimage"]' ).count() );
+				} );
+
+				pasteFiles( editor, [ { name: 'test.webp', type: 'image/webp' } ] );
 
 				wait();
 			} );


### PR DESCRIPTION
New feature

Added a new configuration parameter, `uploadImage_supportedTypes`, dedicated to the image upload plugin that allows to specify additional supported image types, such as 'image/webp' format.

```
* [#4400](https://github.com/ckeditor/ckeditor4/issues/4400): new configuration parameter `uploadImage_supportedTypes` dedicated to upload image plugin.
```

Closes #4400.
