### PR TITLE
Fix incorrect selection handling in the Rich Combos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Features:
 
 * [#5316](https://github.com/ckeditor/ckeditor4/issues/5316): Add vertical margins support for list elements in the [Paste from Word](https://ckeditor.com/cke4/addon/pastefromword) plugin.
 * [#5410](https://github.com/ckeditor/ckeditor4/issues/5410): Added the ability to indicate the language of styles in the [Styles Combo](https://ckeditor.com/cke4/addon/stylescombo) plugin via the [`config.styleSet`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-stylesSet) configuration option.
+* [#5437](https://github.com/ckeditor/ckeditor4/issues/5437): Fixed: Incorrect indication of selected items in comboboxes. The selected item was unmarked upon each opening of the combobox.
 
 Other Changes:
 

--- a/plugins/listblock/plugin.js
+++ b/plugins/listblock/plugin.js
@@ -186,14 +186,6 @@ CKEDITOR.plugins.add( 'listblock', {
 					this.onMark && this.onMark( item );
 				},
 
-				markFirstDisplayed: function() {
-					var context = this;
-					this._.markFirstDisplayed( function() {
-						if ( !context.multiSelect )
-							context.unmarkAll();
-					} );
-				},
-
 				unmark: function( value ) {
 					var doc = this.element.getDocument(),
 						itemId = this._.items[ value ],

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -75,6 +75,28 @@
 			} );
 		},
 
+		// (#5437)
+		'test list block correctly marks selected element upon reopening': function() {
+			var bot = this.editorBot;
+
+			bot.combo( 'Styles', function( combo ) {
+				var block = combo._.panel.getBlock( combo.id ).element,
+					selectedItem = block.findOne( 'a[title="Big"]' );
+
+				selectedItem.$.click();
+				combo._.panel.hide();
+
+				bot.combo( 'Styles', function( combo ) {
+					combo._.panel.hide();
+
+					assert.areEqual( 'true', selectedItem.getAttribute( 'aria-selected' ),
+						'The aria-selected attribute of the selected item has the correct value' );
+					assert.isTrue( selectedItem.getParent().hasClass( 'cke_selected' ),
+						'The selected item has appropriate class applied' );
+				} );
+			} );
+		},
+
 		// Expects both object to have following structure:
 		// { value: 'foo', html: 'bar', title: 'baz' }
 		//

--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor */
-/* bender-ckeditor-plugins: toolbar, stylescombo */
+/* bender-ckeditor-plugins: toolbar, stylescombo, font */
 
 ( function() {
 	'use strict';
@@ -79,14 +79,14 @@
 		'test list block correctly marks selected element upon reopening': function() {
 			var bot = this.editorBot;
 
-			bot.combo( 'Styles', function( combo ) {
+			bot.combo( 'Font', function( combo ) {
 				var block = combo._.panel.getBlock( combo.id ).element,
-					selectedItem = block.findOne( 'a[title="Big"]' );
+					selectedItem = block.findOne( 'a[title="Comic Sans MS"]' );
 
 				selectedItem.$.click();
 				combo._.panel.hide();
 
-				bot.combo( 'Styles', function( combo ) {
+				bot.combo( 'Font', function( combo ) {
 					combo._.panel.hide();
 
 					assert.areEqual( 'true', selectedItem.getAttribute( 'aria-selected' ),

--- a/tests/plugins/listblock/manual/ariaselected.html
+++ b/tests/plugins/listblock/manual/ariaselected.html
@@ -1,0 +1,7 @@
+<div id="editor">
+	<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Distinctio at velit nesciunt!</p>
+</div>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/listblock/manual/ariaselected.html
+++ b/tests/plugins/listblock/manual/ariaselected.html
@@ -3,5 +3,7 @@
 </div>
 
 <script>
-	CKEDITOR.replace( 'editor' );
+	CKEDITOR.replace( 'editor', {
+		toolbar: [ [ 'Font' ] ]
+	} );
 </script>

--- a/tests/plugins/listblock/manual/ariaselected.md
+++ b/tests/plugins/listblock/manual/ariaselected.md
@@ -1,0 +1,17 @@
+@bender-tags: 5437, bug, 4.21.1
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo
+
+1. Select some text in the editor.
+1. Open styles combo.
+1. Select the "Big" style.
+1. Reopen the styles combo.
+
+	**Expected** The "Big" style is selected.
+
+	**Unexpected** The first item in the combo is selected.
+1. Press the <kbd>Down Arrow</kbd>.
+
+	**Expected** Focus moved to the next element but "Big" is still marked as selected (gray background).
+
+	**Unexpected** "Big" is no longer marked.

--- a/tests/plugins/listblock/manual/ariaselected.md
+++ b/tests/plugins/listblock/manual/ariaselected.md
@@ -1,17 +1,17 @@
 @bender-tags: 5437, bug, 4.21.1
 @bender-ui: collapsed
-@bender-ckeditor-plugins: wysiwygarea, toolbar, stylescombo
+@bender-ckeditor-plugins: wysiwygarea, toolbar, font
 
 1. Select some text in the editor.
-1. Open styles combo.
-1. Select the "Big" style.
-1. Reopen the styles combo.
+1. Open "Font" combo.
+1. Select the "Comic Sans MS" font.
+1. Reopen the "Font" combo.
 
-	**Expected** The "Big" style is selected.
+	**Expected** The "Comic Sans MS" font is selected.
 
 	**Unexpected** The first item in the combo is selected.
 1. Press the <kbd>Down Arrow</kbd>.
 
-	**Expected** Focus moved to the next element but "Big" is still marked as selected (gray background).
+	**Expected** Focus moved to the next element but "Comic Sans MS" is still marked as selected (gray background).
 
-	**Unexpected** "Big" is no longer marked.
+	**Unexpected** "Comic Sans MS" is no longer marked.

--- a/tests/plugins/listblock/manual/ariaselected.md
+++ b/tests/plugins/listblock/manual/ariaselected.md
@@ -3,15 +3,16 @@
 @bender-ckeditor-plugins: wysiwygarea, toolbar, font
 
 1. Select some text in the editor.
-1. Open "Font" combo.
-1. Select the "Comic Sans MS" font.
-1. Reopen the "Font" combo.
+2. Open "Font" combo.
+3. Select the "Comic Sans MS" font.
+4. Reopen the "Font" combo.
 
-	**Expected** The "Comic Sans MS" font is selected.
+**Expected** The "Comic Sans MS" font is selected.
 
-	**Unexpected** The first item in the combo is selected.
-1. Press the <kbd>Down Arrow</kbd>.
+**Unexpected** The first item in the combo is selected.
 
-	**Expected** Focus moved to the next element but "Comic Sans MS" is still marked as selected (gray background).
+5. Press the <kbd>Down Arrow</kbd>.
 
-	**Unexpected** "Comic Sans MS" is no longer marked.
+**Expected** Focus moved to the next element but "Comic Sans MS" is still marked as selected (gray background).
+
+**Unexpected** "Comic Sans MS" is no longer marked.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [x] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5437](https://github.com/ckeditor/ckeditor4/issues/5437): Fix: incorrect indication of selected items in comboboxes.
```

## What changes did you make?

I've discovered that we have a whole logic to apply the `[aria-selected]` attribute in place. However, the selected item was unmarked upon each opening of the combobox due to an [incorrectly applied fix](https://github.com/ckeditor/ckeditor4/commit/61a6108#diff-f135dd6497a04478a9efbb561d78b60189163d378f53188ae4c3ba0884e6f671R183-R189) to an [old accessibility issue](https://dev.ckeditor.com/ticket/16804). It was supposed to ensure that after opening the context menu, the first item will be focused. However, as comboboxes are not context menus and their [keyboard interaction pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/#keyboardinteraction) is quite different, I simply removed the old fix.

As a bonus, we now have also correct styling of the selected items in comboboxes 🎉 

## Which issues does your PR resolve?

Closes #5437.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
