### PR TITLE
fix(language): remove default italic style for language selection

### DIFF
--- a/contents.css
+++ b/contents.css
@@ -106,11 +106,6 @@ pre
 	background-color: Yellow;
 }
 
-span[lang]
-{
-	font-style: italic;
-}
-
 figure
 {
 	text-align: center;


### PR DESCRIPTION
## What is the purpose of this pull request?

To remove the default italic style for selected language text.

This was just approved for Ckeditor5 here (https://github.com/ckeditor/ckeditor5/pull/13804).

## Does your PR contain necessary tests?

Only CSS is changed.

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

- https://github.com/ckeditor/ckeditor4/issues/5455: Text with language set is no longer styled as italic. To re-enable previous behavior, add style .ck-content span[lang] { font-style: italic;  } to your css.

## What changes did you make?

Remove the italic styling on span[lang] attribute.

## Which issues does your PR resolve?

Closes #5455
