### PR TITLE
Fix for failing `listblock` test in IE 11

### DIFF
--- a/tests/plugins/listblock/listblock.js
+++ b/tests/plugins/listblock/listblock.js
@@ -83,7 +83,7 @@
 				var block = combo._.panel.getBlock( combo.id ).element,
 					selectedItem = block.findOne( 'a[title="Comic Sans MS"]' );
 
-				selectedItem.$.click();
+				combo.onClick( 'Comic Sans MS' );
 				combo._.panel.hide();
 
 				bot.combo( 'Font', function( combo ) {


### PR DESCRIPTION
<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

Fix for failing test

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [x] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

N/A

## What changes did you make?

I've replaced a click event for the item in the combo with a direct call to `combo.onClick()`.

## Which issues does your PR resolve?

Closes #5498.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
