### PR TITLE
Prevent using `document.domain` by Firefox in the `preview` plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 CKEditor 4 Changelog
 ====================
 
+## CKEditor 4.21.1
+
+Other Changes:
+
+* [#5412](https://github.com/ckeditor/ckeditor4/issues/5412): Prevent using `document.domain` in Firefox in the [Preview](https://ckeditor.com/cke4/addon/preview) plugin.
+
 ## CKEditor 4.21.0
 
 **Security Updates:**

--- a/plugins/preview/plugin.js
+++ b/plugins/preview/plugin.js
@@ -61,7 +61,6 @@
 				// For IE we should use window.location rather than setting url in window.open (https://dev.ckeditor.com/ticket/11146).
 				previewLocation = getPreviewLocation(),
 				nativePreviewWindow,
-				previewUrl = '',
 				previewWindow,
 				doc;
 
@@ -78,7 +77,7 @@
 				window._cke_htmlToLoad = eventData.dataValue;
 			}
 
-			nativePreviewWindow = window.open( previewUrl, null, generateWindowOptions( windowDimensions ) );
+			nativePreviewWindow = window.open( '', null, generateWindowOptions( windowDimensions ) );
 			previewWindow = new CKEDITOR.dom.window( nativePreviewWindow );
 
 			// For IE we want to assign whole js stored in previewLocation, but in case of
@@ -135,13 +134,11 @@
 			'</body></html>';
 
 		function generateBaseTag() {
-			var template = '<base href="{HREF}">';
-
-			if ( config.baseHref ) {
-				return template.replace( '{HREF}', config.baseHref );
+			if ( !config.baseHref ) {
+				return '';
 			}
 
-			return '';
+			return '<base href="' + config.baseHref + '">';
 		}
 
 		function createBodyHtml() {

--- a/plugins/preview/plugin.js
+++ b/plugins/preview/plugin.js
@@ -60,8 +60,8 @@
 				windowDimensions = getWindowDimensions(),
 				// For IE we should use window.location rather than setting url in window.open (https://dev.ckeditor.com/ticket/11146).
 				previewLocation = getPreviewLocation(),
-				previewUrl = getPreviewUrl(),
 				nativePreviewWindow,
+				previewUrl = '',
 				previewWindow,
 				doc;
 
@@ -74,7 +74,7 @@
 			// In cases where we force reloading the location or setting concrete URL to open,
 			// we need a way to pass content to the opened window. We do it by hack with
 			// passing it through window's parent property.
-			if ( previewLocation || previewUrl ) {
+			if ( previewLocation ) {
 				window._cke_htmlToLoad = eventData.dataValue;
 			}
 
@@ -135,25 +135,13 @@
 			'</body></html>';
 
 		function generateBaseTag() {
-			var template = '<base href="{HREF}">',
-				origin = location.origin,
-				pathname = location.pathname;
-
-			if ( !config.baseHref && !CKEDITOR.env.gecko ) {
-				return '';
-			}
+			var template = '<base href="{HREF}">';
 
 			if ( config.baseHref ) {
 				return template.replace( '{HREF}', config.baseHref );
 			}
 
-			// As we use HTML file in Gecko, we must fix the incorrect base for
-			// relative paths.
-			pathname = pathname.split( '/' );
-			pathname.pop();
-			pathname = pathname.join( '/' );
-
-			return template.replace( '{HREF}', origin + pathname + '/' );
+			return '';
 		}
 
 		function createBodyHtml() {
@@ -212,8 +200,7 @@
 	}
 
 	function getPreviewLocation() {
-		// #(4444)
-		if ( !CKEDITOR.env.ie && !CKEDITOR.env.gecko ) {
+		if ( !CKEDITOR.env.ie ) {
 			return null;
 		}
 
@@ -226,18 +213,6 @@
 			'document.close();' +
 			'window.opener._cke_htmlToLoad = null;' +
 		'})() )';
-	}
-
-	function getPreviewUrl() {
-		var pluginPath = CKEDITOR.plugins.getPath( 'preview' );
-
-		if ( !CKEDITOR.env.gecko ) {
-			return '';
-		}
-
-		// With Firefox only, we need to open a special preview page, so
-		// anchors will work properly on it (https://dev.ckeditor.com/ticket/9047).
-		return CKEDITOR.getUrl( pluginPath + 'preview.html' );
 	}
 } )();
 

--- a/tests/plugins/preview/manual/previewcdn.md
+++ b/tests/plugins/preview/manual/previewcdn.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.17.0, bug, 4444
+@bender-tags: 4.17.0, 4.21.1 bug, 4444, 5412
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, preview, font, colorbutton, format, clipboard, pagebreak, toolbar, floatingspace, link, image2
 

--- a/tests/plugins/preview/manual/previewpreservelinks.html
+++ b/tests/plugins/preview/manual/previewpreservelinks.html
@@ -1,0 +1,35 @@
+<div id="editor"></div>
+
+<button id="setContent">Set Content</button>
+
+<script>
+	if ( !CKEDITOR.env.gecko ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		lang: 'en',
+		on: {
+			instanceReady: function( evt ) {
+			var setContent = document.getElementById( 'setContent' ),
+				link = '<p><a id="testId" href="http://cksource.com" name="testName">http://cksource.com</a></p>',
+				editor = evt.editor;
+
+			setContent.addEventListener( 'click', function() {
+				editor.setData( link + '<p>&nbsp;</p>'.repeat( 150 ) );
+
+				setTimeout( function() {
+					editor.focus();
+
+					var range = editor.createRange();
+					range.moveToElementEditEnd( editor.editable() );
+					range.select();
+					editor.getSelection().scrollIntoView();
+				}, 50 );
+			} );
+			}
+		}
+	} );
+
+</script>
+

--- a/tests/plugins/preview/manual/previewpreservelinks.md
+++ b/tests/plugins/preview/manual/previewpreservelinks.md
@@ -1,0 +1,12 @@
+@bender-tags: 4.21.1, bug, 5412
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, preview, link, sourcearea
+
+1. Press `Set Content` button to create a `url` type link with id, name and add 150 new lines.
+2. Create a link and select its type as `Link to anchor in the text` and select the anchor name or id of the link created in the previous step.
+3. Click `Preview` button.
+4. Click the newly created link located at the bottom of page.
+
+**Expected:** Focus has been moved to link at the beginning of the page. The link has been updated with `#testName`.
+
+**Unexpected:** Focus was moved and the page was reloaded.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Task

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5412](https://github.com/ckeditor/ckeditor4/issues/5412): Prevent using `document.domain` by Firefox in the `preview` plugin.
```

## What changes did you make?

In the previous PR with fixing print on Firefox, we [allowed using document.domain](https://github.com/ckeditor/ckeditor4/pull/4813/files#diff-36cb2ca37dc3086bbe191b661d4f8923ff5872b765b8d537439a568da622580aR216) to properly open the preview before print while using the editor from CDN. Looks like FF fixed this and we can remove it.
Additionally, we could simplify the code more by removing [fix for creating links to anchor](https://dev.ckeditor.com/ticket/9047).

## Which issues does your PR resolve?

Closes #5412.
