### PR TITLE
 Support custom type attribute in scriptLoader method with new parameter T/5434

### DIFF
--- a/core/scriptloader.js
+++ b/core/scriptloader.js
@@ -36,6 +36,8 @@ CKEDITOR.scriptLoader = ( function() {
 		 *			alert( 'Number of failures: ' + failed.length );
 		 *		} );
 		 *
+		 *		CKEDITOR.scriptLoader.load( '/myscript.js', callback, CKEDITOR, false, 'module' );
+		 *
 		 * @param {String/Array} scriptUrl One or more URLs pointing to the
 		 * scripts to be loaded.
 		 * @param {Function} [callback] A function to be called when the script
@@ -48,8 +50,10 @@ CKEDITOR.scriptLoader = ( function() {
 		 * the callback call. Defaults to {@link CKEDITOR}.
 		 * @param {Boolean} [showBusy] Changes the cursor of the document while
 		 * the script is loaded.
+		 * @param {String} [typeAttribute] Set a custom type attribute on the
+		 * script tag. Defaults to `text/javascript`.
 		 */
-		load: function( scriptUrl, callback, scope, showBusy ) {
+		load: function( scriptUrl, callback, scope, showBusy, typeAttribute ) {
 			var isString = ( typeof scriptUrl == 'string' );
 
 			if ( isString )
@@ -57,6 +61,9 @@ CKEDITOR.scriptLoader = ( function() {
 
 			if ( !scope )
 				scope = CKEDITOR;
+
+			if ( !typeAttribute )
+				typeAttribute = 'text/javascript';
 
 			var scriptCount = scriptUrl.length,
 				scriptCountDoCallback = scriptCount,
@@ -115,7 +122,7 @@ CKEDITOR.scriptLoader = ( function() {
 					// Create the <script> element.
 					var script = new CKEDITOR.dom.element( 'script' );
 					script.setAttributes( {
-						type: 'text/javascript',
+						type: typeAttribute,
 						src: url
 					} );
 

--- a/tests/core/scriptloader.js
+++ b/tests/core/scriptloader.js
@@ -30,7 +30,7 @@ var tests = {
 
 		function callback() {
 			tc.resume( function() {
-				var script = CKEDITOR.document.findOne( 'src="../_assets/sample.js"' );
+				var script = CKEDITOR.document.findOne( 'script[src="../_assets/sample.js"]' );
 
 				assert.areSame( script.$.attr( 'type' ), 'module' );
 				assert.areSame( 'Test!', testVar );

--- a/tests/core/scriptloader.js
+++ b/tests/core/scriptloader.js
@@ -25,6 +25,23 @@ var tests = {
 		this.wait();
 	},
 
+	'test load with custom type attribute': function() {
+		var tc = this;
+
+		function callback() {
+			tc.resume( function() {
+				var script = CKEDITOR.document.findOne( 'src="../_assets/sample.js"' );
+
+				assert.areSame( script.$.attr( 'type' ), 'module' );
+				assert.areSame( 'Test!', testVar );
+			} );
+		}
+
+		CKEDITOR.scriptLoader.load( '../_assets/sample.js', callback, CKEDITOR, false, 'module' );
+
+		this.wait();
+	},
+
 	'test load event handling': function() {
 		var tc = this;
 


### PR DESCRIPTION
## What is the purpose of this pull request?

New feature to support a custom type attribute on the rendered script tag from the method CKEDITOR.scriptLoader.load to better integrate with applications that may need this, like Drupal.

`<script src="/path/to/script.js" type="module"></script>`

## Does your PR contain necessary tests?

New test named 'test load with custom type attribute' in /tests/core/scriptloader.js.

### This PR contains

- [x] Unit tests
- [N/A] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5434](https://github.com/ckeditor/ckeditor4/issues/5434): Support custom type attribute in scriptLoader method with new parameter.
```

## What changes did you make?

Added a new parameter named 'typeAttribute' to the load method on CKEDITOR.scriptLoader that is default to 'text/javascript'. This will allow Drupal developers to set the custom type attribute of 'module' on the script tag when needed. Also added a new test to confirm the custom parameter works.

## Which issues does your PR resolve?

Closes #5434.

