### PR TITLE
Remove the historyAPI listeners in the `maximize` plugin when destroying the editor instance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Fixed Issues:
 * [#439](https://github.com/ckeditor/ckeditor4/issues/439): Fixed: Incorrect <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> navigation for radio buttons inside the dialog.
 * [#3540](https://github.com/ckeditor/ckeditor4/issues/3540): Fixed: The [startup data](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_plugins_widget.html) command data is not being passed to the widget to populate widget's template.
 * [#4829](https://github.com/ckeditor/ckeditor4/issues/4829): Fixed: Undo reverses entire table content instead of a single cell. Thanks to that fix, multiple changes in a table can be undone one by one.
+* [#5396](https://github.com/ckeditor/ckeditor4/issues/5396): Fixed: Event listeners for `popstate` and `hashchange` events on the `window`, added by the [Maximize](https://ckeditor.com/cke4/addon/maximize) plugin, were not removed when destroying the editor instance.
 
 API changes:
 

--- a/plugins/maximize/plugin.js
+++ b/plugins/maximize/plugin.js
@@ -118,6 +118,14 @@
 				editor.resize( viewPaneSize.width, viewPaneSize.height, null, true );
 			}
 
+			function handleHistoryApi() {
+				var command = editor.getCommand( 'maximize' );
+
+				if ( command.state === CKEDITOR.TRISTATE_ON ) {
+					command.exec();
+				}
+			}
+
 			// Retain state after mode switches.
 			var savedState = CKEDITOR.TRISTATE_OFF;
 
@@ -295,12 +303,11 @@
 				var historyEvent = editor.config.maximize_historyIntegration === CKEDITOR.HISTORY_NATIVE ?
 					'popstate' : 'hashchange';
 
-				mainWindow.on( historyEvent, function() {
-					var command = editor.getCommand( 'maximize' );
+				mainWindow.on( historyEvent, handleHistoryApi );
 
-					if ( command.state === CKEDITOR.TRISTATE_ON ) {
-						command.exec();
-					}
+				// Remove the history listener when destroying an editor instance (#5396).
+				editor.on( 'destroy', function() {
+					mainWindow.removeListener( historyEvent, handleHistoryApi );
 				} );
 			}
 		}

--- a/tests/plugins/maximize/maximize.js
+++ b/tests/plugins/maximize/maximize.js
@@ -203,7 +203,7 @@ bender.test( {
 		} );
 	},
 
-	// #(5396)
+	// (#5396)
 	'test maximize removes \'popstate\' event handler when editor instance is destroyed': function() {
 		bender.editorBot.create( {
 			name: 'editor_destroy_popstate',
@@ -223,7 +223,7 @@ bender.test( {
 		} );
 	},
 
-	// #(5396)
+	// (#5396)
 	'test maximize removes \'hashchange\' event handler when editor instance is destroyed': function() {
 		bender.editorBot.create( {
 			name: 'editor_destroy_hash',
@@ -244,8 +244,8 @@ bender.test( {
 		} );
 	},
 
-	// #(5396)
-	'test maximize leaves \'hashchange\' and \'popstate\' listeners when config.maximize_historyIntegration is set to off value': function() {
+	// (#5396)
+	'test maximize does not add \'hashchange\' and \'popstate\' listeners when config.maximize_historyIntegration is set to off value': function() {
 		bender.editorBot.create( {
 			name: 'editor_destroy_hash',
 			config: {

--- a/tests/plugins/maximize/maximize.js
+++ b/tests/plugins/maximize/maximize.js
@@ -201,5 +201,77 @@ bender.test( {
 			editor.execCommand( 'maximize' );
 			ckeWindow.fire( 'popstate' );
 		} );
+	},
+
+	// #(5396)
+	'test maximize removes \'popstate\' event handler when editor instance is destroyed': function() {
+		bender.editorBot.create( {
+			name: 'editor_destroy_popstate',
+			config: {
+				maximize_historyIntegration: CKEDITOR.HISTORY_NATIVE
+			}
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				initialPopstateListenersLength = ckeWindow.getPrivate().events.popstate.listeners.length;
+
+			editor.destroy();
+
+			var popstateListenersLength = ckeWindow.getPrivate().events.popstate.listeners.length;
+
+			assert.areSame( initialPopstateListenersLength - 1, popstateListenersLength, 'the popstate listener should be removed' );
+		} );
+	},
+
+	// #(5396)
+	'test maximize removes \'hashchange\' event handler when editor instance is destroyed': function() {
+		bender.editorBot.create( {
+			name: 'editor_destroy_hash',
+			config: {
+				maximize_historyIntegration: CKEDITOR.HISTORY_HASH
+			}
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				listeners = ckeWindow.getPrivate().events.hashchange.listeners,
+				initialHashchangeListenersLength = listeners.length;
+
+			editor.destroy();
+
+			var hashchangeListenersLength = listeners.length;
+
+			assert.areSame( initialHashchangeListenersLength - 1, hashchangeListenersLength, 'The hashchange listener be removed' );
+		} );
+	},
+
+	// #(5396)
+	'test maximize leaves \'hashchange\' and \'popstate\' listeners when config.maximize_historyIntegration is set to off value': function() {
+		bender.editorBot.create( {
+			name: 'editor_destroy_hash',
+			config: {
+				maximize_historyIntegration: CKEDITOR.HISTORY_OFF
+			}
+		}, function( bot ) {
+			var ckeWindow = CKEDITOR.document.getWindow(),
+				editor = bot.editor,
+				hashchangeListeners = ckeWindow.getPrivate().events.hashchange.listeners,
+				popstateListeners = ckeWindow.getPrivate().events.popstate.listeners,
+				initialHashchangeListenersLength = hashchangeListeners.length,
+				initialPopstateListenersLength = popstateListeners.length;
+
+			editor.destroy();
+
+			var hashchangeListenersLength = hashchangeListeners.length;
+			var popstateListenersLength = popstateListeners.length;
+
+			assert.areSame(
+				initialHashchangeListenersLength, hashchangeListenersLength,
+				'The hashchange listeners length should be equal with the initial length'
+			);
+			assert.areSame(
+				initialPopstateListenersLength, popstateListenersLength,
+				'The popstate listeners length should be equal with the initial length'
+			);
+		} );
 	}
 } );


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5396](https://github.com/ckeditor/ckeditor4/issues/5396): Fix: window listeners for `popstate` and `hashchange` was not removed when destroying the editor instance.
```

## What changes did you make?

I've added removing the historyApi listeners when the editor instance is destroyed.


## Which issues does your PR resolve?

Closes #5396.
