### PR TITLE
Fix undo in single cell when using tab key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Fixed Issues:
 * [#698](https://github.com/ckeditor/ckeditor4/issues/698): Fixed: The error is thrown after applying formatting to the widget with inline editable and switching to the source mode. Thanks to [Glen](https://github.com/glen-84)!
 * [#439](https://github.com/ckeditor/ckeditor4/issues/439): Fixed: Incorrect <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> navigation for radio buttons inside the dialog.
 * [#3540](https://github.com/ckeditor/ckeditor4/issues/3540): Fixed: The [startup data](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html) command data is not being passed to the widget to populate widget's template.
+* [#4829](https://github.com/ckeditor/ckeditor4/issues/4829): Fixed: Undo reverses entire table content instead of a single cell. Thanks to that fix, multiple changes in a table can be undone one by one.
 
 API changes:
 

--- a/plugins/tab/plugin.js
+++ b/plugins/tab/plugin.js
@@ -24,7 +24,7 @@
 	function selectNextCellCommand( backward ) {
 		return {
 			editorFocus: false,
-			canUndo: false,
+			canUndo: true,
 			modes: { wysiwyg: 1 },
 			exec: function( editor ) {
 				if ( editor.editable().hasFocus ) {

--- a/tests/plugins/tab/manual/tabpreserveundostep.html
+++ b/tests/plugins/tab/manual/tabpreserveundostep.html
@@ -1,0 +1,20 @@
+<h2><code>Iframe</code>-based editor</h2>
+<div id="iframe"></div>
+
+<h2><code>Div</code>-based editor</h2>
+<div id="div"></div>
+
+<h2>Inline editor</h2>
+<div id="inline" contenteditable="true"></div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'iframe' );
+	CKEDITOR.replace( 'div', {
+		extraPlugins: 'divarea'
+	} );
+	CKEDITOR.inline( 'inline' );
+</script>

--- a/tests/plugins/tab/manual/tabpreserveundostep.html
+++ b/tests/plugins/tab/manual/tabpreserveundostep.html
@@ -1,20 +1,26 @@
-<h2><code>Iframe</code>-based editor</h2>
-<div id="iframe"></div>
-
-<h2><code>Div</code>-based editor</h2>
-<div id="div"></div>
-
-<h2>Inline editor</h2>
-<div id="inline" contenteditable="true"></div>
+<div id="editor">
+	<table border="1" cellspacing="1" cellpadding="1" style="width:500px">
+		<tbody>
+			<tr>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
 
 <script>
 	if ( bender.tools.env.mobile ) {
 		bender.ignore();
 	}
 
-	CKEDITOR.replace( 'iframe' );
-	CKEDITOR.replace( 'div', {
-		extraPlugins: 'divarea'
-	} );
-	CKEDITOR.inline( 'inline' );
+	CKEDITOR.replace( 'editor' );
 </script>

--- a/tests/plugins/tab/manual/tabpreserveundostep.md
+++ b/tests/plugins/tab/manual/tabpreserveundostep.md
@@ -1,15 +1,14 @@
-@bender-tags: 4.20.1, bug, 4829
+@bender-tags: 4.21.0, bug, 4829
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, tab, table, undo, floatingspace
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tab, table, undo, floatingspace, sourcearea, basicstyles
 
-1. Create a standard table.
-2. Write some text in a single cell.
-3. Jump to the next cell by using `Tab` key.
-4. Repeat step 2.
-5. Use `undo` button.
+**Note**: If you change the selection when adding text to the table cells, the undo/redo steps may work differently due to updating selection snapshots.
 
-**Expected** Text from the last modified cell was removed. There is undo step for each cell.
+1. Fill all empty cells in the table with some text.
+2. Press undo button at the end of the undo stack.
 
-**Unexpected** There is a single undo step that reverses the entire input from the table.
+**Expected**: Text from each cell separately is undone in the reverse order of adding a text.
 
-6. Repeat above steps for each editor.
+3. Press the redo button at the end of the redo stack.
+
+**Expected**: Text from each cell separately is redone back to the original state.

--- a/tests/plugins/tab/manual/tabpreserveundostep.md
+++ b/tests/plugins/tab/manual/tabpreserveundostep.md
@@ -1,0 +1,15 @@
+@bender-tags: 4.20.1, bug, 4829
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, tab, table, undo, floatingspace
+
+1. Create a standard table.
+2. Write some text in a single cell.
+3. Jump to the next cell by using `Tab` key.
+4. Repeat step 2.
+5. Use `undo` button.
+
+**Expected** Text from the last modified cell was removed. There is undo step for each cell.
+
+**Unexpected** There is a single undo step that reverses the entire input from the table.
+
+6. Repeat above steps for each editor.

--- a/tests/plugins/tab/tab.js
+++ b/tests/plugins/tab/tab.js
@@ -29,6 +29,47 @@
 
 			assert.areSame( '<p><em>foo&nbsp;&nbsp;&nbsp;x</em>bar</p>', this.editorBot.getData( true ),
 				'spaces and text were inserted into the inline element' );
+		},
+
+		// (#4829)
+		'test tab preserves undo step in table cells': function() {
+			bender.editorBot.create( {
+				name: 'tab-undo',
+				config: {
+					plugins: 'tab, undo'
+				}
+			}, function( bot ) {
+				var editor = bot.editor;
+
+				bot.setHtmlWithSelection(
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>text[]</td>' +
+								'<td><br></td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>'
+				);
+
+				editor.editable().fire( 'keydown', new CKEDITOR.dom.event( { keyCode: 9 } ) );
+				editor.insertText( 'foo' );
+
+				assert.areEqual(
+					editor.getSelection().getRanges()[ 0 ]._getTableElement().getText(),
+					'foo',
+					'Inserted text does not match'
+				);
+				editor.execCommand( 'undo' );
+				assert.beautified.html(
+					editor.getData(),
+					'<table>' +
+						'<tbody>' +
+							'<tr><td>text</td><td>&nbsp;</td></tr>' +
+						'</tbody>' +
+					'</table>'
+				);
+			} );
 		}
 	} );
 


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#4829](https://github.com/ckeditor/ckeditor4/issues/4829): Fix: Undo reverse entire table content instead of single cell.
```

## What changes did you make?

In the `tab` plugin implementation, the `canUndo` flag has been set to `false` in the `selectNextCellCommand()` function. 
Setting it to "true" solved the problem of being able to undo only one cell instead of the entire table when using the `Tab` key to move between cells.

## Which issues does your PR resolve?

Closes #4829.
