### PR TITLE
Populate widget template with startup data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ CKEditor 4 Changelog
 
 ## CKEditor 4.21.0 [IN DEVELOPMENT]
 
+New features:
+
+* [#3540](https://github.com/ckeditor/ckeditor4/issues/3540): The [startup data](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html) passed to the widget's command is now used to also populate widget's template.
+
 API changes:
 
 * [#5352](https://github.com/ckeditor/ckeditor4/issues/5352): Added the [`colorButton_contentsCss`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-colorButton_contentsCss) configuration option allowing to add custom CSS to the [Color Button](https://ckeditor.com/cke4/addon/colorbutton) menu content. Thanks to [mihilion](https://github.com/mihilion)!

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2034,7 +2034,9 @@
 				} else if ( widgetDef.template ) {
 					// ... or create a brand-new widget from template.
 					var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,
-						element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( defaults ), editor.document ),
+						renderedTemplate = widgetDef.template.output( CKEDITOR.tools.object.merge( defaults,
+							commandData && commandData.startupData ) ),
+						element = CKEDITOR.dom.element.createFromHtml( renderedTemplate, editor.document ),
 						instance,
 						wrapper = editor.widgets.wrapElement( element, widgetDef.name ),
 						temp = new CKEDITOR.dom.documentFragment( wrapper.getDocument() );

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2034,9 +2034,8 @@
 				} else if ( widgetDef.template ) {
 					// ... or create a brand-new widget from template.
 					var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,
-						renderedTemplate = widgetDef.template.output( CKEDITOR.tools.object.merge( defaults || {},
-							commandData && commandData.startupData || {} ) ),
-						element = CKEDITOR.dom.element.createFromHtml( renderedTemplate, editor.document ),
+						templateData = CKEDITOR.tools.object.merge( defaults || {}, commandData && commandData.startupData || {} ),
+						element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( templateData ), editor.document ),
 						instance,
 						wrapper = editor.widgets.wrapElement( element, widgetDef.name ),
 						temp = new CKEDITOR.dom.documentFragment( wrapper.getDocument() );

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2034,8 +2034,8 @@
 				} else if ( widgetDef.template ) {
 					// ... or create a brand-new widget from template.
 					var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,
-						renderedTemplate = widgetDef.template.output( CKEDITOR.tools.object.merge( defaults,
-							commandData && commandData.startupData ) ),
+						renderedTemplate = widgetDef.template.output( CKEDITOR.tools.object.merge( defaults || {},
+							commandData && commandData.startupData || {} ) ),
 						element = CKEDITOR.dom.element.createFromHtml( renderedTemplate, editor.document ),
 						instance,
 						wrapper = editor.widgets.wrapElement( element, widgetDef.name ),

--- a/tests/plugins/widget/manual/startupdata.html
+++ b/tests/plugins/widget/manual/startupdata.html
@@ -1,0 +1,39 @@
+<p><button id="trigger">Insert widget</button></p>
+<div id="editor">
+	<p>I am the editor</p>
+</div>
+
+<script>
+	( function() {
+		CKEDITOR.plugins.add( 'test', {
+			requires: 'widget',
+			init: function( editor ) {
+				editor.widgets.add( 'test', {
+					requiredContent: 'div(test)',
+					template: '<div class="test">{content}</div>',
+
+					upcast: function( element ) {
+						return element.name == 'div' && element.hasClass( 'test' );
+					},
+
+					defaults: {
+						content: 'default content'
+					},
+				} );
+			}
+		} );
+
+		var editor = CKEDITOR.replace( 'editor', {
+			extraAllowedContent: 'div(test)',
+			extraPlugins: 'test'
+		} );
+
+		CKEDITOR.document.getById( 'trigger' ).on( 'click', function() {
+			editor.execCommand( 'test', {
+				startupData: {
+					content: 'hublabubla'
+				}
+			} );
+		} );
+	} )();
+</script>

--- a/tests/plugins/widget/manual/startupdata.md
+++ b/tests/plugins/widget/manual/startupdata.md
@@ -1,0 +1,11 @@
+@bender-tags: 4.21.0, feature, widget, 3540
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, wysiwygarea, toolbar
+
+1. Focus the editor
+2. Click the "Insert widget" button.
+3. Check the content of the inserted widget.
+
+	**Expected** There's a `hublabubla` text inside the widget.
+
+	**Unexpected** There's a `default content` text inside the widget.

--- a/tests/plugins/widget/widgetapi.js
+++ b/tests/plugins/widget/widgetapi.js
@@ -201,44 +201,6 @@
 			} );
 		},
 
-		// (#3540)
-		'test initialization - startup data is used to populate the widget template': function() {
-			var editor = this.editor,
-				widgetDef = {
-					requiredContent: 'div(test)',
-					template: '<div class="test">{content}</div>',
-
-					upcast: function( element ) {
-						return element.name == 'div' && element.hasClass( 'test' );
-					},
-
-					defaults: {
-						content: 'default content'
-					}
-				},
-				expectedContent = 'hublabubla';
-
-			editor.widgets.add( 'teststartupdata', widgetDef );
-
-			editor.once( 'afterCommandExec', function() {
-				resume( function() {
-					var widget = editor.widgets.instances[ 0 ],
-						widgetContent = widget.element.getHtml();
-
-					assert.areSame( expectedContent, widgetContent );
-				} );
-			} );
-
-			editor.focus();
-			editor.execCommand( 'teststartupdata', {
-				startupData: {
-					content: expectedContent
-				}
-			} );
-
-			wait();
-		},
-
 		'test initialization - basic properties': function() {
 			var editor = this.editor,
 				regWidgetDef = editor.widgets.add( 'testinit5', {} ),
@@ -901,6 +863,51 @@
 
 			this.editorBot.setData( '<p><b class="upcastscope2">Foo</b></p>', function() {
 				assert.areSame( widget, scope, 'Upcasts are called in the context of widget' );
+			} );
+		},
+
+		// (#3540)
+		'test initialization - startup data is used to populate the widget template': function() {
+			bender.editorBot.create( {
+				name: 'test_editor_startupdata',
+				config: {
+					allowedContent: 'div(test)'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					widgetDef = {
+						requiredContent: 'div(test)',
+						template: '<div class="test">{content}</div>',
+
+						upcast: function( element ) {
+							return element.name == 'div' && element.hasClass( 'test' );
+						},
+
+						defaults: {
+							content: 'default content'
+						}
+					},
+					expectedContent = 'hublabubla';
+
+				editor.widgets.add( 'teststartupdata', widgetDef );
+
+				editor.once( 'afterCommandExec', function() {
+					resume( function() {
+						var widget = editor.widgets.instances[ 0 ],
+							widgetContent = widget.element.getHtml();
+
+						assert.areSame( expectedContent, widgetContent );
+					} );
+				} );
+
+				editor.focus();
+				editor.execCommand( 'teststartupdata', {
+					startupData: {
+						content: expectedContent
+					}
+				} );
+
+				wait();
 			} );
 		}
 	} );

--- a/tests/plugins/widget/widgetapi.js
+++ b/tests/plugins/widget/widgetapi.js
@@ -201,6 +201,44 @@
 			} );
 		},
 
+		// (#3540)
+		'test initialization - startup data is used to populate the widget template': function() {
+			var editor = this.editor,
+				widgetDef = {
+					requiredContent: 'div(test)',
+					template: '<div class="test">{content}</div>',
+
+					upcast: function( element ) {
+						return element.name == 'div' && element.hasClass( 'test' );
+					},
+
+					defaults: {
+						content: 'default content'
+					}
+				},
+				expectedContent = 'hublabubla';
+
+			editor.widgets.add( 'teststartupdata', widgetDef );
+
+			editor.once( 'afterCommandExec', function() {
+				resume( function() {
+					var widget = editor.widgets.instances[ 0 ],
+						widgetContent = widget.element.getHtml();
+
+					assert.areSame( expectedContent, widgetContent );
+				} );
+			} );
+
+			editor.focus();
+			editor.execCommand( 'teststartupdata', {
+				startupData: {
+					content: expectedContent
+				}
+			} );
+
+			wait();
+		},
+
 		'test initialization - basic properties': function() {
 			var editor = this.editor,
 				regWidgetDef = editor.widgets.add( 'testinit5', {} ),


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3540](https://github.com/ckeditor/ckeditor4/issues/3540): The startup data passed to the widget's command is now used to also populate widget's template.
```

## What changes did you make?

I've implemented changes proposed in https://github.com/ckeditor/ckeditor4/issues/3540#issuecomment-538508212 – seems to be enough.

## Which issues does your PR resolve?

Closes #3540.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
