### PR TITLE
Fire the `change` event after uploading is done

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#439](https://github.com/ckeditor/ckeditor4/issues/439): Fixed: Incorrect <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> navigation for radio buttons inside the dialog.
 * [#4829](https://github.com/ckeditor/ckeditor4/issues/4829): Fixed: Undo reversed entire table content instead of a single cell. Thanks to that fix, multiple changes in a table can be undone one by one.
 * [#5396](https://github.com/ckeditor/ckeditor4/issues/5396): Fixed: Event listeners for `popstate` and `hashchange` events on the `window`, added by the [Maximize](https://ckeditor.com/cke4/addon/maximize) plugin, were not removed when destroying the editor instance.
+* [#5414](https://github.com/ckeditor/ckeditor4/issues/5414): Fixed: File and image uploaders based on the [Upload Widget plugin](https://ckeditor.com/cke4/addon/uploadwidget) and [Easy Image plugin ](https://ckeditor.com/cke4/addon/easyimage) didn't fire the [`change` event](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change) upon finishing upload, resulting in passing incorrect data in form controls for integration frameworks, like [Reactive forms in Angular](https://angular.io/guide/reactive-forms).
 
 API changes:
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -350,8 +350,8 @@
 							sizes: '100vw'
 						} );
 
-						// Ensure that replacing placeholder image with the final one
-						// ss considered a change of content (#5414).
+						// Ensure that replacing the placeholder image with the final one
+						// is considered a content change (#5414).
 						this.editor.fire( 'change' );
 					} );
 

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -349,6 +349,8 @@
 							srcset: srcset,
 							sizes: '100vw'
 						} );
+
+						this.editor.fire( 'change' );
 					} );
 
 					this.on( 'uploadFailed', function() {

--- a/plugins/easyimage/plugin.js
+++ b/plugins/easyimage/plugin.js
@@ -350,6 +350,8 @@
 							sizes: '100vw'
 						} );
 
+						// Ensure that replacing placeholder image with the final one
+						// ss considered a change of content (#5414).
 						this.editor.fire( 'change' );
 					} );
 

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -95,6 +95,8 @@
 					this.replaceWith( '<img src="' + upload.url + '" ' +
 						'width="' + width + '" ' +
 						'height="' + height + '">' );
+
+					this.editor.fire( 'change' );
 				}
 			} );
 

--- a/plugins/uploadimage/plugin.js
+++ b/plugins/uploadimage/plugin.js
@@ -95,8 +95,6 @@
 					this.replaceWith( '<img src="' + upload.url + '" ' +
 						'width="' + width + '" ' +
 						'height="' + height + '">' );
-
-					this.editor.fire( 'change' );
 				}
 			} );
 

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -360,8 +360,8 @@
 					editor.getSelection().selectBookmarks( bookmarks );
 				}
 
-				// Ensure that replacing upload placeholder with the final
-				// uploaded element is considered a change of content (#5414).
+				// Ensure that replacing the upload placeholder with the final
+				// uploaded element is considered a content change (#5414).
 				editor.fire( 'change' );
 			},
 

--- a/plugins/uploadwidget/plugin.js
+++ b/plugins/uploadwidget/plugin.js
@@ -359,6 +359,10 @@
 				} else {
 					editor.getSelection().selectBookmarks( bookmarks );
 				}
+
+				// Ensure that replacing upload placeholder with the final
+				// uploaded element is considered a change of content (#5414).
+				editor.fire( 'change' );
 			},
 
 			/**

--- a/tests/plugins/easyimage/manual/changeevent.html
+++ b/tests/plugins/easyimage/manual/changeevent.html
@@ -1,0 +1,29 @@
+<p>Note, this test uses a real Cloud Service connection, so you might want to be on-line 😉.</p>
+
+<div id="editor">
+	<p>Drop image here:</p>
+</div>
+
+<div id="changes"></div>
+
+<script>
+	( function() {
+		bender.tools.ignoreUnsupportedEnvironment( 'easyimage' );
+
+		var changeLog = CKEDITOR.document.getById( 'changes' ),
+			i = 0;
+
+		CKEDITOR.replace( 'editor', {
+			cloudServices_uploadUrl: easyImageTools.CLOUD_SERVICES_UPLOAD_GATEWAY,
+			cloudServices_tokenUrl: easyImageTools.CLOUD_SERVICES_TOKEN_URL,
+			on: {
+				change: function( evt ) {
+					var change = CKEDITOR.dom.element.createFromHtml( '<p>Change #' + ( ++i ) + '</p>' );
+
+					changeLog.append( change );
+					console.log( 'change ' + i, evt.editor.getData() );
+				}
+			}
+		} );
+	} ) ();
+</script>

--- a/tests/plugins/easyimage/manual/changeevent.md
+++ b/tests/plugins/easyimage/manual/changeevent.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.20.2, 5414, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, easyimage, undo
+@bender-include: ../_helpers/tools.js
+
+1. Drop image into the editor.
+1. Wait for its upload.
+
+**Expected** There are two change events noted under the editor.
+**Unexpected** There is only one change event noted under the editor.
+
+**Note** You can check editor's data for each `change` event in the browser console.

--- a/tests/plugins/easyimage/manual/changeevent.md
+++ b/tests/plugins/easyimage/manual/changeevent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.20.2, 5414, bug
+@bender-tags: 4.20.2, bug, 5414
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, easyimage, undo
 @bender-include: ../_helpers/tools.js

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -218,6 +218,32 @@
 				wait();
 			},
 
+			// #5414
+			'test change event is fired after the upload finishes': function() {
+				var editor = this.editor,
+					listeners = this.listeners;
+
+				listeners.push( editor.widgets.on( 'instanceCreated', function( evt ) {
+					var widget = evt.data;
+					if ( widget.name == 'easyimage' ) {
+						listeners.push( editor.once( 'change', function( evt ) {
+							resume( function() {
+								var editorData = evt.editor.getData(),
+									// To check if the change contains correct upload data,
+									// we can simply check the existence of srcset attribute with a part of the path.
+									containsUploadedImageSrc = editorData.indexOf( 'srcset="/tests/' ) !== -1;
+
+								assert.isTrue( containsUploadedImageSrc );
+							} );
+						} ) );
+					}
+				} ) );
+
+				pasteFiles( editor, [ bender.tools.getTestPngFile() ], null, { type: 'auto', method: 'paste' } );
+
+				wait();
+			},
+
 			'test pasting mixed HTML content': function() {
 				var editor = this.editor,
 					widgets;

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -218,7 +218,7 @@
 				wait();
 			},
 
-			// #5414
+			// (#5414)
 			'test change event is fired after the upload finishes': function() {
 				var editor = this.editor,
 					listeners = this.listeners;

--- a/tests/plugins/uploadfile/manual/changeevent.html
+++ b/tests/plugins/uploadfile/manual/changeevent.html
@@ -1,0 +1,28 @@
+<div id="editor">
+	<p>Drop some file here:</p>
+</div>
+
+<div id="changes"></div>
+
+<script>
+	( function() {
+		var changeLog = CKEDITOR.document.getById( 'changes' ),
+			i = 0;
+
+		CKEDITOR.once( 'instanceReady', function() {
+			bender.tools.ignoreUnsupportedEnvironment( 'uploadfile' );
+		} );
+
+		CKEDITOR.replace( 'editor', {
+			uploadUrl: 'fakeUrl',
+			on: {
+				change: function( evt ) {
+					var change = CKEDITOR.dom.element.createFromHtml( '<p>Change #' + ( ++i ) + '</p>' );
+
+					changeLog.append( change );
+					console.log( 'change ' + i, evt.editor.getData() );
+				}
+			}
+		} );
+	} ) ();
+</script>

--- a/tests/plugins/uploadfile/manual/changeevent.md
+++ b/tests/plugins/uploadfile/manual/changeevent.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.20.2, 5414, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, uploadfile, undo
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
+
+1. Drop some file into the editor.
+1. Wait for its upload.
+
+**Expected** There are two change events noted under the editor.
+**Unexpected** There is only one change event noted under the editor.
+
+**Note** You can check editor's data for each `change` event in the browser console.

--- a/tests/plugins/uploadfile/manual/changeevent.md
+++ b/tests/plugins/uploadfile/manual/changeevent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.20.2, 5414, bug
+@bender-tags: 4.20.2, bug, 5414
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, uploadfile, undo
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/uploadfile/uploadfile.js
+++ b/tests/plugins/uploadfile/uploadfile.js
@@ -231,7 +231,7 @@ bender.test( {
 		assert.areSame( 'abort', loader.status, 'Loader status' );
 	},
 
-	// #5414
+	// (#5414)
 	'test firing change event after the upload finishes': function() {
 		var editor = this.editors.uploadfile,
 			uploads = editor.uploadRepository,

--- a/tests/plugins/uploadfile/uploadfile.js
+++ b/tests/plugins/uploadfile/uploadfile.js
@@ -229,5 +229,27 @@ bender.test( {
 		loader.abort();
 
 		assert.areSame( 'abort', loader.status, 'Loader status' );
+	},
+
+	// #5414
+	'test firing change event after the upload finishes': function() {
+		var editor = this.editors.uploadfile,
+			uploads = editor.uploadRepository,
+			loader = uploads.create( bender.tools.getTestTxtFile() );
+
+		this.editorBots.uploadfile.setData( '<span data-cke-upload-id="' + loader.id +
+			'" data-widget="uploadfile">...</span>', function() {
+			editor.once( 'change', function() {
+				resume( function() {
+					assert.sameData( '<p><a href="%BASE_PATH%_assets/sample.txt" target="_blank">name.txt</a></p>',
+						editor.getData() );
+				} );
+			} );
+
+			loader.url = '%BASE_PATH%_assets/sample.txt';
+			loader.changeStatus( 'uploaded' );
+
+			wait();
+		} );
 	}
 } );

--- a/tests/plugins/uploadimage/manual/changeevent.html
+++ b/tests/plugins/uploadimage/manual/changeevent.html
@@ -1,0 +1,47 @@
+<h2>With <code>image</code> plugin</h2>
+<div id="image">
+	<p>Drop image here:</p>
+</div>
+
+<div id="changes-image"></div>
+
+<h2>With <code>image2</code> plugin</h2>
+<div id="image2">
+	<p>Drop image here:</p>
+</div>
+
+<div id="changes-image2"></div>
+
+<script>
+	( function() {
+		CKEDITOR.once( 'instanceReady', function() {
+			bender.tools.ignoreUnsupportedEnvironment( 'uploadimage' );
+		} );
+
+		creatEditorWithChangelog( 'image', {
+			extraPlugins: 'image'
+		} );
+		creatEditorWithChangelog( 'image2', {
+			extraPlugins: 'image2'
+		} );
+
+		function creatEditorWithChangelog( editorId, userConfig ) {
+			var changeLog = CKEDITOR.document.getById( 'changes-' + editorId ),
+				i = 0,
+				commonConfig = {
+					uploadUrl: 'fakeUrl',
+						on: {
+							change: function( evt ) {
+								var change = CKEDITOR.dom.element.createFromHtml( '<p>Change #' + ( ++i ) + '</p>' );
+
+								changeLog.append( change );
+								console.log( 'change ' + i, evt.editor.getData() );
+							}
+						}
+					},
+				config = CKEDITOR.tools.object.merge( commonConfig, userConfig || {} );
+
+			CKEDITOR.replace( editorId, config );
+		}
+	} ) ();
+</script>

--- a/tests/plugins/uploadimage/manual/changeevent.md
+++ b/tests/plugins/uploadimage/manual/changeevent.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.20.2, 5414, bug
+@bender-tags: 4.20.2, bug, 5414
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, uploadimage, undo
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js

--- a/tests/plugins/uploadimage/manual/changeevent.md
+++ b/tests/plugins/uploadimage/manual/changeevent.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.20.2, 5414, bug
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, uploadimage, undo
+@bender-include: ../../uploadwidget/manual/_helpers/xhr.js
+
+1. Drop image into the editor.
+1. Wait for its upload.
+
+**Expected** There are two change events noted under the editor.
+**Unexpected** There is only one change event noted under the editor.
+
+**Note** You can check editor's data for each `change` event in the browser console.

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -636,7 +636,7 @@
 			} );
 		},
 
-		// #5414
+		// (#5414)
 		'test change event is fired after upload finishes': function() {
 			bender.editorBot.create( {
 				name: 'undo-integration-change-after-upload',

--- a/tests/plugins/uploadimage/uploadimage.js
+++ b/tests/plugins/uploadimage/uploadimage.js
@@ -634,6 +634,45 @@
 					wait();
 				} );
 			} );
+		},
+
+		// #5414
+		'test change event is fired after upload finishes': function() {
+			bender.editorBot.create( {
+				name: 'undo-integration-change-after-upload',
+				config: {
+					uploadUrl: '%BASE_PATH',
+					extraPlugins: 'uploadimage'
+				}
+			}, function( bot ) {
+				var editor = bot.editor,
+					imageName = 'test.png',
+					image = {
+						name: imageName,
+						type: 'image/png'
+					},
+					loader;
+
+				bot.setData( '', function() {
+					editor.once( 'change', function( evt ) {
+						resume( function() {
+							var editorData = evt.editor.getData(),
+								containsUploadedImageUrl = editorData.indexOf( 'src="' + IMG_URL ) !== -1;
+
+							assert.isTrue( containsUploadedImageUrl );
+						} );
+					} );
+
+					pasteFilesWithFilesMimeType( editor, [ image ] );
+
+					loader = editor.uploadRepository.loaders[ 0 ];
+
+					loader.url = IMG_URL;
+					loader.changeStatus( 'uploaded' );
+
+					wait();
+				} );
+			} );
 		}
 	} );
 

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -1136,7 +1136,7 @@
 			} );
 		},
 
-		// #5414
+		// (#5414)
 		'test firing change after calling replaceWith() method': function() {
 			var bot = this.editorBot,
 				editor = bot.editor,

--- a/tests/plugins/uploadwidget/uploadwidget.js
+++ b/tests/plugins/uploadwidget/uploadwidget.js
@@ -11,7 +11,8 @@
 		htmlMatchingOpts = {
 			compareSelection: true,
 			normalizeSelection: true
-		};
+		},
+		UPLOADED_MARKER = 'uploaded';
 
 	bender.editor = {
 		config: {
@@ -34,7 +35,7 @@
 			},
 
 			onUploaded: function() {
-				this.replaceWith( 'uploaded' );
+				this.replaceWith( UPLOADED_MARKER );
 			}
 		} );
 
@@ -1132,6 +1133,33 @@
 				loader.changeStatus( 'uploaded' );
 
 				assert.areSame( '<p><u>xxx</u></p>', editor.getData() );
+			} );
+		},
+
+		// #5414
+		'test firing change after calling replaceWith() method': function() {
+			var bot = this.editorBot,
+				editor = bot.editor,
+				uploads = editor.uploadRepository,
+				loader = uploads.create( bender.tools.getTestPngFile() );
+
+			loader.loadAndUpload( 'uploadUrl' );
+
+			addTestUploadWidget( editor, 'testChange' );
+
+			bot.setData( '<span data-cke-upload-id="' + loader.id + '" data-widget="testChange">...</span>', function() {
+				editor.once( 'change', function() {
+					resume( function() {
+						var editorContent = editor.getData(),
+							containsUploadedContent = editorContent.indexOf( UPLOADED_MARKER ) !== -1;
+
+						assert.isTrue( containsUploadedContent, 'The editor contains the marker of the uploaded widget' );
+					} );
+				} );
+
+				loader.changeStatus( 'uploaded' );
+
+				wait();
 			} );
 		}
 	} );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5414](https://github.com/ckeditor/ckeditor4/issues/5414): Fixed: File and image uploaders based on the [Upload Widget plugin](https://ckeditor.com/cke4/addon/uploadwidget) and [Easy Image plugin ](https://ckeditor.com/cke4/addon/easyimage)didn't fire the [`change` event](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change) upon finishing upload, resulting in passing incorrect data in form controls for integration frameworks, like [Reactive forms in Angular](https://angular.io/guide/reactive-forms).
```

## What changes did you make?

In the case of `easyimage`, I've added firing of the `change` event at the end of the `uploadDone` listener.

In the case of `uploadwidget` and its dependents, I've added firing of the `change` event at the end of its `replaceWith()` method.

## Which issues does your PR resolve?

Closes #5414.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
