### PR TITLE
[Trusted Types] Adding tooling for Trusted Types compatibility

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -123,6 +123,43 @@
 	 * @singleton
 	 */
 	CKEDITOR.tools = {
+
+		/**
+		 * Claims safety of an html string and returns trusted version.
+		 *
+		 * @param {string} html The safe html string.
+		 * @param {string} justification A short justification for why this
+		 * html string can be verified as safe.
+		 * @returns {TrustedHTML | string} the same html string but as a
+		 * TrustedHTML or a string if TT is not supported.
+		 */
+		htmlSafeByReview: function (html, justification) {
+
+			// If the justification is empty an error is raised. Any input marked as safe must be accompanied by a justification.
+			if (typeof justification !== 'string' || justification.trim() === '') {
+				let errMsg =
+					'Calls to uncheckedconversion functions must go through security review.';
+				errMsg += ' A justification must be provided to capture what security' +
+					' assumptions are being made.';
+				throw new Error(errMsg);
+			}
+
+			if (self.trustedTypes && self.trustedTypes.createPolicy) {
+				const policy = self.trustedTypes.createPolicy(
+					'trusted#htmlSafeByReview',
+					{
+						createHTML: function (html) {
+							// This policy is only to be used for trusted inputs that do not involve unsanitized user inputs.
+							return html;
+						},
+					}
+				);
+				return policy.createHTML(html);
+			} else {
+				return html;
+			}
+		},
+
 		/**
 		 * Compares the elements of two arrays.
 		 *


### PR DESCRIPTION
## What is the purpose of this pull request?

Addresses #4971. Initial PR to add tooling to help with making CKEditor [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible.

This would be used as follows:
Say we have some javascript innerHtml assignment
```javascript
element.innerHtml = someHtml;
```
This would be a XSS sink and could potentially be dangerous so we sanitize our input html.
```javascript
safeHtml = sanitize(someHtml);
element.innerHtml = safeHtml;
```
Now, we have faith in the sanitizer and trust that this is safe but this would still raise a report because the Trusted Type checker is not aware of the sanitizer. We can assure it that our input is safe using the tooling as follows:

```javascript
safeHtml = sanitize(someHtml);
element.innerHtml = CKEDITOR.tools.htmlSafeByReview(safeHtml, 'sanitized');
```

## Does your PR contain necessary tests?

Existing tests will cover this change.

## Did you follow the CKEditor 4 code style guide?

- [x] PR is consistent with the code style guide

*  Adding Trusted Types to CKEditor to help combat XSS injections.

## What changes did you make?

Added a tooling function that will help with conversions to Trusted Types.