### PR TITLE
Fix showing notification about unsupported files when `clipboard_handleImages` is OFF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ New Features:
 
 * [#4400](https://github.com/ckeditor/ckeditor4/issues/4400): Added the [`config.uploadImage_supportedTypes`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-uploadImage_supportedTypes) configuration option allowing to change the image formats accepted by the [Upload Image](https://ckeditor.com/cke4/addon/uploadimage) plugin. Thanks to [SilverYoCha](https://github.com/SilverYoCha)!
 
+Fixed Issues:
+
+* [#5431](https://github.com/ckeditor/ckeditor4/issues/5431): Fix: No notification is shown when pasting or dropping unsupported image types into the editor.
+
 ## CKEditor 4.20.2
 
 Fixed Issues:

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -236,7 +236,7 @@
 			}, null, null, 1 );
 
 			function testImageBase64Support( file ) {
-				// Check if turning images into base64 is disabled. #5431
+				// Check if turning images into base64 is disabled (#5431).
 				if ( !editor.config.clipboard_handleImages ) {
 					return false;
 				}

--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -236,6 +236,11 @@
 			}, null, null, 1 );
 
 			function testImageBase64Support( file ) {
+				// Check if turning images into base64 is disabled. #5431
+				if ( !editor.config.clipboard_handleImages ) {
+					return false;
+				}
+
 				var supportedImageTypes = [ 'image/png', 'image/jpeg', 'image/gif' ];
 				return CKEDITOR.tools.indexOf( supportedImageTypes, file.type ) !== -1;
 			}

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -150,6 +150,46 @@
 			} );
 		},
 
+		// (#5431)
+		'test dropping image when the clipboard_handleImages configuration option is OFF': function() {
+			var originalClipboard_handleImages = CKEDITOR.config.clipboard_handleImages;
+			CKEDITOR.config.clipboard_handleImages = false;
+
+			var dropEvt = bender.tools.mockDropEvent(),
+				imageType = 'image/png',
+				expectedData = '<p class="p">Paste image here:</p>',
+				expectedMsgRegex  = prepareNotificationRegex( this.editor.lang.clipboard.fileFormatNotSupportedNotification ),
+				expectedDuration = this.editor.config.clipboard_notificationDuration,
+				notificationSpy = sinon.spy( this.editor, 'showNotification' );
+
+			FileReader.setFileMockType( imageType );
+			FileReader.setReadResult( 'load' );
+
+			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
+			assertImageDrop(  {
+				editor: this.editor,
+				event: dropEvt,
+				type: imageType,
+				expectedData: expectedData,
+				dropRange: {
+					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+					dropOffset: 17
+				},
+				callback: function() {
+					notificationSpy.restore();
+
+					assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
+					assert.isMatching( expectedMsgRegex, notificationSpy.getCall( 0 ).args[ 0 ],
+						'The notification had correct message' );
+					assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
+					'The notification had correct type' );
+					assert.areSame( expectedDuration, notificationSpy.getCall( 0 ).args[ 2 ],
+						'The notification had correct duration' );
+				}
+			} );
+			CKEDITOR.config.clipboard_handleImages = originalClipboard_handleImages;
+		},
+
 		'test abort drop': function() {
 			var dropEvt = bender.tools.mockDropEvent(),
 				imageType = 'image/png',

--- a/tests/plugins/clipboard/dropimage.js
+++ b/tests/plugins/clipboard/dropimage.js
@@ -151,44 +151,45 @@
 		},
 
 		// (#5431)
-		'test dropping image when the clipboard_handleImages configuration option is OFF': function() {
-			var originalClipboard_handleImages = CKEDITOR.config.clipboard_handleImages;
-			CKEDITOR.config.clipboard_handleImages = false;
+		'test dropping image when the clipboard_handleImages configuration option is OFF displays notification about unsupported image type':
+			function() {
+				var originalClipboard_handleImages = CKEDITOR.config.clipboard_handleImages;
+				CKEDITOR.config.clipboard_handleImages = false;
 
-			var dropEvt = bender.tools.mockDropEvent(),
-				imageType = 'image/png',
-				expectedData = '<p class="p">Paste image here:</p>',
-				expectedMsgRegex  = prepareNotificationRegex( this.editor.lang.clipboard.fileFormatNotSupportedNotification ),
-				expectedDuration = this.editor.config.clipboard_notificationDuration,
-				notificationSpy = sinon.spy( this.editor, 'showNotification' );
+				var dropEvt = bender.tools.mockDropEvent(),
+					imageType = 'image/png',
+					expectedData = '<p class="p">Paste image here:</p>',
+					expectedMsgRegex  = prepareNotificationRegex( this.editor.lang.clipboard.fileFormatNotSupportedNotification ),
+					expectedDuration = this.editor.config.clipboard_notificationDuration,
+					notificationSpy = sinon.spy( this.editor, 'showNotification' );
 
-			FileReader.setFileMockType( imageType );
-			FileReader.setReadResult( 'load' );
+				FileReader.setFileMockType( imageType );
+				FileReader.setReadResult( 'load' );
 
-			setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
-			assertImageDrop(  {
-				editor: this.editor,
-				event: dropEvt,
-				type: imageType,
-				expectedData: expectedData,
-				dropRange: {
-					dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
-					dropOffset: 17
-				},
-				callback: function() {
-					notificationSpy.restore();
+				setHtmlWithSelection( this.editor, '<p class="p">Paste image here:^</p>' );
+				assertImageDrop(  {
+					editor: this.editor,
+					event: dropEvt,
+					type: imageType,
+					expectedData: expectedData,
+					dropRange: {
+						dropContainer: this.editor.editable().findOne( '.p' ).getChild( 0 ),
+						dropOffset: 17
+					},
+					callback: function() {
+						notificationSpy.restore();
 
-					assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
-					assert.isMatching( expectedMsgRegex, notificationSpy.getCall( 0 ).args[ 0 ],
-						'The notification had correct message' );
-					assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
-					'The notification had correct type' );
-					assert.areSame( expectedDuration, notificationSpy.getCall( 0 ).args[ 2 ],
-						'The notification had correct duration' );
-				}
-			} );
-			CKEDITOR.config.clipboard_handleImages = originalClipboard_handleImages;
-		},
+						assert.areSame( 1, notificationSpy.callCount, 'There was only one notification' );
+						assert.isMatching( expectedMsgRegex, notificationSpy.getCall( 0 ).args[ 0 ],
+							'The notification had correct message' );
+						assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
+						'The notification had correct type' );
+						assert.areSame( expectedDuration, notificationSpy.getCall( 0 ).args[ 2 ],
+							'The notification had correct duration' );
+					}
+				} );
+				CKEDITOR.config.clipboard_handleImages = originalClipboard_handleImages;
+			},
 
 		'test abort drop': function() {
 			var dropEvt = bender.tools.mockDropEvent(),

--- a/tests/plugins/clipboard/manual/dropnotificationdisablehandleimages.html
+++ b/tests/plugins/clipboard/manual/dropnotificationdisablehandleimages.html
@@ -1,0 +1,11 @@
+<div id="editor"></div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		clipboard_handleImages: false
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/dropnotificationdisablehandleimages.md
+++ b/tests/plugins/clipboard/manual/dropnotificationdisablehandleimages.md
@@ -2,9 +2,9 @@
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard
 
-**Note** You may want to download a sample image. To do so, just right-click on the link and select `Save as`.
+**Note** You may want to download a sample image. To do so, just right-click on the link and select `Save Link As`.
 
-1. Paste [PNG image](%BASE_PATH%_assets/logo.png) into the editor.
+1. Drop [PNG image](%BASE_PATH%_assets/logo.png) into the editor.
 
 **Expected** The image is not inserted into the editor and the notification: `The image/png file format(s) are not supported.` is displayed.
 

--- a/tests/plugins/clipboard/manual/pastenotificationdisablehandleimages.html
+++ b/tests/plugins/clipboard/manual/pastenotificationdisablehandleimages.html
@@ -1,0 +1,11 @@
+<div id="editor"></div>
+
+<script>
+	if ( bender.tools.env.mobile ) {
+		bender.ignore();
+	}
+
+	CKEDITOR.replace( 'editor', {
+		clipboard_handleImages: false
+	} );
+</script>

--- a/tests/plugins/clipboard/manual/pastenotificationdisablehandleimages.html
+++ b/tests/plugins/clipboard/manual/pastenotificationdisablehandleimages.html
@@ -6,6 +6,13 @@
 	}
 
 	CKEDITOR.replace( 'editor', {
-		clipboard_handleImages: false
+		clipboard_handleImages: false,
+		on: {
+			loaded: function() {
+				if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported ) {
+					bender.ignore();
+				}
+			}
+		}
 	} );
 </script>

--- a/tests/plugins/clipboard/manual/pastenotificationdisablehandleimages.md
+++ b/tests/plugins/clipboard/manual/pastenotificationdisablehandleimages.md
@@ -1,0 +1,9 @@
+@bender-tags: 4.21.0, bug, 5431
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, undo, clipboard
+
+1. Paste [PNG image](%BASE_PATH%_assets/logo.png) into the editor.
+
+**Expected** The image is not inserted into the editor and the notification: `The image/png file format(s) are not supported.` is displayed.
+
+**Unexpected** The image is inserted into the editor.

--- a/tests/plugins/clipboard/notifications.js
+++ b/tests/plugins/clipboard/notifications.js
@@ -168,7 +168,7 @@
 			wait();
 		},
 
-		// #5431
+		// (#5431)
 		'test notification with information about unsupported file types should be displayed when the clipboard_handleImages is disabled': function( editor ) {
 			var originalClipboard_handleImages = CKEDITOR.config.clipboard_handleImages;
 			CKEDITOR.config.clipboard_handleImages = false;

--- a/tests/plugins/clipboard/notifications.js
+++ b/tests/plugins/clipboard/notifications.js
@@ -166,6 +166,36 @@
 			}, 50 );
 
 			wait();
+		},
+
+		// #5431
+		'test notification with information about unsupported file types should be displayed when the clipboard_handleImages is disabled': function( editor ) {
+			var originalClipboard_handleImages = CKEDITOR.config.clipboard_handleImages;
+			CKEDITOR.config.clipboard_handleImages = false;
+
+			var notificationSpy = sinon.spy( editor, 'showNotification' ),
+				notificationMessage = 'The <em>image/jpeg, image/png, image/gif</em> file format(s) are not supported.',
+				files = [
+					{ name: 'test.jpeg', type: 'image/jpeg' },
+					{ name: 'test.png', type: 'image/png' },
+					{ name: 'test.gif', type: 'image/gif' }
+				];
+
+			pasteFiles( editor, files );
+
+			resume( function() {
+				CKEDITOR.config.clipboard_handleImages = originalClipboard_handleImages;
+
+				notificationSpy.restore();
+
+				assert.areSame( 1, notificationSpy.callCount, 'Notification should be called once' );
+				assert.areSame( notificationMessage, notificationSpy.getCall( 0 ).args[ 0 ],
+					'The notification has incorrect message' );
+				assert.areSame( 'info', notificationSpy.getCall( 0 ).args[ 1 ],
+					'The notification type is incorrect' );
+			}, 50 );
+
+			wait();
 		}
 	};
 

--- a/tests/plugins/uploadimage/manual/customsupportedtypes.md
+++ b/tests/plugins/uploadimage/manual/customsupportedtypes.md
@@ -1,4 +1,4 @@
-@bender-tags: 4.20.3, feature, 4400
+@bender-tags: 4.21.0, feature, 4400, 5431
 @bender-ui: collapsed
 @bender-ckeditor-plugins: wysiwygarea, toolbar, uploadimage, undo, image2
 @bender-include: ../../uploadwidget/manual/_helpers/xhr.js


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5431](https://github.com/ckeditor/ckeditor4/issues/5431): Fix: No notification is shown for unsupported image types.
```

## What changes did you make?

.

## Which issues does your PR resolve?

Closes #5431.
