### PR TITLE
Add ability to indicate the language of styles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CKEditor 4 Changelog
 New Features:
 
 * [#5316](https://github.com/ckeditor/ckeditor4/issues/5316): Add vertical margins support for list elements in the [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
+* [#5410](https://github.com/ckeditor/ckeditor4/issues/5410): Added the ability to indicate the language of styles in the [Styles Combo](https://ckeditor.com/cke4/addon/stylescombo) plugin via the [`config.styleSet`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-stylesSet) configuration option.
 
 Other Changes:
 

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -14,6 +14,7 @@ CKEDITOR.plugins.add( 'listblock', {
 					' draggable="false"' +
 					' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 					' href="javascript:void(\'{val}\')" ' +
+					' lang="{language}"' +
 					' onclick="{onclick}CKEDITOR.tools.callFunction({clickFn},\'{val}\'); return false;"' + // https://dev.ckeditor.com/ticket/188
 						' role="option">' +
 					'{text}' +
@@ -83,7 +84,7 @@ CKEDITOR.plugins.add( 'listblock', {
 			},
 
 			proto: {
-				add: function( value, html, title ) {
+				add: function( value, html, title, language ) {
 					var id = CKEDITOR.tools.getNextId();
 
 					if ( !this._.started ) {
@@ -103,6 +104,10 @@ CKEDITOR.plugins.add( 'listblock', {
 						title: CKEDITOR.tools.htmlEncodeAttr( title || value ),
 						text: html || value
 					};
+
+					if ( language ) {
+						data.language = language;
+					}
 
 					this._.pendingList.push( listItem.output( data ) );
 				},

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -14,7 +14,7 @@ CKEDITOR.plugins.add( 'listblock', {
 					' draggable="false"' +
 					' ondragstart="return false;"' + // Draggable attribute is buggy on Firefox.
 					' href="javascript:void(\'{val}\')" ' +
-					' lang="{language}"' +
+					' {language}' +
 					' onclick="{onclick}CKEDITOR.tools.callFunction({clickFn},\'{val}\'); return false;"' + // https://dev.ckeditor.com/ticket/188
 						' role="option">' +
 					'{text}' +
@@ -84,11 +84,8 @@ CKEDITOR.plugins.add( 'listblock', {
 			},
 
 			proto: {
-				add: function( value, html, title, language, editor ) {
-					var id = CKEDITOR.tools.getNextId(),
-						editorLanguage = editor.config.language ||
-							editor.config.defaultLanguage ||
-							editor.langCode;
+				add: function( value, html, title, language ) {
+					var id = CKEDITOR.tools.getNextId();
 
 					if ( !this._.started ) {
 						this._.started = 1;
@@ -106,7 +103,7 @@ CKEDITOR.plugins.add( 'listblock', {
 						clickFn: this._.getClick(),
 						title: CKEDITOR.tools.htmlEncodeAttr( title || value ),
 						text: html || value,
-						language: language || editorLanguage
+						language: language ? 'lang="' + language + '"' : ''
 					};
 
 					this._.pendingList.push( listItem.output( data ) );

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -84,8 +84,11 @@ CKEDITOR.plugins.add( 'listblock', {
 			},
 
 			proto: {
-				add: function( value, html, title, language ) {
-					var id = CKEDITOR.tools.getNextId();
+				add: function( value, html, title, language, editor ) {
+					var id = CKEDITOR.tools.getNextId(),
+						editorLanguage = editor.config.language ||
+							editor.config.defaultLanguage ||
+							editor.langCode;
 
 					if ( !this._.started ) {
 						this._.started = 1;
@@ -102,12 +105,9 @@ CKEDITOR.plugins.add( 'listblock', {
 							'return false;" onmouseup="CKEDITOR.tools.getMouseButton(event)===CKEDITOR.MOUSE_BUTTON_LEFT&&' : '',
 						clickFn: this._.getClick(),
 						title: CKEDITOR.tools.htmlEncodeAttr( title || value ),
-						text: html || value
+						text: html || value,
+						language: language || editorLanguage
 					};
-
-					if ( language ) {
-						data.language = language;
-					}
 
 					this._.pendingList.push( listItem.output( data ) );
 				},

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -365,10 +365,11 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @param {String} value
 			 * @param {String} html
 			 * @param {String} text
+			 * @param {String} language
 			 */
-			add: function( value, html, text ) {
+			add: function( value, html, text, language ) {
 				this._.items[ value ] = text || value;
-				this._.list.add( value, html, text );
+				this._.list.add( value, html, text, language );
 			},
 
 			startGroup: function( title ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -368,8 +368,9 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @param {String} language
 			 */
 			add: function( value, html, text, language ) {
+				var editor = this._.panel._.editor;
 				this._.items[ value ] = text || value;
-				this._.list.add( value, html, text, language );
+				this._.list.add( value, html, text, language, editor );
 			},
 
 			startGroup: function( title ) {

--- a/plugins/richcombo/plugin.js
+++ b/plugins/richcombo/plugin.js
@@ -368,9 +368,8 @@ CKEDITOR.plugins.add( 'richcombo', {
 			 * @param {String} language
 			 */
 			add: function( value, html, text, language ) {
-				var editor = this._.panel._.editor;
 				this._.items[ value ] = text || value;
-				this._.list.add( value, html, text, language, editor );
+				this._.list.add( value, html, text, language );
 			},
 
 			startGroup: function( title ) {

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -26,7 +26,7 @@
 				if ( !stylesDefinitions )
 					return;
 
-				var style, styleName, styleType;
+				var style, styleName, styleType, styleLanguage;
 
 				// Put all styles into an Array.
 				for ( var i = 0, count = stylesDefinitions.length; i < count; i++ ) {
@@ -39,6 +39,8 @@
 					}
 
 					styleName = styleDefinition.name;
+					// In case when the style definition language is not defined, add the editor lang code (#5410).
+					styleLanguage = styleDefinition.language || editor.langCode;
 					style = new CKEDITOR.style( styleDefinition );
 
 					if ( !editor.filter.customConfig || editor.filter.check( style ) ) {
@@ -49,7 +51,7 @@
 
 						// Weight is used to sort styles (https://dev.ckeditor.com/ticket/9029).
 						style._.weight = i + ( styleType == CKEDITOR.STYLE_OBJECT ? 1 : styleType == CKEDITOR.STYLE_BLOCK ? 2 : 3 ) * 1000;
-
+						style._.language = styleLanguage;
 						styles[ styleName ] = style;
 						stylesList.push( style );
 						allowedContent.push( style );
@@ -89,7 +91,7 @@
 				},
 
 				init: function() {
-					var style, styleName, lastType, type, i, count;
+					var style, styleName, lastType, type, language, i, count;
 
 					// Loop over the Array, adding all items to the
 					// combo.
@@ -97,13 +99,19 @@
 						style = stylesList[ i ];
 						styleName = style._name;
 						type = style._.type;
+						language = style._.language;
 
 						if ( type != lastType ) {
 							this.startGroup( lang[ 'panelTitle' + String( type ) ] );
 							lastType = type;
 						}
 
-						this.add( styleName, style.type == CKEDITOR.STYLE_OBJECT ? styleName : style.buildPreview(), styleName );
+						this.add(
+							styleName,
+							style.type == CKEDITOR.STYLE_OBJECT ? styleName : style.buildPreview(),
+							styleName,
+							language
+						);
 					}
 
 					this.commit();

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -99,7 +99,7 @@
 						style = stylesList[ i ];
 						styleName = style._name;
 						type = style._.type;
-						language = style._.language;
+						language = style._.definition.language;
 
 						if ( type != lastType ) {
 							this.startGroup( lang[ 'panelTitle' + String( type ) ] );

--- a/tests/plugins/stylescombo/langattribute.js
+++ b/tests/plugins/stylescombo/langattribute.js
@@ -44,11 +44,11 @@ bender.test( {
 		} );
 	},
 
-	'test adds the editor language to the Styles combo box item if it is not defined': function() {
+	'test skips adding lang attribute to the Styles combo box item if it is not defined': function() {
 		bender.editorBot.create( {
 			name: 'cb_2',
 			config: {
-				language: 'fi',
+				language: 'en',
 				stylesSet: [
 					{ name: 'testName1', element: 'strong' }
 				]
@@ -61,28 +61,7 @@ bender.test( {
 
 			var lang = getLangAttributeFromPanelElements( stylesCombo._.list );
 
-			assert.areSame( editor.config.language, lang[ 0 ] );
-		} );
-	},
-
-	'test adds the default editor language to the Styles combo box item if it is not defined': function() {
-		bender.editorBot.create( {
-			name: 'cb_3',
-			config: {
-				defaultLanguage: 'it',
-				stylesSet: [
-					{ name: 'testName1', element: 'strong' }
-				]
-			}
-		}, function( bot ) {
-			var editor = bot.editor,
-				stylesCombo = editor.ui.get( 'Styles' );
-
-			stylesCombo.createPanel( editor );
-
-			var lang = getLangAttributeFromPanelElements( stylesCombo._.list );
-
-			assert.areSame( editor.config.defaultLanguage, lang[ 0 ] );
+			assert.isNull( lang[ 0 ] );
 		} );
 	}
 } );

--- a/tests/plugins/stylescombo/langattribute.js
+++ b/tests/plugins/stylescombo/langattribute.js
@@ -26,8 +26,8 @@ bender.test( {
 			config: {
 				stylesSet: [
 					{ name: 'testName1', element: 'strong', language: 'pl' },
-					{ name: 'testName1', element: 'strong', language: 'en' },
-					{ name: 'testName1', element: 'strong', language: 'de' }
+					{ name: 'testName2', element: 'strong', language: 'en' },
+					{ name: 'testName3', element: 'strong', language: 'de' }
 				]
 			}
 		}, function( bot ) {
@@ -44,11 +44,11 @@ bender.test( {
 		} );
 	},
 
-	'test adds the default editor lang code to the Styles combo box item if it is not defined': function() {
+	'test adds the editor language to the Styles combo box item if it is not defined': function() {
 		bender.editorBot.create( {
 			name: 'cb_2',
 			config: {
-				lang: 'en',
+				language: 'fi',
 				stylesSet: [
 					{ name: 'testName1', element: 'strong' }
 				]
@@ -61,7 +61,28 @@ bender.test( {
 
 			var lang = getLangAttributeFromPanelElements( stylesCombo._.list );
 
-			assert.areSame( editor.config.lang, lang[ 0 ] );
+			assert.areSame( editor.config.language, lang[ 0 ] );
+		} );
+	},
+
+	'test adds the default editor language to the Styles combo box item if it is not defined': function() {
+		bender.editorBot.create( {
+			name: 'cb_3',
+			config: {
+				defaultLanguage: 'it',
+				stylesSet: [
+					{ name: 'testName1', element: 'strong' }
+				]
+			}
+		}, function( bot ) {
+			var editor = bot.editor,
+				stylesCombo = editor.ui.get( 'Styles' );
+
+			stylesCombo.createPanel( editor );
+
+			var lang = getLangAttributeFromPanelElements( stylesCombo._.list );
+
+			assert.areSame( editor.config.defaultLanguage, lang[ 0 ] );
 		} );
 	}
 } );

--- a/tests/plugins/stylescombo/langattribute.js
+++ b/tests/plugins/stylescombo/langattribute.js
@@ -1,0 +1,67 @@
+/* bender-tags: editor */
+/* bender-ckeditor-plugins: stylescombo,toolbar */
+
+function getLangAttributeFromPanelElements( listBlock ) {
+	var els = listBlock.element.find( 'a' ),
+		ret = [],
+		el,
+		attr;
+
+	for ( var i = 0; i < els.count(); ++i ) {
+		el = els.getItem( i ),
+		attr = el.getAttribute( 'lang' );
+
+		if ( attr !== undefined ) {
+			ret.push( attr );
+		}
+	}
+
+	return ret;
+}
+
+bender.test( {
+	'test adds lang attribute to Styles combo box item': function() {
+		bender.editorBot.create( {
+			name: 'cb_1',
+			config: {
+				stylesSet: [
+					{ name: 'testName1', element: 'strong', language: 'pl' },
+					{ name: 'testName1', element: 'strong', language: 'en' },
+					{ name: 'testName1', element: 'strong', language: 'de' }
+				]
+			}
+		}, function( bot ) {
+			var editor = bot.editor,
+				stylesCombo = editor.ui.get( 'Styles' );
+
+			stylesCombo.createPanel( editor );
+
+			var lang = getLangAttributeFromPanelElements( stylesCombo._.list );
+
+			assert.areSame( 'pl', lang[ 0 ] );
+			assert.areSame( 'en', lang[ 1 ] );
+			assert.areSame( 'de', lang[ 2 ] );
+		} );
+	},
+
+	'test adds the default editor lang code to the Styles combo box item if it is not defined': function() {
+		bender.editorBot.create( {
+			name: 'cb_2',
+			config: {
+				lang: 'en',
+				stylesSet: [
+					{ name: 'testName1', element: 'strong' }
+				]
+			}
+		}, function( bot ) {
+			var editor = bot.editor,
+				stylesCombo = editor.ui.get( 'Styles' );
+
+			stylesCombo.createPanel( editor );
+
+			var lang = getLangAttributeFromPanelElements( stylesCombo._.list );
+
+			assert.areSame( editor.config.lang, lang[ 0 ] );
+		} );
+	}
+} );

--- a/tests/plugins/stylescombo/manual/langattribute.html
+++ b/tests/plugins/stylescombo/manual/langattribute.html
@@ -1,0 +1,38 @@
+<div>
+	<div id="editor"></div>
+
+	<div>
+		<strong id="editorLang"></strong>
+		<div>Panel list attributes:</div>
+		<div id="result"></div>
+	</div>
+</div>
+
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		lang: 'en',
+		stylesSet: [
+			{ name: 'testName1', element: 'strong', language: 'pl' },
+			{ name: 'testName2', element: 'span' }
+		],
+		on: {
+			instanceReady: function( evt ) {
+				var editorLangElement = CKEDITOR.document.getById( 'editorLang' );
+				editorLangElement.appendHtml( 'Editor language: ' + evt.editor.langCode );
+			},
+			panelShow: function( evt ) {
+				var panelItems = evt.data._.panel
+					.getHolderElement()
+					.find( 'a' )
+					.toArray(),
+				resultElement = CKEDITOR.document.getById( 'result' );
+				resultElement.setHtml( '' );
+
+				CKEDITOR.tools.array.forEach( panelItems, function( element, index ) {
+					resultElement.appendHtml( 'Item ' + index + ': ' + JSON.stringify( element.getAttributes() ) + '</br></br>' );
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/stylescombo/manual/langattribute.html
+++ b/tests/plugins/stylescombo/manual/langattribute.html
@@ -11,7 +11,7 @@
 
 <script>
 	CKEDITOR.replace( 'editor', {
-		lang: 'en',
+		language: 'en',
 		stylesSet: [
 			{ name: 'testName1', element: 'strong', language: 'pl' },
 			{ name: 'testName2', element: 'span' }

--- a/tests/plugins/stylescombo/manual/langattribute.html
+++ b/tests/plugins/stylescombo/manual/langattribute.html
@@ -3,7 +3,7 @@
 
 	<div>
 		<strong id="editorLang"></strong>
-		<div>Panel list attributes:</div>
+		<div>Panel list lang attributes:</div>
 		<div id="result"></div>
 	</div>
 </div>
@@ -30,7 +30,9 @@
 				resultElement.setHtml( '' );
 
 				CKEDITOR.tools.array.forEach( panelItems, function( element, index ) {
-					resultElement.appendHtml( 'Item ' + index + ': ' + JSON.stringify( element.getAttributes() ) + '</br></br>' );
+					var lang = element.getAttribute( 'lang' ) || 'Not defined';
+
+					resultElement.appendHtml( 'Item ' + ( index + 1 ) + ': <strong>' + lang + '</strong></br></br>' );
 				} );
 			}
 		}

--- a/tests/plugins/stylescombo/manual/langattribute.md
+++ b/tests/plugins/stylescombo/manual/langattribute.md
@@ -1,0 +1,18 @@
+@bender-tags: 4.21.1, feature, 5410
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo
+
+
+1. Click on the Styles combo box to open the panel elements.
+2. Look at the dropped data.
+
+**Expected**
+
+* Item 0 should have the lang attribute set to `pl`.
+* Item 1 should have the `lang` attribute set to the editor language value.
+
+**Unexpected**
+
+* Both panel items do not contain the lang attribute.
+* Only the first element contains the lang attribute.
+* The applied lang attribute is invalid.

--- a/tests/plugins/stylescombo/manual/langattribute.md
+++ b/tests/plugins/stylescombo/manual/langattribute.md
@@ -8,11 +8,10 @@
 
 **Expected**
 
-* Item 0 should have the lang attribute set to `pl`.
-* Item 1 should have the `lang` attribute set to the editor language value.
+* Item 1 should have the lang attribute set to `pl`.
+* Item 2 should have the `lang` attribute set to `Not defined`.
 
 **Unexpected**
 
 * Both panel items have `Not defined` lang attribute.
-* Only the first element contains the lang attribute.
 * The applied lang attribute is invalid.

--- a/tests/plugins/stylescombo/manual/langattribute.md
+++ b/tests/plugins/stylescombo/manual/langattribute.md
@@ -13,6 +13,6 @@
 
 **Unexpected**
 
-* Both panel items do not contain the lang attribute.
+* Both panel items have `Not defined` lang attribute.
 * Only the first element contains the lang attribute.
 * The applied lang attribute is invalid.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

New feature

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5410](https://github.com/ckeditor/ckeditor4/issues/5410): Added the ability to indicate the language of styles via [config.styleSet config variable](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-stylesSet).
```

## What changes did you make?

PR adds the ability to set the language of the Styles dropdown elements. When the language is not explicitly set, the same language as the editor will be added.

## Which issues does your PR resolve?

Closes #5410.
