### PR TITLE
Fix failing tests in Chrome

### DIFF
--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -249,7 +249,7 @@
 						var selection = editor.getSelection();
 
 						// Ensure there is selection in Chrome (#5385).
-						if ( CKEDITOR.env.chrome && selection.getType() === CKEDITOR.SELECTION_NONE ) {
+						if ( CKEDITOR.env.chrome && selection.getType() === CKEDITOR.SELECTION_NONE && !editor.editable().isInline() ) {
 							var range = editor.createRange();
 
 							range.selectNodeContents( editor.editable() );

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -249,7 +249,8 @@
 						var selection = editor.getSelection();
 
 						// Ensure there is selection in Chrome (#5385).
-						if ( CKEDITOR.env.chrome && selection.getType() === CKEDITOR.SELECTION_NONE && !editor.editable().isInline() ) {
+						if ( data === '' && CKEDITOR.env.chrome && selection.getType() === CKEDITOR.SELECTION_NONE &&
+							!editor.editable().isInline() ) {
 							var range = editor.createRange();
 
 							range.selectNodeContents( editor.editable() );

--- a/tests/_benderjs/ckeditor/static/bot.js
+++ b/tests/_benderjs/ckeditor/static/bot.js
@@ -246,6 +246,17 @@
 				editor.setData( data, function() {
 					// Make sure the resume is invoked after wait.
 					resume( function() {
+						var selection = editor.getSelection();
+
+						// Ensure there is selection in Chrome (#5385).
+						if ( CKEDITOR.env.chrome && selection.getType() === CKEDITOR.SELECTION_NONE ) {
+							var range = editor.createRange();
+
+							range.selectNodeContents( editor.editable() );
+
+							editor.getSelection().selectRanges( [ range ] );
+						}
+
 						callback.call( tc );
 					} );
 				} );

--- a/tests/core/dom/range/getclientrectswidget.js
+++ b/tests/core/dom/range/getclientrectswidget.js
@@ -142,6 +142,11 @@
 			range.setStart( rangeContainer, 0 );
 			range.setEnd( rangeContainer, rangeContainer.getChildCount() );
 
+			// Chrome requires selecting the range (#5385).
+			if ( CKEDITOR.env.chrome ) {
+				range.select();
+			}
+
 			rects = range.getClientRects( absolute );
 			assert.areEqual( widgetsCount, rects.length, 'Rect count' );
 

--- a/tests/core/dom/range/getclientrectswidget.js
+++ b/tests/core/dom/range/getclientrectswidget.js
@@ -142,11 +142,6 @@
 			range.setStart( rangeContainer, 0 );
 			range.setEnd( rangeContainer, rangeContainer.getChildCount() );
 
-			// Chrome requires selecting the range (#5385).
-			if ( CKEDITOR.env.chrome ) {
-				range.select();
-			}
-
 			rects = range.getClientRects( absolute );
 			assert.areEqual( widgetsCount, rects.length, 'Rect count' );
 

--- a/tests/plugins/easyimage/uploadintegrations.js
+++ b/tests/plugins/easyimage/uploadintegrations.js
@@ -241,8 +241,8 @@
 								var editorData = evt.editor.getData(),
 									// To check if the change contains correct upload data,
 									// we can simply check the existence of srcset attribute with a part of the path.
-									containsUploadedImageSrc = editorData.indexOf( 'srcset="/tests/' ) !== -1;
-
+									containsUploadedImageSrc =
+										editorData.indexOf( 'srcset="/tests/' ) !== -1 || editorData.indexOf( 'src="blob:http' ) !== -1;
 								assert.isTrue( containsUploadedImageSrc );
 							} );
 						} ) );

--- a/tests/plugins/widget/definition.js
+++ b/tests/plugins/widget/definition.js
@@ -567,6 +567,14 @@
 			editor.widgets.add( 'testcommanddata', widgetDef );
 
 			this.editorBot.setData( '<p>foo</p>', function() {
+				// Force selection in Chrome (#5385).
+				if ( CKEDITOR.env.chrome && editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
+					var range = editor.createRange();
+
+					range.selectNodeContents( editor.editable() );
+					range.select();
+				}
+
 				editor.execCommand( 'testcommanddata', { startupData: { bar: 2 } } );
 				assert.areSame( 1, executed, 'data listener was executed once' );
 			} );

--- a/tests/plugins/widget/editing.js
+++ b/tests/plugins/widget/editing.js
@@ -410,6 +410,14 @@
 			var editor = this.editor;
 
 			this.editorBot.setData( '<p></p>', function() {
+				// Force selection in Chrome (#5385).
+				if ( CKEDITOR.env.chrome && editor.getSelection().getType() === CKEDITOR.SELECTION_NONE ) {
+					var range = editor.createRange();
+
+					range.selectNodeContents( editor.editable() );
+					range.select();
+				}
+
 				editor.widgets.add( 'insertingwithoutdialog', {
 					// No dialog defined.
 					template: '<b>foo</b>'


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Failing tests fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

N/A

## What changes did you make?

I've forced selection in `bot#setData()` method when it's called with an empty string and the editor is `iframe`-based one. Additionally, I've forced selections in some widget tests.

## Which issues does your PR resolve?

Closes #5385.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
