### PR TITLE
Fix for failing `change` event test in Easy Image plugin

### DIFF
--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -224,9 +224,19 @@
 					listeners = this.listeners;
 
 				listeners.push( editor.widgets.on( 'instanceCreated', function( evt ) {
-					var widget = evt.data;
+					var widget = evt.data,
+						isUploaded = false;
+
 					if ( widget.name == 'easyimage' ) {
-						listeners.push( editor.once( 'change', function( evt ) {
+						widget.once( 'uploadDone', function() {
+							isUploaded = true;
+						} );
+
+						listeners.push( editor.on( 'change', function( evt ) {
+							if ( !isUploaded ) {
+								return;
+							}
+
 							resume( function() {
 								var editorData = evt.editor.getData(),
 									// To check if the change contains correct upload data,


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix for failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

skip

## What changes did you make?

I've added check if the `change` event is fired after the upload is finished (after the `widget#uploadDone` event). Thanks to that, we are sure that the right `change` event is tested.

## Which issues does your PR resolve?

Closes #5420.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
