### PR TITLE
Fix insufficient contrast ratio for links in notifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ New Features:
 * [#5410](https://github.com/ckeditor/ckeditor4/issues/5410): Added the ability to indicate the language of styles in the [Styles Combo](https://ckeditor.com/cke4/addon/stylescombo) plugin via the [`config.styleSet`](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-stylesSet) configuration option.
 * [#5437](https://github.com/ckeditor/ckeditor4/issues/5437): Fixed: Incorrect indication of selected items in comboboxes. The selected item was unmarked upon each opening of the combobox.
 
+Fixed Issues:
+
+* [#5495](https://github.com/ckeditor/ckeditor4/issues/5495): Fixed: Insufficient color ratio for links inside [Notifications](https://ckeditor.com/cke4/addon/notification).
+
 Other Changes:
 
 * [#5412](https://github.com/ckeditor/ckeditor4/issues/5412): Prevent using `document.domain` in Firefox in the [Preview](https://ckeditor.com/cke4/addon/preview) plugin.

--- a/skins/kama/notification.css
+++ b/skins/kama/notification.css
@@ -66,7 +66,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 .cke_notification_message a
 {
-	color: #12306F;
+	color: inherit;
 }
 
 @-webkit-keyframes fadeIn

--- a/skins/moono-lisa/notification.css
+++ b/skins/moono-lisa/notification.css
@@ -66,7 +66,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 .cke_notification_message a
 {
-	color: #12306F;
+	color: inherit;
 }
 
 @-webkit-keyframes fadeIn

--- a/skins/moono/notification.css
+++ b/skins/moono/notification.css
@@ -68,7 +68,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 .cke_notification_message a
 {
-	color: #12306F;
+	color: inherit;
 }
 
 @-webkit-keyframes fadeIn

--- a/tests/plugins/notification/manual/linkcontrastkama.html
+++ b/tests/plugins/notification/manual/linkcontrastkama.html
@@ -1,0 +1,33 @@
+<div id="editor">
+	<p>Hi!</p>
+</div>
+
+<p>
+	<button id="info">Show info</button>
+	<button id="success">Show success</button>
+	<button id="warning">Show warning</button>
+</p>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		skin: 'kama',
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor,
+					message = '<a href="https://ckeditor.com">link</a> text';
+
+				CKEDITOR.document.getById( 'info' ).on( 'click', function() {
+					editor.showNotification( message, 'info', 0 );
+				} );
+
+				CKEDITOR.document.getById( 'success' ).on( 'click', function() {
+					editor.showNotification( message, 'success', 0 );
+				} );
+
+				CKEDITOR.document.getById( 'warning' ).on( 'click', function() {
+					editor.showNotification( message, 'warning', 0 );
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/notification/manual/linkcontrastkama.md
+++ b/tests/plugins/notification/manual/linkcontrastkama.md
@@ -1,0 +1,8 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.21.1, 5495
+@bender-ckeditor-plugins: wysiwygarea, toolbar, notification
+
+1. Open notifications using the buttons under the editor.
+1. Verify if links inside them have the same color as the rest of the text.
+
+**Expected** Links have the same color as the rest of the text.

--- a/tests/plugins/notification/manual/linkcontrastmoono.html
+++ b/tests/plugins/notification/manual/linkcontrastmoono.html
@@ -1,0 +1,33 @@
+<div id="editor">
+	<p>Hi!</p>
+</div>
+
+<p>
+	<button id="info">Show info</button>
+	<button id="success">Show success</button>
+	<button id="warning">Show warning</button>
+</p>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		skin: 'moono',
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor,
+					message = '<a href="https://ckeditor.com">link</a> text';
+
+				CKEDITOR.document.getById( 'info' ).on( 'click', function() {
+					editor.showNotification( message, 'info', 0 );
+				} );
+
+				CKEDITOR.document.getById( 'success' ).on( 'click', function() {
+					editor.showNotification( message, 'success', 0 );
+				} );
+
+				CKEDITOR.document.getById( 'warning' ).on( 'click', function() {
+					editor.showNotification( message, 'warning', 0 );
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/notification/manual/linkcontrastmoono.md
+++ b/tests/plugins/notification/manual/linkcontrastmoono.md
@@ -1,0 +1,8 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.21.1, 5495
+@bender-ckeditor-plugins: wysiwygarea, toolbar, notification
+
+1. Open notifications using the buttons under the editor.
+1. Verify if links inside them have the same color as the rest of the text.
+
+**Expected** Links have the same color as the rest of the text.

--- a/tests/plugins/notification/manual/linkcontrastmoonolisa.html
+++ b/tests/plugins/notification/manual/linkcontrastmoonolisa.html
@@ -1,0 +1,33 @@
+<div id="editor">
+	<p>Hi!</p>
+</div>
+
+<p>
+	<button id="info">Show info</button>
+	<button id="success">Show success</button>
+	<button id="warning">Show warning</button>
+</p>
+
+<script>
+	CKEDITOR.replace( 'editor', {
+		skin: 'moono-lisa',
+		on: {
+			instanceReady: function( evt ) {
+				var editor = evt.editor,
+					message = '<a href="https://ckeditor.com">link</a> text';
+
+				CKEDITOR.document.getById( 'info' ).on( 'click', function() {
+					editor.showNotification( message, 'info', 0 );
+				} );
+
+				CKEDITOR.document.getById( 'success' ).on( 'click', function() {
+					editor.showNotification( message, 'success', 0 );
+				} );
+
+				CKEDITOR.document.getById( 'warning' ).on( 'click', function() {
+					editor.showNotification( message, 'warning', 0 );
+				} );
+			}
+		}
+	} );
+</script>

--- a/tests/plugins/notification/manual/linkcontrastmoonolisa.md
+++ b/tests/plugins/notification/manual/linkcontrastmoonolisa.md
@@ -1,0 +1,8 @@
+@bender-ui: collapsed
+@bender-tags: bug, 4.21.1, 5495
+@bender-ckeditor-plugins: wysiwygarea, toolbar, notification
+
+1. Open notifications using the buttons under the editor.
+1. Verify if links inside them have the same color as the rest of the text.
+
+**Expected** Links have the same color as the rest of the text.


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Bug fix

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [x] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#5495](https://github.com/ckeditor/ckeditor4/issues/5495): Fixed: insufficient color ratio for links inside [notifications](https://ckeditor.com/cke4/addon/notification).
```

## What changes did you make?

I've forced inherited font color for links inside notifications. It seems that the current link color was inherited (pun not intended) from the `kama` skin.

Additionally, commit 5a4f216eee27653a277b1d97837cad3fd0197b35 contains further (more aggressive) contrast enhancements, involving changing backgrounds of the notifications in the `moono` and `moono-lisa` skins (`kama` has already good contrast ratio).

## Which issues does your PR resolve?

Closes #5495.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
