### PR TITLE
MathJax Plugin: Propose MathJax 3 support

### DIFF
--- a/bender.js
+++ b/bender.js
@@ -160,7 +160,7 @@ var config = {
 		extra_liners: 'head, body, div, p, /html'
 	},
 	mathJaxLibPath: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
-	mathJaxLibPathV3: 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
+	mathJaxLibPathV3: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js'
 };
 
 module.exports = config;

--- a/bender.js
+++ b/bender.js
@@ -159,7 +159,8 @@ var config = {
 		end_with_newline: true,
 		extra_liners: 'head, body, div, p, /html'
 	},
-	mathJaxLibPath: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML'
+	mathJaxLibPath: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
+	mathJaxLibPathV3: 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 };
 
 module.exports = config;

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -7,9 +7,10 @@
  * @fileOverview The [Mathematical Formulas](https://ckeditor.com/cke4/addon/mathjax) plugin that allows you to create and modify mathematical equations written in TeX directly in CKEditor..
  */
 
-'use strict'
-;(function () {
-	CKEDITOR.plugins.add('mathjax', {
+'use strict';
+
+( function() {
+	CKEDITOR.plugins.add( 'mathjax', {
 		// jscs:disable maximumLineLength
 		lang: 'af,ar,az,bg,ca,cs,cy,da,de,de-ch,el,en,en-au,en-gb,eo,es,es-mx,et,eu,fa,fi,fr,gl,he,hr,hu,id,it,ja,km,ko,ku,lt,lv,nb,nl,no,oc,pl,pt,pt-br,ro,ru,sk,sl,sq,sr,sr-latn,sv,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
@@ -17,137 +18,145 @@
 		icons: 'mathjax',
 		hidpi: true, // %REMOVE_LINE_CORE%
 
-		isSupportedEnvironment: function () {
-			return !CKEDITOR.env.ie || CKEDITOR.env.version > 8
+		isSupportedEnvironment: function() {
+			return !CKEDITOR.env.ie || CKEDITOR.env.version > 8;
 		},
 
-		init: function (editor) {
-			var cls = editor.config.mathJaxClass || 'math-tex'
+		init: function( editor ) {
+			var cls = editor.config.mathJaxClass || 'math-tex';
 
-			if (!editor.config.mathJaxLib) {
-				CKEDITOR.error('mathjax-no-config')
+			if ( !editor.config.mathJaxLib ) {
+				CKEDITOR.error( 'mathjax-no-config' );
 			}
 
-			editor.widgets.add('mathjax', {
+			editor.widgets.add( 'mathjax', {
 				inline: true,
 				dialog: 'mathjax',
 				button: editor.lang.mathjax.button,
 				mask: true,
 				allowedContent: 'span(!' + cls + ')',
 				// Allow style classes only on spans having mathjax class.
-				styleToAllowedContentRules: function (style) {
-					var classes = style.getClassesArray()
-					if (!classes) return null
-					classes.push('!' + cls)
+				styleToAllowedContentRules: function( style ) {
+					var classes = style.getClassesArray();
+					if ( !classes )
+						return null;
+					classes.push( '!' + cls );
 
-					return 'span(' + classes.join(',') + ')'
+					return 'span(' + classes.join( ',' ) + ')';
 				},
 				pathName: editor.lang.mathjax.pathName,
 
 				template: '<span class="' + cls + '" style="display:inline-block" data-cke-survive=1></span>',
 
 				parts: {
-					span: 'span',
+					span: 'span'
 				},
 
 				defaults: {
-					math: '\\(x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}\\)',
+					math: '\\(x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}\\)'
 				},
 
-				init: function () {
-					var iframe = this.parts.span.getChild(0)
+				init: function() {
+					var iframe = this.parts.span.getChild( 0 );
 
 					// Check if span contains iframe and create it otherwise.
-					if (!iframe || iframe.type != CKEDITOR.NODE_ELEMENT || !iframe.is('iframe')) {
-						iframe = new CKEDITOR.dom.element('iframe')
-						iframe.setAttributes({
+					if ( !iframe || iframe.type != CKEDITOR.NODE_ELEMENT || !iframe.is( 'iframe' ) ) {
+						iframe = new CKEDITOR.dom.element( 'iframe' );
+						iframe.setAttributes( {
 							style: 'border:0;width:0;height:0',
 							scrolling: 'no',
 							frameborder: 0,
 							allowTransparency: true,
-							src: CKEDITOR.plugins.mathjax.fixSrc,
-						})
-						this.parts.span.append(iframe)
+							src: CKEDITOR.plugins.mathjax.fixSrc
+						} );
+						this.parts.span.append( iframe );
 					}
 
 					// Wait for ready because on some browsers iFrame will not
 					// have document element until it is put into document.
 					// This is a problem when you crate widget using dialog.
-					this.once('ready', function () {
+					this.once( 'ready', function() {
 						// Src attribute must be recreated to fix custom domain error after undo
 						// (see iFrame.removeAttribute( 'src' ) in frameWrapper.load).
-						if (CKEDITOR.env.ie) iframe.setAttribute('src', CKEDITOR.plugins.mathjax.fixSrc)
+						if ( CKEDITOR.env.ie )
+							iframe.setAttribute( 'src', CKEDITOR.plugins.mathjax.fixSrc );
 
-						this.frameWrapper = new CKEDITOR.plugins.mathjax.frameWrapper(iframe, editor)
-						this.frameWrapper.setValue(this.data.math)
-					})
+						this.frameWrapper = new CKEDITOR.plugins.mathjax.frameWrapper( iframe, editor );
+						this.frameWrapper.setValue( this.data.math );
+					} );
 				},
 
-				data: function () {
-					if (this.frameWrapper) this.frameWrapper.setValue(this.data.math)
+				data: function() {
+					if ( this.frameWrapper )
+						this.frameWrapper.setValue( this.data.math );
 				},
 
-				upcast: function (el, data) {
-					if (!(el.name == 'span' && el.hasClass(cls))) return
+				upcast: function( el, data ) {
+					if ( !( el.name == 'span' && el.hasClass( cls ) ) )
+						return;
 
-					if (el.children.length > 1 || el.children[0].type != CKEDITOR.NODE_TEXT) return
+					if ( el.children.length > 1 || el.children[ 0 ].type != CKEDITOR.NODE_TEXT )
+						return;
 
-					data.math = CKEDITOR.tools.htmlDecode(el.children[0].value)
+					data.math = CKEDITOR.tools.htmlDecode( el.children[ 0 ].value );
 
 					// Add style display:inline-block to have proper height of widget wrapper and mask.
-					var attrs = el.attributes
+					var attrs = el.attributes;
 
-					if (attrs.style) attrs.style += ';display:inline-block'
-					else attrs.style = 'display:inline-block'
+					if ( attrs.style )
+						attrs.style += ';display:inline-block';
+					else
+						attrs.style = 'display:inline-block';
 
 					// Add attribute to prevent deleting empty span in data processing.
-					attrs['data-cke-survive'] = 1
+					attrs[ 'data-cke-survive' ] = 1;
 
-					el.children[0].remove()
+					el.children[ 0 ].remove();
 
-					return el
+					return el;
 				},
 
-				downcast: function (el) {
-					el.children[0].replaceWith(new CKEDITOR.htmlParser.text(CKEDITOR.tools.htmlEncode(this.data.math)))
+				downcast: function( el ) {
+					el.children[ 0 ].replaceWith( new CKEDITOR.htmlParser.text( CKEDITOR.tools.htmlEncode( this.data.math ) ) );
 
 					// Remove style display:inline-block.
-					var attrs = el.attributes
-					attrs.style = attrs.style.replace(/display:\s?inline-block;?\s?/, '')
-					if (attrs.style === '') delete attrs.style
+					var attrs = el.attributes;
+					attrs.style = attrs.style.replace( /display:\s?inline-block;?\s?/, '' );
+					if ( attrs.style === '' )
+						delete attrs.style;
 
-					return el
-				},
-			})
+					return el;
+				}
+			} );
 
 			// Add dialog.
-			CKEDITOR.dialog.add('mathjax', this.path + 'dialogs/mathjax.js')
+			CKEDITOR.dialog.add( 'mathjax', this.path + 'dialogs/mathjax.js' );
 
 			// Add MathJax script to page preview.
-			editor.on('contentPreview', function (evt) {
+			editor.on( 'contentPreview', function( evt ) {
 				evt.data.dataValue = evt.data.dataValue.replace(
 					/<\/head>/,
-					'<script src="' + CKEDITOR.getUrl(editor.config.mathJaxLib) + '"></script></head>'
-				)
-			})
+					'<script src="' + CKEDITOR.getUrl( editor.config.mathJaxLib ) + '"><\/script><\/head>'
+				);
+			} );
 
-			editor.on('paste', function (evt) {
+			editor.on( 'paste', function( evt ) {
 				// Firefox does remove iFrame elements from pasted content so this event do the same on other browsers.
 				// Also iFrame in paste content is reason of "Unspecified error" in IE9 (https://dev.ckeditor.com/ticket/10857).
-				var regex = new RegExp('<span[^>]*?' + cls + '.*?</span>', 'ig')
-				evt.data.dataValue = evt.data.dataValue.replace(regex, function (match) {
-					return match.replace(/(<iframe.*?\/iframe>)/i, '')
-				})
-			})
-		},
-	})
+				var regex = new RegExp( '<span[^>]*?' + cls + '.*?<\/span>', 'ig' );
+				evt.data.dataValue = evt.data.dataValue.replace( regex, function( match ) {
+					return match.replace( /(<iframe.*?\/iframe>)/i, '' );
+				} );
+			} );
+		}
+	} );
 
 	/**
 	 * @private
 	 * @singleton
 	 * @class CKEDITOR.plugins.mathjax
 	 */
-	CKEDITOR.plugins.mathjax = {}
+	CKEDITOR.plugins.mathjax = {};
 
 	/**
 	 * A variable to fix problems with `iframe`. This variable is global
@@ -158,16 +167,16 @@
 	 */
 	CKEDITOR.plugins.mathjax.fixSrc =
 		// In Firefox src must exist and be different than about:blank to emit load event.
-		CKEDITOR.env.gecko
-			? 'javascript:true' // jshint ignore:line
-			: // Support for custom document.domain in IE.
-			CKEDITOR.env.ie
-				? 'javascript:' + // jshint ignore:line
-				'void((function(){' +
-				encodeURIComponent('document.open();' + '(' + CKEDITOR.tools.fixDomain + ')();' + 'document.close();') +
-				'})())'
-				: // In Chrome src must be undefined to emit load event.
-				'javascript:void(0)' // jshint ignore:line
+		CKEDITOR.env.gecko ? 'javascript:true' : // jshint ignore:line
+		// Support for custom document.domain in IE.
+		CKEDITOR.env.ie ? 'javascript:' + // jshint ignore:line
+						'void((function(){' + encodeURIComponent(
+							'document.open();' +
+							'(' + CKEDITOR.tools.fixDomain + ')();' +
+							'document.close();'
+						) + '})())' :
+		// In Chrome src must be undefined to emit load event.
+						'javascript:void(0)'; // jshint ignore:line
 
 	/**
 	 * Loading indicator image generated by http://preloaders.net.
@@ -175,7 +184,7 @@
 	 * @private
 	 * @property {String} loadingIcon
 	 */
-	CKEDITOR.plugins.mathjax.loadingIcon = CKEDITOR.plugins.get('mathjax').path + 'images/loader.gif'
+	CKEDITOR.plugins.mathjax.loadingIcon = CKEDITOR.plugins.get( 'mathjax' ).path + 'images/loader.gif';
 
 	/**
 	 * Computes predefined styles and copies them to another element.
@@ -184,15 +193,16 @@
 	 * @param {CKEDITOR.dom.element} from Copy source.
 	 * @param {CKEDITOR.dom.element} to Copy target.
 	 */
-	CKEDITOR.plugins.mathjax.copyStyles = function (from, to) {
-		var stylesToCopy = ['color', 'font-family', 'font-style', 'font-weight', 'font-variant', 'font-size']
+	CKEDITOR.plugins.mathjax.copyStyles = function( from, to ) {
+		var stylesToCopy = [ 'color', 'font-family', 'font-style', 'font-weight', 'font-variant', 'font-size' ];
 
-		for (var i = 0; i < stylesToCopy.length; i++) {
-			var key = stylesToCopy[i],
-				val = from.getComputedStyle(key)
-			if (val) to.setStyle(key, val)
+		for ( var i = 0; i < stylesToCopy.length; i++ ) {
+			var key = stylesToCopy[ i ],
+				val = from.getComputedStyle( key );
+			if ( val )
+				to.setStyle( key, val );
 		}
-	}
+	};
 
 	/**
 	 * Trims MathJax value from '\(1+1=2\)' to '1+1=2'.
@@ -201,12 +211,12 @@
 	 * @param {String} value String to trim.
 	 * @returns {String} Trimed string.
 	 */
-	CKEDITOR.plugins.mathjax.trim = function (value) {
-		var begin = value.indexOf('\\(') + 2,
-			end = value.lastIndexOf('\\)')
+	CKEDITOR.plugins.mathjax.trim = function( value ) {
+		var begin = value.indexOf( '\\(' ) + 2,
+			end = value.lastIndexOf( '\\)' );
 
-		return value.substring(begin, end)
-	}
+		return value.substring( begin, end );
+	};
 
 	/**
 	 * FrameWrapper is responsible for communication between the MathJax library
@@ -221,75 +231,82 @@
 	 * @param {CKEDITOR.dom.element} iFrame The `iframe` element to be wrapped.
 	 * @param {CKEDITOR.editor} editor The editor instance.
 	 */
-	if (!(CKEDITOR.env.ie && CKEDITOR.env.version === 8)) {
-		CKEDITOR.plugins.mathjax.frameWrapper = function (iFrame, editor) {
-			var buffer,
-				preview,
-				value,
-				newValue,
+	if ( !( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) ) {
+		CKEDITOR.plugins.mathjax.frameWrapper = function( iFrame, editor ) {
+
+			var buffer, preview, value, newValue,
 				doc = iFrame.getFrameDocument(),
+
 				// Is MathJax loaded and ready to work.
 				isInit = false,
+
 				// Is MathJax parsing Tex.
 				isRunning = false,
-				// Function called when MathJax is loaded.
-				loadedHandler = CKEDITOR.tools.addFunction(function () {
-					preview = doc.getById('preview')
-					buffer = doc.getById('buffer')
-					isInit = true
 
-					if (newValue) update()
+				// Function called when MathJax is loaded.
+				loadedHandler = CKEDITOR.tools.addFunction( function() {
+					preview = doc.getById( 'preview' );
+					buffer = doc.getById( 'buffer' );
+					isInit = true;
+
+					if ( newValue )
+						update();
 
 					// Private! For test usage only.
-					CKEDITOR.fire('mathJaxLoaded', iFrame)
-				}),
+					CKEDITOR.fire( 'mathJaxLoaded', iFrame );
+				} ),
+
 				// Function called when MathJax finish his job.
-				updateDoneHandler = CKEDITOR.tools.addFunction(function () {
-					CKEDITOR.plugins.mathjax.copyStyles(iFrame, preview)
+				updateDoneHandler = CKEDITOR.tools.addFunction( function() {
+					CKEDITOR.plugins.mathjax.copyStyles( iFrame, preview );
 
-					preview.setHtml(buffer.getHtml())
+					preview.setHtml( buffer.getHtml() );
 
-					editor.fire('lockSnapshot')
+					editor.fire( 'lockSnapshot' );
 
-					iFrame.setStyles({
+					iFrame.setStyles( {
 						height: 0,
-						width: 0,
-					})
+						width: 0
+					} );
 
 					// Set iFrame dimensions.
-					var height = Math.max(doc.$.body.offsetHeight, doc.$.documentElement.offsetHeight),
-						width = Math.max(preview.$.offsetWidth, doc.$.body.scrollWidth)
+					var height = Math.max( doc.$.body.offsetHeight, doc.$.documentElement.offsetHeight ),
+						width = Math.max( preview.$.offsetWidth, doc.$.body.scrollWidth );
 
-					iFrame.setStyles({
+					iFrame.setStyles( {
 						height: height + 'px',
-						width: width + 'px',
-					})
+						width: width + 'px'
+					} );
 
-					editor.fire('unlockSnapshot')
+					editor.fire( 'unlockSnapshot' );
 
 					// Private! For test usage only.
-					CKEDITOR.fire('mathJaxUpdateDone', iFrame)
+					CKEDITOR.fire( 'mathJaxUpdateDone', iFrame );
 
 					// If value changed in the meantime update it again.
-					if (value != newValue) update()
-					else isRunning = false
-				})
+					if ( value != newValue )
+						update();
+					else
+						isRunning = false;
+				} );
+
 			// Function called to run MathJax on update and star
+			iFrame.on( 'load', load );
 
-			iFrame.on('load', load)
-
-			load()
+			load();
 
 			function load() {
-				doc = iFrame.getFrameDocument()
+				doc = iFrame.getFrameDocument();
 
-				if (doc.getById('preview')) return
+				if ( doc.getById( 'preview' ) )
+					return;
 
 				// Because of IE9 bug in a src attribute can not be javascript
 				// when you undo (https://dev.ckeditor.com/ticket/10930). If you have iFrame with javascript in src
 				// and call insertBefore on such element then IE9 will see crash.
-				if (CKEDITOR.env.ie) iFrame.removeAttribute('src')
-				
+				if ( CKEDITOR.env.ie )
+					iFrame.removeAttribute( 'src' );
+
 				doc.write(
 					`<!doctype html>
                           <html lang="${editor.lang}">
@@ -368,35 +385,33 @@
                             <span id="buffer" style="display:none"></span>
                           </body>
                       </html>`
-				)
+				);
 			}
 
 			// Run MathJax parsing Tex.
 			function update() {
-				isRunning = true
+				isRunning = true;
 
-				value = newValue
+				value = newValue;
 
-				editor.fire('lockSnapshot')
+				editor.fire( 'lockSnapshot' );
 
-				buffer.setHtml(value)
+				buffer.setHtml( value );
 
 				// Set loading indicator.
-				preview.setHtml(
-					'<img src=' + CKEDITOR.plugins.mathjax.loadingIcon + ' alt=' + editor.lang.mathjax.loading + '>'
-				)
+				preview.setHtml( '<img src=' + CKEDITOR.plugins.mathjax.loadingIcon + ' alt=' + editor.lang.mathjax.loading + '>' );
 
-				iFrame.setStyles({
+				iFrame.setStyles( {
 					height: '16px',
 					width: '16px',
 					display: 'inline',
-					'vertical-align': 'middle',
-				})
+					'vertical-align': 'middle'
+				} );
 
-				editor.fire('unlockSnapshot')
+				editor.fire( 'unlockSnapshot' );
 
 				// Run MathJax.
-				doc.getWindow().$.update(value)
+				doc.getWindow().$.update( value );
 			}
 
 			return {
@@ -408,55 +423,52 @@
 				 *
 				 * @param {String} value TeX string.
 				 */
-				setValue: function (value) {
-					newValue = CKEDITOR.tools.htmlEncode(value)
+				setValue: function( value ) {
+					newValue = CKEDITOR.tools.htmlEncode( value );
 
-					if (isInit && !isRunning) update()
-				},
-			}
-		}
+					if ( isInit && !isRunning )
+						update();
+				}
+			};
+		};
 	} else {
 		// In IE8 MathJax does not work stable so instead of using standard
 		// frame wrapper it is replaced by placeholder to show pure TeX in iframe.
-		CKEDITOR.plugins.mathjax.frameWrapper = function (iFrame, editor) {
-			iFrame
-				.getFrameDocument()
-				.write(
-					'<!DOCTYPE html>' +
-					'<html>' +
-					'<head>' +
+		CKEDITOR.plugins.mathjax.frameWrapper = function( iFrame, editor ) {
+			iFrame.getFrameDocument().write( '<!DOCTYPE html>' +
+				'<html>' +
+				'<head>' +
 					'<meta charset="utf-8">' +
-					'</head>' +
-					'<body style="padding:0;margin:0;background:transparent;overflow:hidden">' +
+				'</head>' +
+				'<body style="padding:0;margin:0;background:transparent;overflow:hidden">' +
 					'<span style="white-space:nowrap;" id="tex"></span>' +
-					'</body>' +
-					'</html>'
-				)
+				'</body>' +
+				'</html>' );
 
 			return {
-				setValue: function (value) {
+				setValue: function( value ) {
 					var doc = iFrame.getFrameDocument(),
-						tex = doc.getById('tex')
+						tex = doc.getById( 'tex' );
 
-					tex.setHtml(CKEDITOR.plugins.mathjax.trim(CKEDITOR.tools.htmlEncode(value)))
+					tex.setHtml( CKEDITOR.plugins.mathjax.trim( CKEDITOR.tools.htmlEncode( value ) ) );
 
-					CKEDITOR.plugins.mathjax.copyStyles(iFrame, tex)
+					CKEDITOR.plugins.mathjax.copyStyles( iFrame, tex );
 
-					editor.fire('lockSnapshot')
+					editor.fire( 'lockSnapshot' );
 
-					iFrame.setStyles({
-						width: Math.min(250, tex.$.offsetWidth) + 'px',
+					iFrame.setStyles( {
+						width: Math.min( 250, tex.$.offsetWidth ) + 'px',
 						height: doc.$.body.offsetHeight + 'px',
 						display: 'inline',
-						'vertical-align': 'middle',
-					})
+						'vertical-align': 'middle'
+					} );
 
-					editor.fire('unlockSnapshot')
-				},
-			}
-		}
+					editor.fire( 'unlockSnapshot' );
+				}
+			};
+		};
 	}
-})()
+} )();
 
 /**
  * Sets the path to the MathJax library. It can be both a local resource and a location different than the default CDN.
@@ -466,7 +478,7 @@
  * Read more in the {@glink features/mathjax documentation}
  * and see the {@glink examples/mathjax example}.
  *
- *		config.mathJaxLib = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
+ *		config.mathJaxLib = 'https//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML';
  *
  * **Note:** Since CKEditor 4.5.0 this option does not have a default value, so it must
  * be set in order to enable the MathJax plugin.
@@ -488,7 +500,6 @@
  * @cfg {String} matJaxVer
  * @member CKEDITOR.config
  */
-
 
 /**
  * Sets the default class for `span` elements that will be

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -309,7 +309,7 @@
 
 				doc.write(
 					`<!doctype html>
-                          <html lang="${editor.lang}">
+						'<html lang="' + editor.langCode + '">' +
                           <head>
                             <meta charset="utf-8">
                             <script>

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -7,10 +7,9 @@
  * @fileOverview The [Mathematical Formulas](https://ckeditor.com/cke4/addon/mathjax) plugin that allows you to create and modify mathematical equations written in TeX directly in CKEditor..
  */
 
-'use strict';
-
-( function() {
-	CKEDITOR.plugins.add( 'mathjax', {
+'use strict'
+;(function () {
+	CKEDITOR.plugins.add('mathjax', {
 		// jscs:disable maximumLineLength
 		lang: 'af,ar,az,bg,ca,cs,cy,da,de,de-ch,el,en,en-au,en-gb,eo,es,es-mx,et,eu,fa,fi,fr,gl,he,hr,hu,id,it,ja,km,ko,ku,lt,lv,nb,nl,no,oc,pl,pt,pt-br,ro,ru,sk,sl,sq,sr,sr-latn,sv,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
@@ -18,145 +17,137 @@
 		icons: 'mathjax',
 		hidpi: true, // %REMOVE_LINE_CORE%
 
-		isSupportedEnvironment: function() {
-			return !CKEDITOR.env.ie || CKEDITOR.env.version > 8;
+		isSupportedEnvironment: function () {
+			return !CKEDITOR.env.ie || CKEDITOR.env.version > 8
 		},
 
-		init: function( editor ) {
-			var cls = editor.config.mathJaxClass || 'math-tex';
+		init: function (editor) {
+			var cls = editor.config.mathJaxClass || 'math-tex'
 
-			if ( !editor.config.mathJaxLib ) {
-				CKEDITOR.error( 'mathjax-no-config' );
+			if (!editor.config.mathJaxLib) {
+				CKEDITOR.error('mathjax-no-config')
 			}
 
-			editor.widgets.add( 'mathjax', {
+			editor.widgets.add('mathjax', {
 				inline: true,
 				dialog: 'mathjax',
 				button: editor.lang.mathjax.button,
 				mask: true,
 				allowedContent: 'span(!' + cls + ')',
 				// Allow style classes only on spans having mathjax class.
-				styleToAllowedContentRules: function( style ) {
-					var classes = style.getClassesArray();
-					if ( !classes )
-						return null;
-					classes.push( '!' + cls );
+				styleToAllowedContentRules: function (style) {
+					var classes = style.getClassesArray()
+					if (!classes) return null
+					classes.push('!' + cls)
 
-					return 'span(' + classes.join( ',' ) + ')';
+					return 'span(' + classes.join(',') + ')'
 				},
 				pathName: editor.lang.mathjax.pathName,
 
 				template: '<span class="' + cls + '" style="display:inline-block" data-cke-survive=1></span>',
 
 				parts: {
-					span: 'span'
+					span: 'span',
 				},
 
 				defaults: {
-					math: '\\(x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}\\)'
+					math: '\\(x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}\\)',
 				},
 
-				init: function() {
-					var iframe = this.parts.span.getChild( 0 );
+				init: function () {
+					var iframe = this.parts.span.getChild(0)
 
 					// Check if span contains iframe and create it otherwise.
-					if ( !iframe || iframe.type != CKEDITOR.NODE_ELEMENT || !iframe.is( 'iframe' ) ) {
-						iframe = new CKEDITOR.dom.element( 'iframe' );
-						iframe.setAttributes( {
+					if (!iframe || iframe.type != CKEDITOR.NODE_ELEMENT || !iframe.is('iframe')) {
+						iframe = new CKEDITOR.dom.element('iframe')
+						iframe.setAttributes({
 							style: 'border:0;width:0;height:0',
 							scrolling: 'no',
 							frameborder: 0,
 							allowTransparency: true,
-							src: CKEDITOR.plugins.mathjax.fixSrc
-						} );
-						this.parts.span.append( iframe );
+							src: CKEDITOR.plugins.mathjax.fixSrc,
+						})
+						this.parts.span.append(iframe)
 					}
 
 					// Wait for ready because on some browsers iFrame will not
 					// have document element until it is put into document.
 					// This is a problem when you crate widget using dialog.
-					this.once( 'ready', function() {
+					this.once('ready', function () {
 						// Src attribute must be recreated to fix custom domain error after undo
 						// (see iFrame.removeAttribute( 'src' ) in frameWrapper.load).
-						if ( CKEDITOR.env.ie )
-							iframe.setAttribute( 'src', CKEDITOR.plugins.mathjax.fixSrc );
+						if (CKEDITOR.env.ie) iframe.setAttribute('src', CKEDITOR.plugins.mathjax.fixSrc)
 
-						this.frameWrapper = new CKEDITOR.plugins.mathjax.frameWrapper( iframe, editor );
-						this.frameWrapper.setValue( this.data.math );
-					} );
+						this.frameWrapper = new CKEDITOR.plugins.mathjax.frameWrapper(iframe, editor)
+						this.frameWrapper.setValue(this.data.math)
+					})
 				},
 
-				data: function() {
-					if ( this.frameWrapper )
-						this.frameWrapper.setValue( this.data.math );
+				data: function () {
+					if (this.frameWrapper) this.frameWrapper.setValue(this.data.math)
 				},
 
-				upcast: function( el, data ) {
-					if ( !( el.name == 'span' && el.hasClass( cls ) ) )
-						return;
+				upcast: function (el, data) {
+					if (!(el.name == 'span' && el.hasClass(cls))) return
 
-					if ( el.children.length > 1 || el.children[ 0 ].type != CKEDITOR.NODE_TEXT )
-						return;
+					if (el.children.length > 1 || el.children[0].type != CKEDITOR.NODE_TEXT) return
 
-					data.math = CKEDITOR.tools.htmlDecode( el.children[ 0 ].value );
+					data.math = CKEDITOR.tools.htmlDecode(el.children[0].value)
 
 					// Add style display:inline-block to have proper height of widget wrapper and mask.
-					var attrs = el.attributes;
+					var attrs = el.attributes
 
-					if ( attrs.style )
-						attrs.style += ';display:inline-block';
-					else
-						attrs.style = 'display:inline-block';
+					if (attrs.style) attrs.style += ';display:inline-block'
+					else attrs.style = 'display:inline-block'
 
 					// Add attribute to prevent deleting empty span in data processing.
-					attrs[ 'data-cke-survive' ] = 1;
+					attrs['data-cke-survive'] = 1
 
-					el.children[ 0 ].remove();
+					el.children[0].remove()
 
-					return el;
+					return el
 				},
 
-				downcast: function( el ) {
-					el.children[ 0 ].replaceWith( new CKEDITOR.htmlParser.text( CKEDITOR.tools.htmlEncode( this.data.math ) ) );
+				downcast: function (el) {
+					el.children[0].replaceWith(new CKEDITOR.htmlParser.text(CKEDITOR.tools.htmlEncode(this.data.math)))
 
 					// Remove style display:inline-block.
-					var attrs = el.attributes;
-					attrs.style = attrs.style.replace( /display:\s?inline-block;?\s?/, '' );
-					if ( attrs.style === '' )
-						delete attrs.style;
+					var attrs = el.attributes
+					attrs.style = attrs.style.replace(/display:\s?inline-block;?\s?/, '')
+					if (attrs.style === '') delete attrs.style
 
-					return el;
-				}
-			} );
+					return el
+				},
+			})
 
 			// Add dialog.
-			CKEDITOR.dialog.add( 'mathjax', this.path + 'dialogs/mathjax.js' );
+			CKEDITOR.dialog.add('mathjax', this.path + 'dialogs/mathjax.js')
 
 			// Add MathJax script to page preview.
-			editor.on( 'contentPreview', function( evt ) {
+			editor.on('contentPreview', function (evt) {
 				evt.data.dataValue = evt.data.dataValue.replace(
 					/<\/head>/,
-					'<script src="' + CKEDITOR.getUrl( editor.config.mathJaxLib ) + '"><\/script><\/head>'
-				);
-			} );
+					'<script src="' + CKEDITOR.getUrl(editor.config.mathJaxLib) + '"></script></head>'
+				)
+			})
 
-			editor.on( 'paste', function( evt ) {
+			editor.on('paste', function (evt) {
 				// Firefox does remove iFrame elements from pasted content so this event do the same on other browsers.
 				// Also iFrame in paste content is reason of "Unspecified error" in IE9 (https://dev.ckeditor.com/ticket/10857).
-				var regex = new RegExp( '<span[^>]*?' + cls + '.*?<\/span>', 'ig' );
-				evt.data.dataValue = evt.data.dataValue.replace( regex, function( match ) {
-					return match.replace( /(<iframe.*?\/iframe>)/i, '' );
-				} );
-			} );
-		}
-	} );
+				var regex = new RegExp('<span[^>]*?' + cls + '.*?</span>', 'ig')
+				evt.data.dataValue = evt.data.dataValue.replace(regex, function (match) {
+					return match.replace(/(<iframe.*?\/iframe>)/i, '')
+				})
+			})
+		},
+	})
 
 	/**
 	 * @private
 	 * @singleton
 	 * @class CKEDITOR.plugins.mathjax
 	 */
-	CKEDITOR.plugins.mathjax = {};
+	CKEDITOR.plugins.mathjax = {}
 
 	/**
 	 * A variable to fix problems with `iframe`. This variable is global
@@ -167,16 +158,16 @@
 	 */
 	CKEDITOR.plugins.mathjax.fixSrc =
 		// In Firefox src must exist and be different than about:blank to emit load event.
-		CKEDITOR.env.gecko ? 'javascript:true' : // jshint ignore:line
-		// Support for custom document.domain in IE.
-		CKEDITOR.env.ie ? 'javascript:' + // jshint ignore:line
-						'void((function(){' + encodeURIComponent(
-							'document.open();' +
-							'(' + CKEDITOR.tools.fixDomain + ')();' +
-							'document.close();'
-						) + '})())' :
-		// In Chrome src must be undefined to emit load event.
-						'javascript:void(0)'; // jshint ignore:line
+		CKEDITOR.env.gecko
+			? 'javascript:true' // jshint ignore:line
+			: // Support for custom document.domain in IE.
+			CKEDITOR.env.ie
+				? 'javascript:' + // jshint ignore:line
+				'void((function(){' +
+				encodeURIComponent('document.open();' + '(' + CKEDITOR.tools.fixDomain + ')();' + 'document.close();') +
+				'})())'
+				: // In Chrome src must be undefined to emit load event.
+				'javascript:void(0)' // jshint ignore:line
 
 	/**
 	 * Loading indicator image generated by http://preloaders.net.
@@ -184,7 +175,7 @@
 	 * @private
 	 * @property {String} loadingIcon
 	 */
-	CKEDITOR.plugins.mathjax.loadingIcon = CKEDITOR.plugins.get( 'mathjax' ).path + 'images/loader.gif';
+	CKEDITOR.plugins.mathjax.loadingIcon = CKEDITOR.plugins.get('mathjax').path + 'images/loader.gif'
 
 	/**
 	 * Computes predefined styles and copies them to another element.
@@ -193,16 +184,15 @@
 	 * @param {CKEDITOR.dom.element} from Copy source.
 	 * @param {CKEDITOR.dom.element} to Copy target.
 	 */
-	CKEDITOR.plugins.mathjax.copyStyles = function( from, to ) {
-		var stylesToCopy = [ 'color', 'font-family', 'font-style', 'font-weight', 'font-variant', 'font-size' ];
+	CKEDITOR.plugins.mathjax.copyStyles = function (from, to) {
+		var stylesToCopy = ['color', 'font-family', 'font-style', 'font-weight', 'font-variant', 'font-size']
 
-		for ( var i = 0; i < stylesToCopy.length; i++ ) {
-			var key = stylesToCopy[ i ],
-				val = from.getComputedStyle( key );
-			if ( val )
-				to.setStyle( key, val );
+		for (var i = 0; i < stylesToCopy.length; i++) {
+			var key = stylesToCopy[i],
+				val = from.getComputedStyle(key)
+			if (val) to.setStyle(key, val)
 		}
-	};
+	}
 
 	/**
 	 * Trims MathJax value from '\(1+1=2\)' to '1+1=2'.
@@ -211,12 +201,12 @@
 	 * @param {String} value String to trim.
 	 * @returns {String} Trimed string.
 	 */
-	CKEDITOR.plugins.mathjax.trim = function( value ) {
-		var begin = value.indexOf( '\\(' ) + 2,
-			end = value.lastIndexOf( '\\)' );
+	CKEDITOR.plugins.mathjax.trim = function (value) {
+		var begin = value.indexOf('\\(') + 2,
+			end = value.lastIndexOf('\\)')
 
-		return value.substring( begin, end );
-	};
+		return value.substring(begin, end)
+	}
 
 	/**
 	 * FrameWrapper is responsible for communication between the MathJax library
@@ -231,156 +221,183 @@
 	 * @param {CKEDITOR.dom.element} iFrame The `iframe` element to be wrapped.
 	 * @param {CKEDITOR.editor} editor The editor instance.
 	 */
-	if ( !( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) ) {
-		CKEDITOR.plugins.mathjax.frameWrapper = function( iFrame, editor ) {
-
-			var buffer, preview, value, newValue,
+	if (!(CKEDITOR.env.ie && CKEDITOR.env.version === 8)) {
+		CKEDITOR.plugins.mathjax.frameWrapper = function (iFrame, editor) {
+			var buffer,
+				preview,
+				value,
+				newValue,
 				doc = iFrame.getFrameDocument(),
-
 				// Is MathJax loaded and ready to work.
 				isInit = false,
-
 				// Is MathJax parsing Tex.
 				isRunning = false,
-
 				// Function called when MathJax is loaded.
-				loadedHandler = CKEDITOR.tools.addFunction( function() {
-					preview = doc.getById( 'preview' );
-					buffer = doc.getById( 'buffer' );
-					isInit = true;
+				loadedHandler = CKEDITOR.tools.addFunction(function () {
+					preview = doc.getById('preview')
+					buffer = doc.getById('buffer')
+					isInit = true
 
-					if ( newValue )
-						update();
+					if (newValue) update()
 
 					// Private! For test usage only.
-					CKEDITOR.fire( 'mathJaxLoaded', iFrame );
-				} ),
-
+					CKEDITOR.fire('mathJaxLoaded', iFrame)
+				}),
 				// Function called when MathJax finish his job.
-				updateDoneHandler = CKEDITOR.tools.addFunction( function() {
-					CKEDITOR.plugins.mathjax.copyStyles( iFrame, preview );
+				updateDoneHandler = CKEDITOR.tools.addFunction(function () {
+					CKEDITOR.plugins.mathjax.copyStyles(iFrame, preview)
 
-					preview.setHtml( buffer.getHtml() );
+					preview.setHtml(buffer.getHtml())
 
-					editor.fire( 'lockSnapshot' );
+					editor.fire('lockSnapshot')
 
-					iFrame.setStyles( {
+					iFrame.setStyles({
 						height: 0,
-						width: 0
-					} );
+						width: 0,
+					})
 
 					// Set iFrame dimensions.
-					var height = Math.max( doc.$.body.offsetHeight, doc.$.documentElement.offsetHeight ),
-						width = Math.max( preview.$.offsetWidth, doc.$.body.scrollWidth );
+					var height = Math.max(doc.$.body.offsetHeight, doc.$.documentElement.offsetHeight),
+						width = Math.max(preview.$.offsetWidth, doc.$.body.scrollWidth)
 
-					iFrame.setStyles( {
+					iFrame.setStyles({
 						height: height + 'px',
-						width: width + 'px'
-					} );
+						width: width + 'px',
+					})
 
-					editor.fire( 'unlockSnapshot' );
+					editor.fire('unlockSnapshot')
 
 					// Private! For test usage only.
-					CKEDITOR.fire( 'mathJaxUpdateDone', iFrame );
+					CKEDITOR.fire('mathJaxUpdateDone', iFrame)
 
 					// If value changed in the meantime update it again.
-					if ( value != newValue )
-						update();
-					else
-						isRunning = false;
-				} );
+					if (value != newValue) update()
+					else isRunning = false
+				})
+			// Function called to run MathJax on update and star
 
-			iFrame.on( 'load', load );
+			iFrame.on('load', load)
 
-			load();
+			load()
 
 			function load() {
-				doc = iFrame.getFrameDocument();
+				doc = iFrame.getFrameDocument()
 
-				if ( doc.getById( 'preview' ) )
-					return;
+				if (doc.getById('preview')) return
 
 				// Because of IE9 bug in a src attribute can not be javascript
 				// when you undo (https://dev.ckeditor.com/ticket/10930). If you have iFrame with javascript in src
 				// and call insertBefore on such element then IE9 will see crash.
-				if ( CKEDITOR.env.ie )
-					iFrame.removeAttribute( 'src' );
+				if (CKEDITOR.env.ie) iFrame.removeAttribute('src')
 
-				doc.write( '<!DOCTYPE html>' +
-							'<html>' +
-							'<head>' +
-								'<meta charset="utf-8">' +
-								'<script type="text/x-mathjax-config">' +
+				var script = editor.config.mathJaxVer === 'v3' ? v3Script() : v2Script()
+				doc.write(
+					`<!doctype html>
+                          <html lang="${editor.lang}">
+                          <head>
+                            <meta charset="utf-8">
+                            <script>
+                            function getCKE() {if ( typeof window.parent.CKEDITOR == 'object' ) {return window.parent.CKEDITOR;} else {return window.parent.parent.CKEDITOR;}}
+                            ${
+						editor.config.mathJaxVer === 'v3'
+							? `
+                                    var MathJax = {
+                                options: {
+                                    enableMenu: false,
+                                    ignoreHtmlClass: 'tex2jax_ignore',
+                                    processHtmlClass: 'tex2jax_process'
+                                },
+                                startup: {
+                                    pageReady: function () {
+                                        MathJax.startup.promise.then(function () {
+                                            getCKE().tools.callFunction(${loadedHandler});
+                                        },
+                                        function (err) {
+                                            console.log('Typeset failed: ' + err.message)
+                                        }
+                                      )
+                                    }
+                                }
+                              };
+                              function update() {
+                              MathJax.startup.promise.then(function () {
+                                var buffer = this.buffer;
+                                if (!Array.isArray(buffer)) buffer = [buffer];
+                                MathJax.typesetPromise(buffer).then(
+                                    function () {
+                                        getCKE().tools.callFunction(${updateDoneHandler});
+                                    },
+                                    function (err) {
+                                        console.log('Typeset failed: ' + err.message)
+                                        console.log(this.buffer)
+                                        console.log(typeof this.buffer)
+                                    }
+                                );
+                              },
+                              function (err) {
+                                  console.log('Typeset failed: ' + err.message);
+                              }
+                              );
+                              }
+                            `
+							: `
+                            MathJax.Hub.Config( {
+                                showMathMenu: false,
+                                messageStyle: "none"
+                            }
+                            );
+                            function update() {
+                                MathJax.Hub.Queue([ 'Typeset', MathJax.Hub, this.buffer ],
+                                function() {
+                                    getCKE().tools.callFunction(${updateDoneHandler});
+                                }
+                                );
+                            }
 
-									// MathJax configuration, disable messages.
-									'MathJax.Hub.Config( {' +
-										'showMathMenu: false,' +
-										'messageStyle: "none"' +
-									'} );' +
-
-									// Get main CKEDITOR form parent.
-									'function getCKE() {' +
-										'if ( typeof window.parent.CKEDITOR == \'object\' ) {' +
-											'return window.parent.CKEDITOR;' +
-										'} else {' +
-											'return window.parent.parent.CKEDITOR;' +
-										'}' +
-									'}' +
-
-									// Run MathJax.Hub with its actual parser and call callback function after that.
-									// Because MathJax.Hub is asynchronous create MathJax.Hub.Queue to wait with callback.
-									'function update() {' +
-										'MathJax.Hub.Queue(' +
-											'[ \'Typeset\', MathJax.Hub, this.buffer ],' +
-											'function() {' +
-												'getCKE().tools.callFunction( ' + updateDoneHandler + ' );' +
-											'}' +
-										');' +
-									'}' +
-
-									// Run MathJax for the first time, when the script is loaded.
-									// Callback function will be called then it's done.
-									'MathJax.Hub.Queue( function() {' +
-										'getCKE().tools.callFunction(' + loadedHandler + ');' +
-									'} );' +
-								'</script>' +
-
-								// Load MathJax lib.
-								'<script src="' + ( editor.config.mathJaxLib ) + '"></script>' +
-							'</head>' +
-							'<body style="padding:0;margin:0;background:transparent;overflow:hidden">' +
-								'<span id="preview"></span>' +
-
-								// Render everything here and after that copy it to the preview.
-								'<span id="buffer" style="display:none"></span>' +
-							'</body>' +
-							'</html>' );
+                            MathJax.Hub.Queue( function() {
+                                    getCKE().tools.callFunction(${loadedHandler});
+                            });
+                            `
+					}
+                            </script>
+                            <script type="text/javascript" id="MathJax-script" async src="${
+						editor.config.mathJaxLib
+					}"></script>
+                          </head>
+                          <body style="padding:0;margin:0;background:transparent;overflow:hidden">
+                            <span id="preview"></span>
+                            <span id="buffer" style="display:none"></span>
+                          </body>
+                      </html>`
+				)
 			}
 
 			// Run MathJax parsing Tex.
 			function update() {
-				isRunning = true;
+				isRunning = true
 
-				value = newValue;
+				value = newValue
 
-				editor.fire( 'lockSnapshot' );
+				editor.fire('lockSnapshot')
 
-				buffer.setHtml( value );
+				buffer.setHtml(value)
 
 				// Set loading indicator.
-				preview.setHtml( '<img src=' + CKEDITOR.plugins.mathjax.loadingIcon + ' alt=' + editor.lang.mathjax.loading + '>' );
+				preview.setHtml(
+					'<img src=' + CKEDITOR.plugins.mathjax.loadingIcon + ' alt=' + editor.lang.mathjax.loading + '>'
+				)
 
-				iFrame.setStyles( {
+				iFrame.setStyles({
 					height: '16px',
 					width: '16px',
 					display: 'inline',
-					'vertical-align': 'middle'
-				} );
+					'vertical-align': 'middle',
+				})
 
-				editor.fire( 'unlockSnapshot' );
+				editor.fire('unlockSnapshot')
 
 				// Run MathJax.
-				doc.getWindow().$.update( value );
+				doc.getWindow().$.update(value)
 			}
 
 			return {
@@ -392,52 +409,55 @@
 				 *
 				 * @param {String} value TeX string.
 				 */
-				setValue: function( value ) {
-					newValue = CKEDITOR.tools.htmlEncode( value );
+				setValue: function (value) {
+					newValue = CKEDITOR.tools.htmlEncode(value)
 
-					if ( isInit && !isRunning )
-						update();
-				}
-			};
-		};
+					if (isInit && !isRunning) update()
+				},
+			}
+		}
 	} else {
 		// In IE8 MathJax does not work stable so instead of using standard
 		// frame wrapper it is replaced by placeholder to show pure TeX in iframe.
-		CKEDITOR.plugins.mathjax.frameWrapper = function( iFrame, editor ) {
-			iFrame.getFrameDocument().write( '<!DOCTYPE html>' +
-				'<html>' +
-				'<head>' +
+		CKEDITOR.plugins.mathjax.frameWrapper = function (iFrame, editor) {
+			iFrame
+				.getFrameDocument()
+				.write(
+					'<!DOCTYPE html>' +
+					'<html>' +
+					'<head>' +
 					'<meta charset="utf-8">' +
-				'</head>' +
-				'<body style="padding:0;margin:0;background:transparent;overflow:hidden">' +
+					'</head>' +
+					'<body style="padding:0;margin:0;background:transparent;overflow:hidden">' +
 					'<span style="white-space:nowrap;" id="tex"></span>' +
-				'</body>' +
-				'</html>' );
+					'</body>' +
+					'</html>'
+				)
 
 			return {
-				setValue: function( value ) {
+				setValue: function (value) {
 					var doc = iFrame.getFrameDocument(),
-						tex = doc.getById( 'tex' );
+						tex = doc.getById('tex')
 
-					tex.setHtml( CKEDITOR.plugins.mathjax.trim( CKEDITOR.tools.htmlEncode( value ) ) );
+					tex.setHtml(CKEDITOR.plugins.mathjax.trim(CKEDITOR.tools.htmlEncode(value)))
 
-					CKEDITOR.plugins.mathjax.copyStyles( iFrame, tex );
+					CKEDITOR.plugins.mathjax.copyStyles(iFrame, tex)
 
-					editor.fire( 'lockSnapshot' );
+					editor.fire('lockSnapshot')
 
-					iFrame.setStyles( {
-						width: Math.min( 250, tex.$.offsetWidth ) + 'px',
+					iFrame.setStyles({
+						width: Math.min(250, tex.$.offsetWidth) + 'px',
 						height: doc.$.body.offsetHeight + 'px',
 						display: 'inline',
-						'vertical-align': 'middle'
-					} );
+						'vertical-align': 'middle',
+					})
 
-					editor.fire( 'unlockSnapshot' );
-				}
-			};
-		};
+					editor.fire('unlockSnapshot')
+				},
+			}
+		}
 	}
-} )();
+})()
 
 /**
  * Sets the path to the MathJax library. It can be both a local resource and a location different than the default CDN.
@@ -456,6 +476,20 @@
  * @cfg {String} mathJaxLib
  * @member CKEDITOR.config
  */
+
+/**
+ * Sets the major version of MathJax you want CKEditor to leverage. This can be set to 'v3' for the latest MathJax@3.
+ * Otherwise, this will default to v2. This version must match the value specified in CKEDITOR.config.mathjaxLib
+ *
+ *
+ *		config.mathJaxVer = 'v3';
+ *
+ *
+ * @since 4.20.0
+ * @cfg {String} matJaxVer
+ * @member CKEDITOR.config
+ */
+
 
 /**
  * Sets the default class for `span` elements that will be

--- a/plugins/mathjax/plugin.js
+++ b/plugins/mathjax/plugin.js
@@ -289,8 +289,7 @@
 				// when you undo (https://dev.ckeditor.com/ticket/10930). If you have iFrame with javascript in src
 				// and call insertBefore on such element then IE9 will see crash.
 				if (CKEDITOR.env.ie) iFrame.removeAttribute('src')
-
-				var script = editor.config.mathJaxVer === 'v3' ? v3Script() : v2Script()
+				
 				doc.write(
 					`<!doctype html>
                           <html lang="${editor.lang}">

--- a/tests/plugins/mathjax/manual/mathjax3.html
+++ b/tests/plugins/mathjax/manual/mathjax3.html
@@ -1,0 +1,21 @@
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+	<h1>Apollo 11</h1>
+
+		<div style="background:red;color:blue">
+			<p><strong>Apollo 11</strong>&nbsp;was the&nbsp;spaceflight&nbsp;that landed the first humans, Americans <a href="http://en.wikipedia.org/wiki/Neil_Armstrong">Neil Armstrong</a>&nbsp;and&nbsp;<a href="http://en.wikipedia.org/wiki/Buzz_Aldrin">Buzz Aldrin</a> <span class="math-tex">\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\)</span>. Armstrong became the first to step onto the lunar surface 6 hours later. Armstrong spent about two and a half hours outside the spacecraft, Aldrin slightly less; and together they collected 47.5 pounds (21.5&nbsp;kg) of lunar material for return to Earth. A third member of the mission,&nbsp;Michael Collins, piloted the&nbsp;command spacecraft&nbsp;alone in lunar orbit until Armstrong and Aldrin returned to it for the trip back to Earth.</p>
+		</div>
+
+		<p>Foo foo <span class="math-tex">\(J_\alpha(x) = \sum\limits_{m=0}^\infty \frac{(-1)^m}{m! \, \Gamma(m + \alpha + 1)}{\left({\frac{x}{2}}\right)}^{2 m + \alpha}\)</span> bar bar.</p>
+
+		<p>Launched by a&nbsp;Saturn V&nbsp;rocket from&nbsp;Kennedy Space Center&nbsp;in&nbsp;Merritt Island, Florida&nbsp;on July 16, Apollo 11 was the fifth manned mission of <a href="http://en.wikipedia.org/wiki/NASA">NASA</a>&#39;s&nbsp;Apollo program. The Apollo&nbsp;spacecraft&nbsp;had three parts: aCommand Module&nbsp;with a cabin for the three astronauts which was the only part which landed back on Earth; a&nbsp;Service Module&nbsp;which supported the Command Module with propulsion, electrical power, oxygen and water; and a&nbsp;Lunar Module&nbsp;for landing on the Moon. After being sent to the Moon by the Saturn V&#39;s upper stage, the astronauts separated the spacecraft from it and travelled for three days until they entered into lunar orbit. Armstrong and Aldrin then moved into the Lunar Module and landed in the&nbsp;Sea of Tranquility. They stayed a total of about 21 and a half hours on the lunar surface. After lifting off in the upper part of the Lunar Module and rejoining Collins in the Command Module, they returned to Earth and landed in the&nbsp;Pacific Ocean&nbsp;.</p>
+
+</textarea>
+
+<script>
+	// Ignore on mobiles due to hovering.
+
+	CKEDITOR.replace( 'editor1', {
+		mathJaxVer: 'v3',
+		mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js'
+	} );
+</script>

--- a/tests/plugins/mathjax/manual/mathjax3.md
+++ b/tests/plugins/mathjax/manual/mathjax3.md
@@ -1,6 +1,6 @@
 @bender-tags: 1441, feature, 4.21.1, mathjax
 @bender-ui: collapsed
-@bender-ckeditor-plugins: widget, dialog, mathjax
+@bender-ckeditor-plugins: mathjax, wysiwygarea
 
 Open Editor
 

--- a/tests/plugins/mathjax/manual/mathjax3.md
+++ b/tests/plugins/mathjax/manual/mathjax3.md
@@ -1,0 +1,13 @@
+@bender-tags: 1441, feature, 4.21.1, mathjax
+@bender-ui: collapsed
+@bender-ckeditor-plugins: widget, dialog, mathjax
+
+Open Editor
+
+## Expected
+
+Mathjax Widget replaces the mjx equation with the widget that works properly
+
+## Unexpected
+
+Mathjax Widget does not work or replace the equation

--- a/tests/plugins/mathjax/mathjax.js
+++ b/tests/plugins/mathjax/mathjax.js
@@ -7,6 +7,7 @@
 	CKEDITOR.disableAutoInline = true;
 
 	var mathJaxLib = bender.config.mathJaxLibPath;
+	var mathJaxLibV3 = bender.config.mathJaxLibPathV3;
 
 	if ( !mathJaxLib ) {
 		throw new Error( 'bender.config.mathJaxLibPath should be defined with the path to MathJax lib (MathJax.js?config=TeX-AMS_HTML).' );
@@ -49,8 +50,28 @@
 
 			wait();
 		},
+		'async:init:v3': function() {
+			bender.tools.ignoreUnsupportedEnvironment( 'mathjax' );
 
-		'async:init': function() {
+			var tc = this;
+
+			editor = new CKEDITOR.replace( 'editor_mathjax', {
+				mathJaxLib: mathJaxLibV3,
+				extraAllowedContent: 'p{font-size}',
+				extraPlugins: 'font',
+				on: {
+					instanceReady: function() {
+						editor.setData( '<p>A<span class="math-tex">\\(1 + 1 = 2\\)</span>B</p>' );
+					}
+				}
+			} );
+
+			CKEDITOR.once( 'mathJaxUpdateDone', function() {
+				// Deffer executing test callback since calling it synchronously fails in Chrome (starting from 85 version) (#4232).
+				setTimeout( tc.callback, 0 );
+			} );
+		},
+		'async:init:v2': function() {
 			bender.tools.ignoreUnsupportedEnvironment( 'mathjax' );
 
 			var tc = this;

--- a/tests/plugins/mathjax/mathjax.js
+++ b/tests/plugins/mathjax/mathjax.js
@@ -57,6 +57,7 @@
 
 			editor = new CKEDITOR.replace( 'editor_mathjax', {
 				mathJaxLib: mathJaxLibV3,
+				mathJaxVer: 'v3',
 				extraAllowedContent: 'p{font-size}',
 				extraPlugins: 'font',
 				on: {


### PR DESCRIPTION
## What is the purpose of this pull request?

Allow users to select Mathjax v3 as the version for the math

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ X] Unit tests
- [X ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ X] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#3411](https://github.com/ckeditor/ckeditor4/issues/3411): A config option was added for the mathjax plugin to allow the user to select and use MathJax v3. The necessary code was added to the widget to enable use of v3.
```

## What changes did you make?

-Added code to the widget that will execute correctly using V3, added config option to specify

## Which issues does your PR resolve?

Closes #3411.
